### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ tgui assets are licensed under a [Creative Commons Attribution-ShareAlike 4.0 In
 See tgui/LICENSE.md for the MIT license.
 See tgui/assets/fonts/SIL-OFL-1.1-LICENSE.md for the SIL Open Font License.
 
-All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](http://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
+All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](http://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated..


### PR DESCRIPTION
:cl: Guyonbroadway
balance: Taser bolts now deal 80 stamina damage and force people to drop items.
balance: Improvised stun prods deal 80 stamina damage that ignores armour and force people to drop items.
balance: The detectives revolver now deals 65 stamina damage, 15 brute and forces people to drop items.
balance: Taser and disabler beams have had their shot cost adjusted, with a standard taser you have 8 taser bolts or 12 disabler beams. Enough to drop four nerds if your aim is on point.
balance: Syndiacte Sniper Rifles still have a stun, but it has been reduced to one tick (not that it matters when you are so slow the followup shot is both easy to land and will put you in crit anyway)
balance: Bulldog shotguns taser rounds also match the tasers change, but they count as bullets so are better vs certain types of defences.
balance: Yes I took into account the R&D guns.
balance: Yes the mechs too
experiment: Disabler beams now travel faster so you can peg fleeing targets more easily (You can still just about outrun them on ephedrine though)
/:cl: