### PR TITLE
removes organ eating

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -84,16 +84,6 @@
 	return ..()
 
 /obj/item/organ/attack(mob/living/carbon/M, mob/user)
-	if(M == user && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(status == ORGAN_ORGANIC)
-			var/obj/item/weapon/reagent_containers/food/snacks/S = prepare_eat()
-			if(S)
-				H.drop_item()
-				H.put_in_active_hand(S)
-				S.attack(H, H)
-				qdel(src)
-	else
 		..()
 
 /obj/item/organ/item_action_slot_check(slot,mob/user)


### PR DESCRIPTION
fixes https://github.com/HippieStation/HippieStation/issues/2449

deep fry them or something

apologies if the code isn't up to standard, I used the online editor, but it's a simple enough change so I figured it wasn't necessary.

I'm also going to be gone for five days, any reviews or recommendations will be cleared up then.
feel free to close this pr if someone makes a better version

:cl: ShadowDeath6
rscdel: Removes the ability to eat organs that you could normally use in surgery.
/:cl:
