### PR TITLE
Move the Hippie config out of the "repo"

### DIFF
--- a/config/hippiestation_config.txt
+++ b/config/hippiestation_config.txt
@@ -1,0 +1,5 @@
+#Determines what internet address to use.
+INTERNET_ADDRESS_TO_USE 0.0.0.0.0
+
+#Mentors only see ckeys by default. Uncomment to have them only see mob name
+#MENTORS_MOBNAME_ONLY

--- a/hippiestation/code/init.dm
+++ b/hippiestation/code/init.dm
@@ -2,6 +2,6 @@
 //Create a proc to load something in the appropriate module file and call the proc here.
 
 /proc/hippie_initialize()
-	load_hippie_config("config/hippiestation_config.txt")
+	load_hippie_config('config/hippiestation_config.txt')
 	LAZYCLEARLIST(mentor_datums)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/moth_wings, GLOB.moth_wings_list, roundstart = TRUE)

--- a/hippiestation/code/init.dm
+++ b/hippiestation/code/init.dm
@@ -2,6 +2,6 @@
 //Create a proc to load something in the appropriate module file and call the proc here.
 
 /proc/hippie_initialize()
-	load_hippie_config("hippiestation/config/config.txt")
+	load_hippie_config("config/hippiestation_config.txt")
 	LAZYCLEARLIST(mentor_datums)
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/moth_wings, GLOB.moth_wings_list, roundstart = TRUE)


### PR DESCRIPTION
Our config folder is static across repo changes, the Hippie folder is not, so we need to move our custom config into the config folder.