### PR TITLE
Fixes gear item duplication bug

### DIFF
--- a/hippiestation/code/modules/client/preferences_savefile.dm
+++ b/hippiestation/code/modules/client/preferences_savefile.dm
@@ -6,6 +6,8 @@
 	var/text_to_load
 	S["loadout"] >> text_to_load
 	var/list/saved_loadout_paths = splittext(text_to_load, "|")
+	LAZYCLEARLIST(chosen_gear)
+	gear_points = initial(gear_points)
 	for(var/i in saved_loadout_paths)
 		var/datum/gear/path = text2path(i)
 		if(path)


### PR DESCRIPTION
:cl: Carbonhell/GuyonBroadway
fix: fixed the bug where swapping load-outs would cause you to spawn with twice your load-out gear. 
/:cl:

[why]: Carbon asked me to do this so I did it, please help he is sending me threatening letters and has my dog and I don't even have a dog
