### PR TITLE
Comments out supermatter theft objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -85,14 +85,14 @@
 	special_equipment += /obj/item/weapon/storage/box/syndie_kit/nuke
 	..()
 
-/datum/objective_item/steal/supermatter
+/*/datum/objective_item/steal/supermatter
 	name = "a sliver of a supermatter crystal. Be sure to use the proper safety equipment when extracting the sliver!"
 	targetitem = /obj/item/nuke_core/supermatter_sliver
 	difficulty = 15
 
 /datum/objective_item/steal/supermatter/New()
 	special_equipment += /obj/item/weapon/storage/box/syndie_kit/supermatter
-	..()
+	..()*/
 
 //Items with special checks!
 /datum/objective_item/steal/plasma


### PR DESCRIPTION
Comments it out in a way to nearly 0 the chance of a merge conflict. 

We don't use the supermatter anyways (except for the times we use BoxStation rather than Hippie). As the supermatter is like, hypersensitive, either running into it OR extracting a sliver = boom boom crystal.

:cl: thefastfoodguy
del; Removed SM sliver theft
/:cl:



_also the SM is stupid_