### PR TITLE
Increases disabler damage slightly, gives a less shitty item drop function to tasers and revolvers. 

### DIFF
--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -6,7 +6,8 @@
 /obj/item/projectile/bullet/weakbullet2/on_hit(atom/target, blocked = 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		C.drop_item()
+		if(prob(50))
+			C.drop_item()
 		..()
 
 

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -3,6 +3,12 @@
 	stun = 0
 	stamina = 45 //Plus the 15 base damage means two shots will down a perp
 
+/obj/item/projectile/bullet/weakbullet2/on_hit(atom/target, blocked = 0)
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		C.drop_item()
+		..()
+
 
 /obj/item/projectile/bullet/stunshot
 	stun = 0

--- a/hippiestation/code/modules/projectiles/projectile/energy.dm
+++ b/hippiestation/code/modules/projectiles/projectile/energy.dm
@@ -6,7 +6,8 @@
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		C.drop_item()
+		if(prob(50))
+			C.drop_item()
 		..()
 
 /obj/item/projectile/beam/disabler

--- a/hippiestation/code/modules/projectiles/projectile/energy.dm
+++ b/hippiestation/code/modules/projectiles/projectile/energy.dm
@@ -3,8 +3,14 @@
 	knockdown = 0
 	stamina = 60
 
+/obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0)
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		C.drop_item()
+		..()
+
 /obj/item/projectile/beam/disabler
 	speed = 0.7
-	damage = 21 //it should take about five shots to down someone, but seeing as people regen stamina all the time, setting it to 20 means you would need six shots.
+	damage = 26 //it should take about four shots to down someone, but seeing as people regen stamina all the time, setting it to 25 means you would need 5 shots.
 
 


### PR DESCRIPTION
:cl:GuyonBroadway
balance: Disable beams now do 26 damage meaning it takes one less shot to down a guy.
balance: Tasers now cause the target to drop items with a %50 chance.
balance: Detectives revolver now causes the target to drop items with a %50 chance. 
/:cl:

Disablers were a bit weak after last nerf, and tasers weren't much better. this should make them a little nicer to use while still giving the target a chance to fight back. 