### PR TITLE
Fixes reinforced fake walls

### DIFF
--- a/hippiestation/code/game/objects/structures/false_walls.dm
+++ b/hippiestation/code/game/objects/structures/false_walls.dm
@@ -1,2 +1,5 @@
 /obj/structure/falsewall
 	icon = 'hippiestation/icons/turf/walls/wall.dmi'
+
+/obj/structure/falsewall/reinforced
+	icon = 'hippiestation/icons/turf/walls/reinforced_wall.dmi'


### PR DESCRIPTION
Fixes #1627 

:cl:
fix: Reinforced false walls have the right icon now.
/:cl:

[why]: because