### PR TITLE
Removes SM from engineering, adds back Singulo/Tesla

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -64512,8 +64512,7 @@
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
 	pixel_x = 0;
-	pixel_y = -32;
-	step_y = 0
+	pixel_y = -32
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -55797,7 +55797,7 @@
 	c_tag = "Singularity North-West";
 	network = list("Singularity")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crL" = (
 /obj/structure/cable{
@@ -55814,7 +55814,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crN" = (
 /obj/structure/table,
@@ -55864,7 +55864,7 @@
 /area/space)
 "crV" = (
 /obj/item/weapon/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crW" = (
 /obj/machinery/light/small{
@@ -55912,7 +55912,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csc" = (
 /obj/structure/lattice,
@@ -55934,7 +55934,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csf" = (
 /obj/machinery/power/emitter{
@@ -55971,7 +55971,7 @@
 /area/space)
 "csj" = (
 /obj/item/device/multitool,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csk" = (
 /obj/structure/disposalpipe/segment,
@@ -56061,7 +56061,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -56098,7 +56098,7 @@
 	anchored = 1;
 	state = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csB" = (
 /obj/item/weapon/wirecutters,
@@ -56109,7 +56109,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csD" = (
 /obj/structure/grille,
@@ -56150,13 +56150,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -56218,14 +56218,14 @@
 /area/engine/engineering)
 "csQ" = (
 /obj/item/weapon/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csR" = (
 /obj/machinery/the_singularitygen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "csS" = (
 /obj/item/weapon/weldingtool,
@@ -59308,7 +59308,7 @@
 	c_tag = "Singularity North-East";
 	network = list("Singularity")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59617,7 +59617,7 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAm" = (
 /obj/structure/cable/yellow{
@@ -59630,7 +59630,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAn" = (
 /obj/structure/cable/yellow{
@@ -59660,7 +59660,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAq" = (
 /obj/machinery/power/tesla_coil,
@@ -59668,7 +59668,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAr" = (
 /obj/structure/cable/yellow{
@@ -59681,7 +59681,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAs" = (
 /obj/machinery/power/tesla_coil,
@@ -59689,14 +59689,14 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAt" = (
 /obj/machinery/the_singularitygen/tesla,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAu" = (
 /obj/structure/cable{
@@ -61375,7 +61375,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cEk" = (
 /obj/machinery/firealarm{
@@ -61393,7 +61393,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cEn" = (
 /obj/structure/cable{
@@ -61407,7 +61407,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cEo" = (
 /obj/structure/lattice,
@@ -61423,7 +61423,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cEq" = (
 /obj/structure/lattice,
@@ -61440,7 +61440,7 @@
 /area/space/nearstation)
 "cEt" = (
 /obj/machinery/power/grounding_rod,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cEu" = (
 /obj/machinery/power/rad_collector{
@@ -61574,7 +61574,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cEG" = (
 /obj/structure/lattice/catwalk,
@@ -61981,7 +61981,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFD" = (
 /obj/structure/cable{
@@ -61990,7 +61990,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFE" = (
 /obj/structure/lattice/catwalk,
@@ -62584,7 +62584,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cHi" = (
 /obj/structure/reflector/box{
@@ -66825,7 +66825,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUd" = (
 /obj/structure/cable/yellow{
@@ -66833,7 +66833,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUe" = (
 /obj/structure/cable/yellow{
@@ -66841,7 +66841,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUf" = (
 /obj/structure/cable/yellow{
@@ -66862,7 +66862,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUh" = (
 /obj/structure/cable/yellow{
@@ -66891,7 +66891,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUk" = (
 /obj/item/weapon/weldingtool,
@@ -66905,7 +66905,7 @@
 /area/space/nearstation)
 "cUm" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUn" = (
 /obj/effect/turf_decal/stripes/line{
@@ -66915,7 +66915,7 @@
 /area/space/nearstation)
 "cUo" = (
 /obj/item/device/radio,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUp" = (
 /obj/machinery/power/emitter{
@@ -66932,7 +66932,7 @@
 /area/engine/engineering)
 "cUq" = (
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUr" = (
 /obj/structure/grille,
@@ -66948,7 +66948,7 @@
 	dir = 1;
 	network = list("Singularity")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUu" = (
 /obj/structure/cable/yellow{
@@ -66956,7 +66956,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUv" = (
 /obj/structure/cable/yellow{
@@ -66970,7 +66970,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUw" = (
 /obj/structure/cable/yellow{
@@ -67006,7 +67006,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cUz" = (
 /obj/machinery/camera/emp_proof{
@@ -67014,7 +67014,7 @@
 	dir = 1;
 	network = list("Singularity")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cUA" = (
 /obj/structure/grille,
@@ -67133,6 +67133,99 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"cVd" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVe" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVf" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVh" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVi" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVj" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVk" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVl" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVm" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVn" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVo" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVp" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVq" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVr" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVs" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVt" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVu" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVv" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVw" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVy" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVz" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVA" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVB" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVC" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVD" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVE" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVF" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -91739,7 +91832,7 @@ cqw
 cqO
 crp
 aaa
-cUb
+cUa
 aaa
 aaa
 cEl
@@ -93294,8 +93387,8 @@ ccw
 ccw
 ccw
 ccw
-cUB
-cUG
+cUa
+cUa
 aaa
 aaa
 aaa
@@ -93549,7 +93642,7 @@ cEp
 cEF
 cFD
 cUq
-cUs
+cUq
 ccw
 aaa
 cEl
@@ -93795,20 +93888,20 @@ cqA
 cqT
 czh
 cEm
-ciZ
+cVd
 csb
-ciZ
-crL
+cVh
+cst
 cEF
 cFC
 cEF
 csu
-ciZ
+cVu
 csb
-ciZ
-ciZ
+cVy
+cVC
 ccw
-cUC
+cUq
 cEl
 cEl
 aaa
@@ -94052,21 +94145,21 @@ ccw
 ccw
 ccw
 crK
-ciZ
-crh
+cVe
+cVg
 csj
-ciZ
-ciZ
-ciZ
-ciZ
-ciZ
+cVk
+cVm
+cVo
+cVq
+cVs
 cUo
-crh
-ciZ
+cVx
+cVz
 cUt
 ccw
 ccw
-cUH
+cUq
 aaa
 aaa
 aaa
@@ -94321,10 +94414,10 @@ cEr
 cFb
 cEr
 cEr
-ciZ
+cVE
 ccw
-cUI
-cUW
+cUq
+cUa
 aaa
 aaa
 aaa
@@ -94565,25 +94658,25 @@ cqb
 cTU
 cTW
 cqY
-cEs
+aaH
 cUc
 cUe
 cAp
-cUh
-cAo
+cUe
+cUe
 cAp
-cAo
-cAo
+cUe
+cUe
 cAp
-cAo
-cAo
+cUe
+cUe
 cUu
 cFb
 ccw
-cUJ
-cUX
-cUZ
-cVa
+cUq
+cUa
+cUa
+cUa
 aaa
 aaa
 aaa
@@ -94819,25 +94912,25 @@ cgK
 cjS
 cpv
 cqb
-cqB
+cTU
 cTX
 cqY
-cEs
+aaH
 cAl
-cEs
+aaH
 cAq
-cEs
-cEs
+aaH
+aaH
 cAq
-cEs
-cEs
+aaH
+aaH
 cAq
-cEs
-cEs
+aaH
+aaH
 cAl
 cFb
 ccw
-cUK
+cUq
 aaf
 aaa
 aaa
@@ -95076,8 +95169,8 @@ cgU
 chG
 cpv
 cqd
-cqB
-cqU
+cTU
+cTW
 cqY
 cEt
 cAl
@@ -95090,7 +95183,7 @@ cEr
 cEr
 cEr
 csA
-cEs
+aaH
 cAl
 cFb
 ccw
@@ -95351,7 +95444,7 @@ cHh
 cUv
 cFb
 ccw
-cUL
+cUq
 cEl
 aaa
 aaa
@@ -95604,11 +95697,11 @@ cFb
 cFb
 cEr
 cEr
-cEs
+aaH
 cAl
 cEr
 ccw
-cUM
+cUq
 cEl
 aaa
 aaa
@@ -95849,7 +95942,7 @@ cTP
 cqh
 ciZ
 cra
-crI
+cTR
 cqY
 cAl
 cEr
@@ -95857,15 +95950,15 @@ cEr
 cFb
 csH
 csR
-cUl
+ctm
 cFb
 cFb
 csA
-cEs
+aaH
 cAl
 cEr
 ccw
-cUN
+cUq
 cEl
 aaa
 aaa
@@ -96119,10 +96212,10 @@ cFb
 cEr
 cEr
 cHh
-cUw
+cUv
 cEr
 ccw
-cUO
+cUq
 cEl
 aaa
 aaa
@@ -96371,15 +96464,15 @@ cFb
 cFb
 csI
 cAt
-cUn
+czD
 cFb
 cEr
 cEr
-cEs
+aaH
 cAl
 cEr
 ccw
-cUP
+cUq
 cEl
 aaa
 aaa
@@ -96632,11 +96725,11 @@ cFb
 cFM
 cEr
 cEr
-cEs
+aaH
 cAl
 cEr
 ccw
-cUQ
+cUq
 aaf
 aaa
 aaa
@@ -96890,10 +96983,10 @@ cEr
 cEr
 cEr
 cHh
-cUx
+cUv
 cFb
 ccw
-cUR
+cUq
 aaf
 aaa
 aaa
@@ -97132,8 +97225,8 @@ cgR
 cgR
 cpD
 cDw
-cqB
-cqU
+cTU
+cTW
 cqY
 cEt
 cAl
@@ -97146,15 +97239,15 @@ csA
 cEr
 cEr
 csA
-cEs
+aaH
 cAl
 cFb
 ccw
 csF
 aaf
 aaf
-cVb
-cVc
+cUa
+cUa
 aaa
 aaa
 aaa
@@ -97389,25 +97482,25 @@ cgR
 cgR
 cpD
 cqb
-cqB
-cqU
+cTU
+cTW
 cqY
-cEs
+aaH
 cAl
-cEs
+aaH
 cAs
-cEs
-cEs
+aaH
+aaH
 cAs
-cEs
-cEs
+aaH
+aaH
 cAs
-cEs
-cEs
+aaH
+aaH
 cAl
 cFb
 ccw
-cUS
+cUq
 aaf
 aaa
 aaa
@@ -97644,27 +97737,27 @@ cmQ
 cny
 cgR
 cgR
-cnx
+cTL
 cqb
-cqB
-cqU
+cTU
+cTW
 cqY
-cEs
+aaH
 cUd
-cUf
+cUe
 cAr
-cUi
-cAo
+cUe
+cUe
 cAr
-cAo
-cAo
+cUe
+cUe
 cAr
-cAo
-cAo
+cUe
+cUe
 cUy
 cFb
 ccw
-cUT
+cUq
 cEl
 aaa
 aaa
@@ -97903,7 +97996,7 @@ cgR
 cgR
 cen
 cqc
-cqC
+cTT
 crc
 ccw
 cEr
@@ -97919,9 +98012,9 @@ cEr
 cFb
 cEr
 cEr
-ciZ
+cVF
 ccw
-cUU
+cUq
 aaa
 aaa
 aaa
@@ -98159,26 +98252,26 @@ ckF
 cDe
 ckF
 cgw
-cqa
+cMm
 ccw
 ccw
 ccw
 czF
-ciZ
+cVf
 cEj
-ciZ
-ciZ
-ciZ
-ciZ
-ciZ
-ciZ
-ciZ
+cVi
+cVl
+cVn
+cVp
+cVr
+cVt
+cVv
 cEj
-ciZ
+cVA
 cUz
 ccw
 ccw
-cUV
+cUq
 aaa
 aaa
 aaa
@@ -98413,7 +98506,7 @@ ckT
 cgU
 cTK
 cTM
-cTN
+cTM
 cis
 cTS
 ckH
@@ -98423,18 +98516,18 @@ cDH
 crM
 crV
 cUg
-ciZ
+cVj
 cEp
 cEF
 cUj
 cEF
 cFD
-ciZ
-cUp
-ciZ
-ciZ
+cVw
+cUg
+cVB
+cVD
 ccw
-cUD
+cUq
 cEl
 cEl
 cEl
@@ -98677,7 +98770,7 @@ cqc
 cig
 crd
 ccw
-crL
+cst
 cEF
 cse
 cEF
@@ -98685,13 +98778,13 @@ csu
 ccw
 ccw
 ccw
-crL
+cst
 cEF
 csu
-cUr
-cUA
+cUq
+cUq
 ccw
-cUE
+cUa
 cEl
 aaa
 aaa
@@ -98950,7 +99043,7 @@ ccw
 ccw
 cUF
 aaf
-cUY
+cUa
 aaa
 aaa
 aaa

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -2841,7 +2841,10 @@
 /turf/open/floor/plating,
 /area/security/main)
 "agd" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "age" = (
@@ -45896,9 +45899,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWV" = (
@@ -48542,6 +48542,12 @@
 	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccn" = (
@@ -50577,17 +50583,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/highpressure/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgM" = (
 /obj/machinery/requests_console{
@@ -51035,32 +51043,16 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/grille,
-/obj/structure/window/reinforced/highpressure/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"chG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"chG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chH" = (
 /obj/structure/closet/firecloset,
@@ -51227,18 +51219,11 @@
 /area/engine/engineering)
 "chX" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
@@ -51463,7 +51448,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cis" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cit" = (
@@ -51617,17 +51609,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciP" = (
 /obj/structure/cable{
@@ -53676,6 +53670,19 @@
 "cnv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Singularity Chamber";
+	dir = 1;
+	name = "Singularity Engine Telescreen";
+	network = list("Singularity");
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnw" = (
@@ -53687,18 +53694,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
@@ -54399,18 +54400,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/highpressure/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "coL" = (
 /obj/structure/cable/yellow{
@@ -54753,35 +54751,26 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpw" = (
 /obj/structure/table,
@@ -54799,17 +54788,17 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cpy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpz" = (
 /obj/structure/particle_accelerator/end_cap,
@@ -54843,16 +54832,18 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cpD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55053,38 +55044,49 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/highpressure/fulltile,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/turf/open/floor/plating,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqb" = (
-/obj/structure/cable{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqd" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 24;
+	req_access = null;
+	req_access_txt = "11"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqe" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -55100,62 +55102,42 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cqf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Filter";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("SS13","Engine");
-	pixel_x = 23
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "10"
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -24;
+	req_access = null;
+	req_access_txt = "11"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqg" = (
+/obj/structure/particle_accelerator/fuel_chamber,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqh" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqi" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 24;
+	req_access = null;
+	req_access_txt = "11"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqj" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqk" = (
 /obj/effect/turf_decal/stripes/line,
@@ -55299,44 +55281,42 @@
 	req_access = null;
 	req_access_txt = "10;13"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqD" = (
 /obj/structure/sign/radiation,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_engineering{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/power_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cqF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -55456,15 +55436,19 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/cable/yellow,
+/obj/machinery/power/rad_collector{
+	anchored = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqV" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -55501,49 +55485,27 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/particle_emitter/center,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cra" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0;
-	req_access = null;
-	req_one_access_txt = "24;10"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/particle_emitter/left,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Gas to Chamber"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/particle_emitter/right,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/black,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cre" = (
 /obj/structure/cable{
@@ -55657,20 +55619,22 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
-	dir = 6
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crt" = (
-/obj/machinery/door/airlock/glass_engineering{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/item/weapon/wirecutters,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cru" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -55812,12 +55776,14 @@
 /turf/open/space,
 /area/space)
 "crI" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -55826,23 +55792,29 @@
 /turf/open/space,
 /area/space)
 "crK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity North-West";
+	network = list("Singularity")
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
-	dir = 8
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/black,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crM" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crN" = (
 /obj/structure/table,
@@ -55891,10 +55863,8 @@
 /turf/open/space,
 /area/space)
 "crV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
+/obj/item/weapon/wrench,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crW" = (
 /obj/machinery/light/small{
@@ -55932,12 +55902,18 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "csb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 4;
+	icon_state = "emitter";
+	state = 2
 	},
-/turf/open/space,
-/area/space)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -55947,10 +55923,18 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cse" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/black,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "csf" = (
 /obj/machinery/power/emitter{
@@ -55986,11 +55970,8 @@
 /turf/open/space,
 /area/space)
 "csj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/item/device/multitool,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "csk" = (
 /obj/structure/disposalpipe/segment,
@@ -56074,8 +56055,13 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csu" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/black,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "csv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -56108,30 +56094,23 @@
 /turf/open/space,
 /area/space/nearstation)
 "csA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/space/nearstation)
 "csB" = (
 /obj/item/weapon/wirecutters,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "csC" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "csD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -56168,19 +56147,17 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "csI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 5
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "csJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
@@ -56240,19 +56217,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "csQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
+/obj/item/weapon/wrench,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "csR" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/the_singularitygen,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "csS" = (
 /obj/item/weapon/weldingtool,
 /turf/open/space,
@@ -59182,6 +59156,11 @@
 	req_access_txt = "10;13"
 	},
 /obj/structure/fans/tiny,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "czi" = (
@@ -59324,11 +59303,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "czF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity North-East";
+	network = list("Singularity")
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59631,26 +59611,27 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cAm" = (
-/obj/machinery/power/supermatter_shard/crystal,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cAn" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -59661,76 +59642,62 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cAp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cAq" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAp" = (
-/obj/structure/cable{
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cAr" = (
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop to Gas";
-	on = 1
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAq" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cAs" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cAt" = (
+/obj/machinery/the_singularitygen/tesla,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	initialize_directions = 11
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Mix";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAt" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cAu" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -60412,12 +60379,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cBR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/effect/landmark/event_spawn,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cBS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61006,13 +60970,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDq" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cDr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -61071,10 +61040,19 @@
 /area/engine/engineering)
 "cDw" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -24;
+	req_access = null;
+	req_access_txt = "11"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDx" = (
 /obj/structure/cable{
@@ -61167,20 +61145,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDH" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cDI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -61396,7 +61372,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEj" = (
-/turf/open/floor/plasteel/black,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cEk" = (
 /obj/machinery/firealarm{
@@ -61406,26 +61385,30 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cEl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
 /turf/open/space,
 /area/space)
 "cEm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/open/space,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cEn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cEo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -61434,11 +61417,14 @@
 /turf/open/space,
 /area/space)
 "cEp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/space,
-/area/space)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cEq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -61447,45 +61433,15 @@
 /turf/open/space,
 /area/space)
 "cEr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cEs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Cooling Loop";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEt" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/space/nearstation)
+"cEt" = (
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cEu" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -61612,12 +61568,14 @@
 /turf/open/space,
 /area/space)
 "cEF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/space,
-/area/space)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cEG" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -61810,14 +61768,9 @@
 /turf/open/space,
 /area/space)
 "cFb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cFc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -62019,15 +61972,26 @@
 /turf/closed/wall/r_wall,
 /area/space)
 "cFC" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cFD" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cFE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -62085,17 +62049,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cFM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cFN" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
@@ -62236,9 +62193,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGf" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/item/weapon/crowbar,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cGg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -62622,18 +62579,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHh" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	icon_state = "emitter";
-	state = 2
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/space/nearstation)
 "cHi" = (
 /obj/structure/reflector/box{
 	anchored = 1;
@@ -64554,9 +64506,17 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/labor)
 "cMm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/highpressure/fulltile,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = -32;
+	step_y = 0
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cMn" = (
 /obj/structure/grille,
@@ -64651,8 +64611,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cMD" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cME" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -64663,8 +64626,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cMH" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cMI" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -66692,6 +66662,478 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cTK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTL" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Center"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTQ" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTW" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTX" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/item/weapon/tank/internals/plasma{
+	anchored = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTY" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cUa" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUb" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUc" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUd" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUe" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUg" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUi" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUk" = (
+/obj/item/weapon/weldingtool,
+/turf/open/space/basic,
+/area/space/nearstation)
+"cUl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUm" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUo" = (
+/obj/item/device/radio,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUp" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUq" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUr" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUs" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUt" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity South-West";
+	dir = 1;
+	network = list("Singularity")
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUz" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity South-East";
+	dir = 1;
+	network = list("Singularity")
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUA" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUB" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUC" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUD" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUF" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUG" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUH" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUI" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUJ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUK" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUL" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUM" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUN" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUO" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUP" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUQ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUR" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUS" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUT" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUU" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUV" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUW" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUX" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUY" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUZ" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVa" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVb" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVc" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -80697,7 +81139,7 @@ aUQ
 aXL
 cTt
 cTz
-cTF
+cTE
 cTH
 beO
 beR
@@ -80949,12 +81391,12 @@ aLA
 aQD
 aSd
 cTm
-aTq
-aTq
-aTq
+cTm
+cTm
+cTm
 cTu
 baJ
-aTq
+cTm
 cTI
 beO
 beU
@@ -81211,7 +81653,7 @@ aUl
 aWs
 cTv
 cTA
-aTq
+cTm
 bbf
 beT
 beT
@@ -81719,13 +82161,13 @@ aLB
 aLB
 aQK
 ayl
-cTo
+cTn
 aUl
 cTr
 aXN
 aUO
 cTB
-aTq
+cTm
 bcI
 aPz
 bdt
@@ -81976,13 +82418,13 @@ ayl
 ayl
 ayl
 aSf
-aTq
-aTq
-aTq
-aTq
-aTq
-aTq
-aTq
+cTm
+cTm
+cTm
+cTm
+cTm
+cTm
+cTm
 aPz
 aPz
 bdB
@@ -90784,7 +91226,7 @@ aaf
 aaf
 cig
 aaf
-aaT
+cTZ
 aaT
 aaT
 aaT
@@ -91041,17 +91483,17 @@ ccw
 ccw
 ccw
 aaa
-aaf
+cUa
 aaa
 aaa
 aaf
 aaa
 aaa
-aaf
+cEl
 aaa
 aaa
 aaa
-aaf
+cEl
 aaa
 aaa
 aaa
@@ -91298,19 +91740,19 @@ cqw
 cqO
 crp
 aaa
-aaf
+cUb
 aaa
 aaa
-aaf
+cEl
 aaa
 aaa
-aaf
+cEl
 aaa
 aaa
 aaa
-aaT
-abY
-abY
+cEl
+cEl
+cEl
 aaa
 aaa
 aaa
@@ -91555,19 +91997,19 @@ cgR
 cqN
 cro
 cEl
-cEE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cEl
-cFm
-cFC
-cFm
-cFm
-cFC
-cGO
-aaa
-aaa
-aaT
-cEX
-abY
 aaa
 aaa
 aaa
@@ -91811,20 +92253,20 @@ ciN
 cji
 cDZ
 crr
-cEm
-cEF
-cEm
-cFn
-cFD
-cFC
-cFC
-cFD
-csb
-aaf
-aaf
-aaT
-cEX
-abY
+cEl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cEl
+cEl
+cEl
+aaa
+cEl
 aaa
 aaa
 aaa
@@ -92068,20 +92510,20 @@ cgR
 cDB
 cqP
 crq
-cEn
-cEF
-cEn
-cFo
-cFD
-cFm
-cFm
-cFD
-cGO
+cEl
+aaa
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
 aaa
 aaa
-aaT
-cEX
-abY
+cEl
+aaa
+cEl
 aaa
 aaa
 aaa
@@ -92325,20 +92767,20 @@ cgR
 cqx
 cqR
 crp
-cEm
-cEF
-cEm
-cFn
-cFD
-cFC
-cFC
-cFD
-csb
-aaf
-aaf
-aaT
-cEX
-abY
+cEl
+aaa
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+aaa
+cEl
 aaa
 aaa
 aaa
@@ -92582,20 +93024,20 @@ cpX
 cqz
 cqQ
 ccw
-cEp
-cEF
-cEn
-cFo
-cFD
-cFm
-cFm
-cFD
-cGO
+cEl
+aaa
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
+cEl
 aaa
 aaa
-aaT
-cEX
-abY
+cEl
+aaa
+cEl
 aaa
 aaa
 aaa
@@ -92839,22 +93281,22 @@ clJ
 cig
 cig
 ccw
-cEm
-cEF
-cEm
-cFn
-cFD
-cFC
-cFC
-cFD
-csb
-aaf
-aaf
-aaT
-cEX
-abY
-aaa
-aaa
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+csF
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cUB
+cUG
 aaa
 aaa
 aaa
@@ -93099,19 +93541,19 @@ ccw
 cEp
 cEF
 cEn
-cFo
+cEF
 cFD
-cFm
-cFm
+ccw
+ccw
+ccw
+cEp
+cEF
 cFD
-cGO
+cUq
+cUs
+ccw
 aaa
-aaa
-aaT
-cEX
-abY
-aaa
-aaf
+cEl
 aaa
 aaa
 aaa
@@ -93348,28 +93790,28 @@ cmG
 cnt
 cob
 coL
-cDo
-cgR
+ckH
+ckH
 cqA
 cqT
 czh
 cEm
-crU
+ciZ
 csb
-cFn
-cFD
+ciZ
+crL
+cEF
 cFC
-cFC
-cFD
+cEF
+csu
+ciZ
 csb
-aaf
-aaf
-aaT
-aaT
-aaT
-aaf
-aaf
-aaf
+ciZ
+ciZ
+ccw
+cUC
+cEl
+cEl
 aaa
 aaa
 aaa
@@ -93611,21 +94053,21 @@ ccw
 ccw
 ccw
 crK
-cEK
-csa
+ciZ
+crh
 csj
-csa
-csa
-cGr
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+ciZ
+ciZ
+ciZ
+ciZ
+ciZ
+cUo
+crh
+ciZ
+cUt
+ccw
+ccw
+cUH
 aaa
 aaa
 aaa
@@ -93860,30 +94302,30 @@ ckG
 clJ
 cmF
 cgR
-cgI
+cjN
 chF
 ciO
 cqc
-cqc
-cqc
-cEd
+cTT
+cTV
+ccw
 cEr
-cEL
+cEr
 cFb
-cFu
-cFI
-cGd
-cGs
-cGr
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
+cEr
+cEr
+cEr
+cEr
+cEr
+cEr
+cEr
+cFb
+cEr
+cEr
+ciZ
+ccw
+cUI
+cUW
 aaa
 aaa
 aaa
@@ -94027,7 +94469,7 @@ akP
 aly
 amh
 amR
-cSN
+cSM
 anz
 aov
 aph
@@ -94117,32 +94559,32 @@ cgR
 ceu
 clQ
 cgR
-cgx
-coM
+cjN
+cjS
 cpv
 cqb
-cqb
-cqb
-cqb
+cTU
+cTW
+cqY
 cEs
-cqb
-cqb
+cUc
+cUe
 cAp
-cqb
+cUh
 cAo
-cGt
-cgx
+cAp
+cAo
+cAo
+cAp
+cAo
+cAo
+cUu
+cFb
 ccw
-ccw
-ccw
-ccw
-ccw
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
+cUJ
+cUX
+cUZ
+cVa
 aaa
 aaa
 aaa
@@ -94283,7 +94725,7 @@ akl
 akR
 alx
 cSF
-cSI
+cSH
 cSO
 anz
 aov
@@ -94375,29 +94817,29 @@ ceZ
 ckF
 ckF
 cgK
-cDg
-cDp
-cqe
+cjS
+cpv
+cqb
 cqB
-cqB
-cEe
-csP
+cTX
+cqY
+cEs
 cAl
-cFc
+cEs
 cAq
-cFJ
-cDq
-cGu
-cGH
-cGR
-cHa
-cEj
-ciZ
+cEs
+cEs
+cAq
+cEs
+cEs
+cAq
+cEs
+cEs
+cAl
+cFb
 ccw
-aaa
-abY
-cEX
-abY
+cUK
+aaf
 aaa
 aaa
 aaa
@@ -94631,31 +95073,31 @@ cnA
 cev
 cfg
 cgU
-cgJ
+cgU
 chG
-cDq
+cpv
 cqd
-cDC
+cqB
 cqU
-cEf
+cqY
 cEt
-cEM
+cAl
 csA
-cEg
-cFK
-cGe
-cGv
-cGI
-cGS
-cHb
-cHg
-cHn
+cEr
+cEr
+csA
+cEr
+cEr
+cEr
+cEr
+csA
+cEs
+cAl
+cFb
 ccw
-aaf
-aaT
-cEX
-aaT
-aaf
+csF
+cEl
+cEl
 aaa
 aaa
 aaa
@@ -94888,30 +95330,30 @@ ckJ
 clJ
 cmL
 cgR
+csF
 ccw
-cDh
 cpy
-cDv
-cDD
-cqU
-cMD
-cEu
-cMI
-cMI
-cMD
-cFL
-cGf
-cGw
-cMm
-ciZ
-cHc
-cHh
-cHh
 ccw
-aaa
-abY
-cEX
-abY
+ccw
+cqY
+cMD
+cqY
+cAl
+cEr
+cEr
+cEr
+cFb
+cEr
+cUk
+cEr
+cEr
+cEr
+cHh
+cUv
+cFb
+ccw
+cUL
+cEl
 aaa
 aaa
 aaa
@@ -95057,7 +95499,7 @@ amj
 amR
 anw
 anz
-cTd
+cTc
 aph
 aph
 ard
@@ -95146,29 +95588,29 @@ cig
 cmK
 cBO
 ccw
-chV
+ciZ
 cDq
 cqf
-cqD
-cMD
+chX
+chX
 crs
-cEv
-cEv
-cFe
-cMD
+cqY
+cAl
+cEr
+cEr
 cFM
-czE
-cGx
+cFb
+cFb
+cFb
+cFb
+cEr
+cEr
+cEs
+cAl
+cEr
 ccw
-cGT
-cEj
-cEj
-ciZ
-ccw
-aaf
-aaT
-cEX
-abY
+cUM
+cEl
 aaa
 aaa
 aaa
@@ -95311,9 +95753,9 @@ akl
 akT
 aww
 cSG
-cSJ
+cSH
 cSQ
-cTa
+cSZ
 cTe
 apk
 anw
@@ -95401,31 +95843,31 @@ cgR
 ckK
 clJ
 cmL
-cgR
+cnw
 cgL
 chX
-cDq
+cTP
 cqh
-cqF
+ciZ
 cra
 crI
-cEw
-cEw
-cEw
-cFw
-cFN
+cqY
+cAl
+cEr
+cEr
+cFb
 csH
 csR
-cMm
-cGU
-cEj
-cEj
-cHo
+cUl
+cFb
+cFb
+csA
+cEs
+cAl
+cEr
 ccw
-aaa
-abY
-cEX
-abY
+cUN
+cEl
 aaa
 aaa
 aae
@@ -95569,7 +96011,7 @@ akS
 alw
 amk
 amR
-cSR
+cSM
 anS
 aoy
 apj
@@ -95659,30 +96101,30 @@ ckK
 clJ
 cmL
 cnv
-cMm
-chX
-cDq
+ccw
+cTO
+cpz
 cqg
 cqE
 cqZ
 crt
 cMH
 cAm
-cMH
-cMN
-cFO
+cEr
+cEr
+cFb
 csC
 csQ
-cMm
-cGV
-cEj
-cGV
+cUm
+cFb
+cEr
+cEr
+cHh
+cUw
+cEr
 ccw
-ccw
-aaa
-abY
-cEX
-abY
+cUO
+cEl
 aaa
 aaa
 aaa
@@ -95915,31 +96357,31 @@ cfb
 cfb
 cig
 cmN
-cgR
+cTL
 cgL
 chX
-cDq
+cTQ
 cqj
-cqF
+cqH
 crb
-cru
-cEx
-cEx
-cEx
-cAP
-cFP
+ciZ
+cqY
+cAl
+csA
+cFb
+cFb
 csI
 cAt
-cMm
-cEj
-cEj
-cEj
-cHp
+cUn
+cFb
+cEr
+cEr
+cEs
+cAl
+cEr
 ccw
-aaf
-abY
-cEX
-abY
+cUP
+cEl
 aaa
 aaa
 aaa
@@ -96083,7 +96525,7 @@ akU
 alz
 aml
 amT
-cSS
+cSM
 anz
 cTg
 apl
@@ -96174,29 +96616,29 @@ clM
 cfz
 cgR
 ccw
-cii
-cDq
-cqi
-cMD
-cAP
-crv
-cEy
-cEy
-cFh
-cMD
-cFQ
-czE
-cGx
-ccw
-cGT
-cEj
-cEj
 ciZ
+cTR
+cqi
+ciZ
+ciZ
+ciZ
+cqY
+cAl
+cEr
+cEr
+cFM
+cFb
+cFb
+cFb
+cFM
+cEr
+cEr
+cEs
+cAl
+cEr
 ccw
+cUQ
 aaf
-aaS
-cEX
-abY
 aaa
 aaa
 aaa
@@ -96340,7 +96782,7 @@ akV
 alB
 amn
 amV
-cST
+cSM
 anz
 aoz
 aod
@@ -96430,30 +96872,30 @@ ceq
 cfa
 cmQ
 cgR
+csF
 ccw
-cDi
-cDr
-cDw
-cDE
-cEa
-cMD
-cEz
-cEz
-cEz
-cMD
-cFR
+cpy
+ccw
+ccw
+cqY
+cqY
+cqY
+cAl
+cEr
+cEr
+cEr
 cGf
-cGz
-cMm
-ciZ
-cHd
-cHj
-cHd
+cEr
+cFb
+cEr
+cEr
+cEr
+cHh
+cUx
+cFb
 ccw
-aaa
-abY
-cEX
-abY
+cUR
+aaf
 aaa
 aaa
 aaa
@@ -96597,7 +97039,7 @@ akQ
 alA
 amm
 amU
-cSU
+cSM
 anT
 aoA
 apn
@@ -96687,33 +97129,33 @@ ceq
 clQ
 cmQ
 cgR
-cMm
-chX
+cgR
+cgR
 cpD
 cDw
-cDF
-cEa
-cEg
-cEA
-cET
-cFj
-cEf
-cFS
-cGg
-cGA
-cGI
-cGS
-cHe
-cHe
-cHr
+cqB
+cqU
+cqY
+cEt
+cAl
+csA
+cEr
+cEr
+cEr
+cEr
+csA
+cEr
+cEr
+csA
+cEs
+cAl
+cFb
 ccw
+csF
 aaf
-aaT
-cEX
-aaT
 aaf
-aaa
-aaa
+cVb
+cVc
 aaa
 aaa
 aaa
@@ -96942,32 +97384,32 @@ cio
 cjY
 ckP
 ckH
-cja
+cmR
 cgR
-cMm
-cDj
-cDs
-cql
-cDG
-cDG
-cEh
-cEB
-cEU
-cFk
+cgR
+cgR
+cpD
+cqb
+cqB
+cqU
+cqY
+cEs
+cAl
+cEs
 cAs
-cFT
-cDq
-cGx
-cGK
-cGY
-cEk
-cEj
-cHs
+cEs
+cEs
+cAs
+cEs
+cEs
+cAs
+cEs
+cEs
+cAl
+cFb
 ccw
+cUS
 aaf
-abY
-cEX
-abY
 aaa
 aaa
 aaa
@@ -97111,7 +97553,7 @@ akW
 aiG
 amo
 amW
-cSW
+cSV
 anz
 aoz
 aod
@@ -97199,32 +97641,32 @@ cjj
 cjX
 ckO
 clP
-cgR
+cmQ
 cny
-ccw
-cip
+cgR
+cgR
 cnx
-cDx
 cqb
-cqb
-cqb
-cEC
-cqb
-cqb
+cqB
+cqU
+cqY
+cEs
+cUd
+cUf
 cAr
-cqb
-cGh
-cGC
-cey
+cUi
+cAo
+cAr
+cAo
+cAo
+cAr
+cAo
+cAo
+cUy
+cFb
 ccw
-ccw
-cHl
-ccw
-ccw
-aaf
-abY
-aaT
-abY
+cUT
+cEl
 aaa
 aaa
 aaa
@@ -97456,31 +97898,31 @@ cfb
 cfb
 ckR
 clR
+cmQ
 cgR
 cgR
-cMm
-cir
-cDt
-cDy
+cgR
+cen
+cqc
 cqC
 crc
-cEi
-cED
-crc
-crc
-cFy
+ccw
+cEr
+cEr
+cFb
+cEr
 cBR
-cGi
-cGD
-cGL
-aag
-aag
-aaf
-aaf
-aaf
-aaf
-aaa
-aaf
+cEr
+cEr
+cEr
+cEr
+cEr
+cFb
+cEr
+cEr
+ciZ
+ccw
+cUU
 aaa
 aaa
 aaa
@@ -97716,28 +98158,28 @@ clN
 ccm
 ckF
 cDe
-cDk
-coc
+ckF
+cgw
 cqa
-cig
+ccw
 ccw
 ccw
 czF
+ciZ
 cEj
+ciZ
+ciZ
+ciZ
+ciZ
+ciZ
+ciZ
+ciZ
 cEj
-cFz
-cFU
-cGj
-cGE
-cGM
-cGZ
-aag
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+ciZ
+cUz
+ccw
+ccw
+cUV
 aaa
 aaa
 aaa
@@ -97970,33 +98412,33 @@ cel
 cyM
 ckT
 cgU
-cco
-cgU
-cgU
+cTK
+cTM
+cTN
 cis
-cjN
-cDz
+cTS
+ckH
 cDH
-cMm
-cEj
+cTY
+cDH
 crM
 crV
-crV
-cFA
-cEj
-cGk
+cUg
+ciZ
+cEp
+cEF
+cUj
+cEF
+cFD
+ciZ
+cUp
+ciZ
+ciZ
 ccw
-aag
-aag
-aag
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+cUD
+cEl
+cEl
+cEl
 aaa
 aaa
 aaa
@@ -98232,26 +98674,26 @@ cfI
 cgQ
 cjS
 cjN
-cqm
-cgR
+cqc
+cig
 crd
-cEk
-crL
-cEW
-cse
-cse
-csu
-cGl
 ccw
-aaa
-aaa
-aaf
-aaa
-aaf
-cEX
-abY
-aaa
-aaf
+crL
+cEF
+cse
+cEF
+csu
+ccw
+ccw
+ccw
+crL
+cEF
+csu
+cUr
+cUA
+ccw
+cUE
+cEl
 aaa
 aaa
 aaa
@@ -98489,27 +98931,27 @@ ccw
 ccw
 cDl
 cjN
-cjh
-cDI
+cgR
+cig
+cig
+cig
 ccw
 ccw
 ccw
 ccw
 ccw
-cMm
-cMm
-cMm
 ccw
+csF
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cUF
 aaf
-aaf
-aaf
-aaf
-aaf
-cEX
-abY
-aaa
-aaf
-aaa
+cUY
 aaa
 aaa
 aaa
@@ -98747,7 +99189,7 @@ ccw
 cDm
 cjP
 ckF
-cDJ
+ckF
 ckF
 cpE
 cjR
@@ -98760,10 +99202,10 @@ aaa
 aaa
 aaa
 aaa
-cEX
-cEX
-cEX
-abY
+aaa
+aaa
+aaa
+cEl
 aaa
 aaa
 aaa
@@ -99004,7 +99446,7 @@ ccw
 coZ
 cgU
 cgU
-cDK
+cgU
 crw
 cjO
 ccw
@@ -99017,10 +99459,10 @@ aaa
 aaa
 aaa
 aaa
-abY
-abY
-abY
-abY
+aaa
+cEl
+cEl
+cEl
 aaa
 aaa
 aae
@@ -99261,7 +99703,7 @@ ccw
 cpa
 cjc
 cqo
-cDL
+ccw
 cjk
 cjm
 ccw
@@ -99518,7 +99960,7 @@ ccw
 ccw
 cpI
 ccw
-cDL
+ccw
 cjl
 cjQ
 cjV
@@ -99775,7 +100217,7 @@ cig
 cpb
 ciZ
 cqp
-cDN
+cig
 cjT
 cgR
 crP
@@ -100032,7 +100474,7 @@ cig
 cig
 czg
 cig
-cDN
+cig
 crh
 crA
 crR
@@ -100289,7 +100731,7 @@ cig
 cpc
 cpJ
 cpc
-cDN
+cig
 cqY
 cqY
 cqY
@@ -100546,7 +100988,7 @@ cig
 cpd
 czM
 cpd
-cDN
+cig
 aaa
 aaa
 aaa
@@ -100779,8 +101221,8 @@ bRE
 bSL
 bPe
 bOd
-cCB
-cCC
+bOd
+bOd
 bXT
 bXT
 bXT
@@ -100803,7 +101245,7 @@ ccw
 cpd
 czL
 cpd
-cDL
+ccw
 aaf
 aaa
 aaa
@@ -100984,7 +101426,7 @@ arj
 aCq
 aDR
 aFl
-aGD
+aDR
 aHZ
 aCr
 aKJ
@@ -101037,7 +101479,7 @@ bSO
 bTU
 bUS
 bUS
-cCD
+bUS
 bXU
 bUS
 bUS
@@ -101060,7 +101502,7 @@ aaa
 cpd
 cpM
 cpd
-cDS
+aaf
 aaf
 aaa
 aaa
@@ -101294,7 +101736,7 @@ bSN
 bTT
 bUR
 bWb
-cCE
+bUR
 bTT
 bUR
 bZJ
@@ -101317,7 +101759,7 @@ aaa
 aaa
 czN
 aaa
-cDS
+aaf
 aaf
 aaa
 aaa
@@ -101574,7 +102016,7 @@ aaa
 aaa
 aaa
 aaa
-cDS
+aaf
 aaf
 aaa
 aaa
@@ -101808,7 +102250,7 @@ bSP
 bPh
 bQy
 bRI
-cCF
+bQy
 bPh
 bQy
 bRI
@@ -101831,7 +102273,7 @@ aaa
 aaa
 aaa
 aaa
-cDS
+aaf
 aaf
 aaa
 aaa
@@ -102065,16 +102507,16 @@ apQ
 bRK
 apQ
 bVv
-cCG
-cCH
-cCI
-cCJ
-cCI
-cCH
-cCI
-cCJ
-cCI
-cCP
+apQ
+bRK
+apQ
+bVv
+apQ
+bRK
+apQ
+bVv
+apQ
+apQ
 bLK
 chg
 bLK
@@ -102088,7 +102530,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+apQ
 aoV
 aaa
 aaa
@@ -102331,7 +102773,7 @@ bPj
 bQA
 bPj
 bOh
-cCQ
+apQ
 bLK
 cyG
 bLK
@@ -102345,7 +102787,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+apQ
 aoV
 aaa
 aaa
@@ -102588,21 +103030,21 @@ cbI
 ccC
 cdD
 bOh
-cCG
-cCS
-cCS
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cDY
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
+apQ
 apQ
 aaf
 aaf


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/15840795/26835611/94dea434-4ad0-11e7-8b12-65b2f3cd2409.png)

![image](https://cloud.githubusercontent.com/assets/15840795/26835633/a2bfab2a-4ad0-11e7-9562-ebaa4d1a6631.png)

![image](https://cloud.githubusercontent.com/assets/15840795/26835653/ac3f9732-4ad0-11e7-8ea8-208d9c011d5b.png)

![image](https://cloud.githubusercontent.com/assets/15840795/26835661/b024627e-4ad0-11e7-8667-c325728da226.png)


:cl: 
del: Removed the Supermatter shard from Engineering.
add: Added Singulo and Tesla back to Engineering.
/:cl:

Let's not force SM on our players, don't change what ain't broke /tg/. I'm actually alright with SM being a round start engine, but forcing the players to do SM or solars is kinda bad. I'm not a good enough mapper to try and take the whole remake old engineering with singulo/tesla and SM with atmos having access into the main area.

That being said, I redid this from scratch while referring to the old set up. I've compiled and tested the set up 5 or so times to fix small bugs. Cameras are working, engineering shutters are working, and it's generating power properly.

If there are any bugs that come up later, I'll fix them as they're reported.
