### PR TITLE
Fixes bug where hand crafted prods were wrong type. 

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2195,6 +2195,7 @@
 #include "hippiestation\code\game\objects\items\weapons\clown_items.dm"
 #include "hippiestation\code\game\objects\items\weapons\stunbaton.dm"
 #include "hippiestation\code\game\objects\items\weapons\twohanded.dm"
+#include "hippiestation\code\game\objects\items\weapons\weaponry.dm"
 #include "hippiestation\code\game\objects\items\weapons\implants\implant_mindslave.dm"
 #include "hippiestation\code\game\objects\items\weapons\implants\implant_misc.dm"
 #include "hippiestation\code\game\objects\items\weapons\implants\implantcase.dm"

--- a/hippiestation/code/game/objects/items/weapons/weaponry.dm
+++ b/hippiestation/code/game/objects/items/weapons/weaponry.dm
@@ -1,0 +1,24 @@
+/obj/item/weapon/wirerod/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/shard))
+		var/obj/item/weapon/twohanded/spear/S = new /obj/item/weapon/twohanded/spear
+
+		remove_item_from_storage(user)
+		qdel(I)
+		qdel(src)
+
+		user.put_in_hands(S)
+		to_chat(user, "<span class='notice'>You fasten the glass shard to the top of the rod with the cable.</span>")
+
+	else if(istype(I, /obj/item/device/assembly/igniter) && !(I.flags & NODROP))
+		var/obj/item/weapon/melee/baton/cattleprod/hippie_cattleprod/P = new /obj/item/weapon/melee/baton/cattleprod/hippie_cattleprod
+
+		remove_item_from_storage(user)
+
+		to_chat(user, "<span class='notice'>You fasten [I] to the top of the rod with the cable.</span>")
+
+		qdel(I)
+		qdel(src)
+
+		user.put_in_hands(P)
+	else
+		return ..()


### PR DESCRIPTION

:cl: GuyonBroadway
fix: Fixed a bug where applying an igniter to a wired rod gave back the wrong type of prod that didn't fit in your backpack. 
/:cl:

This was something I didn't spot and was not aware of in the initial stuns update. 
