### PR TITLE
Makes medbay more like it was prebase.

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -29476,10 +29476,13 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "boq" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bor" = (
 /obj/structure/table,
@@ -30746,6 +30749,10 @@
 "bra" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "brb" = (
@@ -30801,10 +30808,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
-	dir = 2
-	},
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/genetics)
 "bri" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
@@ -30817,11 +30822,10 @@
 	},
 /area/medical/medbay/central)
 "brj" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 6
-	},
-/area/medical/medbay/central)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "brk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32316,6 +32320,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/structure/closet/wardrobe/genetics_white,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bum" = (
@@ -32869,18 +32874,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bvn" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the genetics doors.";
-	id = "GeneticsDoor";
-	name = "Genetics Exit Button";
-	normaldoorcontrol = 1;
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/structure/table,
-/obj/item/weapon/book/manual/medical_cloning{
-	pixel_y = 6
-	},
+/obj/machinery/computer/cloning,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvo" = (
@@ -32899,11 +32893,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvq" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvr" = (
@@ -33523,17 +33516,16 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/item/weapon/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8;
+	step_y = 0
 	},
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/pen,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwM" = (
@@ -34768,12 +34760,12 @@
 	},
 /area/medical/genetics)
 "bzn" = (
-/obj/machinery/computer/cloning,
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/machinery/computer/cloning,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
 	},
@@ -35298,6 +35290,7 @@
 "bAt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/wrench/medical,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bAu" = (
@@ -39142,9 +39135,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIr" = (
@@ -67404,6 +67395,60 @@
 /obj/structure/reagent_dispensers/water_cooler/honk,
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
+"cWq" = (
+/obj/structure/closet,
+/turf/closed/wall/r_wall,
+/area/medical/genetics)
+"cWr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"cWs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWt" = (
+/obj/machinery/clonepod,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWu" = (
+/obj/machinery/button/door{
+	desc = "A remote control switch for the genetics doors.";
+	dir = 2;
+	id = "GeneticsDoor";
+	name = "Genetics Exit Button";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWv" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/pen,
+/obj/item/weapon/storage/pill_bottle/mannitol,
+/obj/item/weapon/storage/pill_bottle/mutadone,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWw" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/medical_cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWx" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"cWy" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 
 (1,1,1) = {"
 aaa
@@ -104554,8 +104599,8 @@ bhh
 bsx
 btV
 bvh
-bwH
-bxS
+bwI
+bxV
 bzh
 bAs
 bvj
@@ -106350,12 +106395,12 @@ bkR
 bfL
 boo
 bqQ
-bhg
-bua
+cWs
+cWt
 bvn
 bwL
-bxX
 bsL
+cWy
 bua
 bBJ
 bhh
@@ -106607,9 +106652,9 @@ bkQ
 bmW
 bom
 bIq
-bri
 bsu
-bsL
+cWu
+cWx
 bsL
 bvo
 bzl
@@ -106862,11 +106907,11 @@ biz
 biz
 bla
 bmY
-boq
+bhh
 boq
 brj
-bpE
-btk
+cWv
+bsL
 bum
 bvq
 bzn
@@ -107120,9 +107165,9 @@ biB
 bkU
 bmX
 bpE
-bpE
-bpE
-bpE
+cWr
+brj
+cWw
 bti
 bul
 bvp
@@ -107378,7 +107423,7 @@ bla
 bmZ
 bpH
 bra
-bsK
+bpE
 bpE
 bpE
 buq
@@ -107893,7 +107938,7 @@ bmZ
 bpJ
 brc
 bsL
-bug
+brc
 btl
 but
 bvw
@@ -108403,7 +108448,7 @@ biE
 bkf
 bfS
 bKH
-bmZ
+cWq
 bpL
 bre
 bsN

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -33523,7 +33523,6 @@
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8;
-	step_y = 0
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,


### PR DESCRIPTION
:cl: GuyonBroadway
add: Added an extra cryotube to medbay.
add: Added extra cloning machine to Genetics along with some mannitol and mutadone pill bottles.
/:cl:

Old medbay was a bit like this, the three cryotubes means greyshits might be less inclined to steal all the medkits.

Two cloners means that a nasty accident is easier to recover from, same goes for the mannitol and mutadone bottles. /tg/ seems hell bent on nerfing ways to have fun so this should make their cloning nerfs a little less terrible by reducing clone time turnaround.

![image](https://user-images.githubusercontent.com/22083966/28578352-6b0834ac-7151-11e7-9342-075f259d52e6.png)

Everything is tested and works. The button on the table was how old genetics used to do it. 