### PR TITLE
[s] Fixes pool tiles disappearing when lighted on fire

### DIFF
--- a/hippiestation/code/modules/pool/pool_main.dm
+++ b/hippiestation/code/modules/pool/pool_main.dm
@@ -4,6 +4,7 @@
 	name = "poolwater"
 	desc = "You're safer here than in the deep."
 	icon_state = "deep"
+	heat_capacity = INFINITY
 	var/next_splash = 1
 	var/obj/effect/overlay/water/watereffect
 


### PR DESCRIPTION
:cl: Tortellini Tony
fix: Pool tiles are no longer deleted by a flamethrower.
/:cl:

fixes #2554 