### PR TITLE
Fixes the url for the build status in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## HippieStation 13 [![Jenkins](https://img.shields.io/jenkins/s/https/jenkins.hippiestation.com/job/HippieStation%20PR%20Builder/.svg)](https://jenkins.hippiestation.com/job/HippieStation%20PR%20Builder/) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box)
+## HippieStation 13 [![Build Status](https://jenkins.hippiestation.com/buildStatus/icon?job=HippieStation)](https://jenkins.hippiestation.com/job/HippieStation/) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box)
 
 **Website:** http://www.hippiestation.com <BR>
 **Code:** https://github.com/hippiestation/hippiestation <BR>


### PR DESCRIPTION
It shouldn't be pointed at the PR builder