### PR TITLE
Taser Stun Reduction Test

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -11,10 +11,10 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = 1
-	stun = 5
-	weaken = 5
-	stutter = 5
-	jitter = 20
+	stun = 3
+	weaken = 3
+	stutter = 3
+	jitter = 15
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7
 

--- a/html/changelogs/QuarianCommando - Taser Adjustments.yml
+++ b/html/changelogs/QuarianCommando - Taser Adjustments.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: "QuarianCommando"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Slightly reduced the stun duration on tasers. Remember to get in close with a melee stun if you're looking to take someone in, and that Krav Maga exists."


### PR DESCRIPTION
Let's take this for a spin.

Reduces taser stun time from 5 to 3. Still enough time to cuff a weakened target, but you'll have to go in and hit them with either a melee stun or krav maga pin otherwise. I have a whole, big ranged stun rework already written out, but I want to put this up to see both how the playerbase reacts and how it works in practice. I feel that even if this isn't something that we intend to keep, it should still be merged for a while to see if reducing ranged stun duration has a positive effect on combat so that the data can be used for future use.