### PR TITLE
Clean up how we reset the branch

### DIFF
--- a/hippiestation/tools/merge-upstream-pull-request.sh
+++ b/hippiestation/tools/merge-upstream-pull-request.sh
@@ -35,12 +35,9 @@ wget "$BASE_PATCH_URL$1.patch" -q -O "$tmpfile"
 
 # We need to make sure we are always on a clean master when creating the new branch.
 # So we forcefully reset, clean and then checkout the master branch
-git reset --hard
+git fetch
+git reset --hard origin/master
 git clean -f
-git checkout -f master
-
-# pull the last changes
-git pull
 
 # Create a new branch
 git checkout -b "$BASE_BRANCH_NAME$1"


### PR DESCRIPTION
Sometimes for some reasonnnnnnnnnnnnnnnnnn we end up with a branch which gets merged into master on the merge server mastrer repo even though it's not merged on origin, this should fix it