### PR TITLE
Fixes critical bug with the Ka-Nada set

### DIFF
--- a/hippiestation/code/modules/sports/hockey.dm
+++ b/hippiestation/code/modules/sports/hockey.dm
@@ -265,7 +265,7 @@
 	slowdown = -1
 
 /obj/item/clothing/mask/hippie/hockey
-	name = "Ka-Nada Hokcey Mask"
+	name = "Ka-Nada Hockey Mask"
 	desc = "The iconic mask of the Ka-Nada special sports forces, guaranteed to strike terror into the hearts of men and goalies."
 	icon_state = "hockey_mask"
 	item_state = "hockey_mask"


### PR DESCRIPTION



:cl: GuyonBroadway
fix: Several sets of the Ka-nada hockey suit have been found to have a misprint on the label for the mask, this has henceforth been fixed and the line manage responsible was made to play as Goalie.
/:cl:

[why]: I've had this feeling that something has been "wrong" for most of the year, this is why and this is the fix.

Tested in game thoroughly for billions of hours and its safe.