### PR TITLE
Gives the Extra annoying bike horn some illegal tech levels, also adds adminlogging and makes the brain damage it does a define.

### DIFF
--- a/hippiestation/code/game/objects/items/weapons/clown_items.dm
+++ b/hippiestation/code/game/objects/items/weapons/clown_items.dm
@@ -1,4 +1,5 @@
 /obj/item/weapon/bikehorn/golden/retardhorn
+	origin_tech = "engineering=4;syndicate=3" //Science can uncover if this is a regular bike horn or not using science goggles.
 
 /obj/item/weapon/bikehorn/golden/retardhorn/attack()
 	flip_mobs()

--- a/hippiestation/code/game/objects/items/weapons/clown_items.dm
+++ b/hippiestation/code/game/objects/items/weapons/clown_items.dm
@@ -1,3 +1,5 @@
+#define HORN_BRAIN_DAMAGE 10
+
 /obj/item/weapon/bikehorn/golden/retardhorn
 	origin_tech = "engineering=4;syndicate=3" //Science can uncover if this is a regular bike horn or not using science goggles.
 
@@ -19,4 +21,7 @@
 				var/mob/living/carbon/human/H = M
 				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
 					continue
-			M.adjustBrainLoss(10)
+			M.adjustBrainLoss(HORN_BRAIN_DAMAGE)
+			log_admin("[key_name(user)] dealt brain damage to [key_name(M)] with the Extra annoying bike horn")
+
+#undef HORN_BRAIN_DAMAGE


### PR DESCRIPTION
:cl: Guyonbroadway
tweak: The Extra Annoying Bike horn now has illegal tech levels.
/:cl:

[why]: Turns out having a clown item that's near impossible to detect before its too late and the whole station is a collective of gibbering retards (or moreso than normal anyway) is not the best of ideas.

Also made the brain damage it did a define for good practise reasons and added adminlogging because honking a horn like that and being basically untraceable is also bad idea.

Fixes https://github.com/HippieStation/HippieStation/pull/2006
