### PR TITLE
Tweaks and changes to the new stamina stuns system. 

### DIFF
--- a/hippiestation/code/game/objects/items/weapons/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/weapons/stunbaton.dm
@@ -1,10 +1,11 @@
+#define MAKESHIFT_BATON_CD 1.5
 
 /obj/item/weapon/melee/baton
 	var/stamforce = 80
 
 /obj/item/weapon/melee/baton/cattleprod/hippie_cattleprod
 	w_class = WEIGHT_CLASS_NORMAL
-	stunforce = 0.1
+	stunforce = 0
 
 
 /obj/item/weapon/melee/baton/proc/baton_stun_hippie_makeshift(mob/living/L, mob/user)
@@ -24,6 +25,7 @@
 	L.Stun(stunforce)
 	L.staminaloss += stamforce //Not reduced by armour to give it an edge over a taser.
 	L.apply_effect(STUTTER, 7) //Duration of sec baton
+	user.changeNext_move(CLICK_CD_MELEE * MAKESHIFT_BATON_CD)
 	if(user)
 		user.lastattacked = L
 		L.lastattacker = user
@@ -38,3 +40,5 @@
 		H.forcesay(GLOB.hit_appends)
 
 	return 1
+
+#undef MAKESHIFT_BATON_CD

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/weakbullet2
 	weaken = 0
 	stun = 0
-	stamina = 65 //Plus the 15 base damage means two shots will down a perp
+	stamina = 45 //Plus the 15 base damage means two shots will down a perp
 
 
 /obj/item/projectile/bullet/stunshot

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -1,13 +1,13 @@
 /obj/item/projectile/bullet/weakbullet2
 	weaken = 0
-	stun = 0.1
+	stun = 0
 	stamina = 65 //Plus the 15 base damage means two shots will down a perp
 
 
 /obj/item/projectile/bullet/stunshot
-	stun = 0.1
+	stun = 0
 	weaken = 0
-	stamina = 80
+	stamina = 80 //Stunshot can stay potent to give nukies an edge.
 
 /obj/item/projectile/bullet/sniper
 	stun = 1

--- a/hippiestation/code/modules/projectiles/projectile/energy.dm
+++ b/hippiestation/code/modules/projectiles/projectile/energy.dm
@@ -1,9 +1,10 @@
 /obj/item/projectile/energy/electrode
-	stun = 0.1
+	stun = 0
 	weaken = 0
-	stamina = 80
+	stamina = 60
 
 /obj/item/projectile/beam/disabler
-	speed = 0.6
+	speed = 0.7
+	damage = 21 //it should take about five shots to down someone, but seeing as people regen stamina all the time, setting it to 20 means you would need six shots.
 
 


### PR DESCRIPTION


:cl: GuyonBroadway
balance: Disablers now do 21 stamina damage, it takes five shots to down a perp, same as laser crit.
balance: Made disabler beams slightly slower yet still faster than they were pre buff.
balance: Tasers now do 60 stamina damage, enough to slow someone down but not so slow that its impossible to dodge.
balance: Tasers, detective revolver and makeshift stunprods have had the mechanism that makes them drop items removed as it was causing a full second of stun as opposed to one tenth of a second. This is because currently stuns cannot be measured in anything lower than a second, but /tg/ does have a PR that supposedly allows you to do this so until then imma just remove the feature for now.
balance: Makeshift batons also now have a slight attack delay between swings, Juuust long enough to get one, maybe two disarms in before you are knocked down. 
/:cl:

[why]: In essence I didn't really solve the issue of "one stun = done" as one stun held you in place long enough for a guy to level a second. Same went for makeshift batons, however I kept their very high armour ignoring stamina damage as getting into melee range with a melee weapon is risky business.

The supersonic disablers, while fun, were very powerful, you got 20 shots each with 34 stamina damage a piece, you had more than enough disabling to fight off 4-6 people before needing a recharge. Now its more similar to the laser in that five shots is needed to down an armour less person, and if they make use of nicotine for stamina regen they might just get six. 