### PR TITLE
Adds RCLs to HippieStation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## HippieStation 13 [![Build Status](https://jenkins.hippiestation.com/buildStatus/icon?job=HippieStation)](https://jenkins.hippiestation.com/job/HippieStation/) [![Krihelimeter](http://www.krihelinator.xyz/badge/HippieStation/HippieStation)](http://www.krihelinator.xyz/repositories/HippieStation/HippieStation) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box) 
+## HippieStation 13 [![Build Status](https://jenkins.hippiestation.com/buildStatus/icon?job=HippieStation)](https://jenkins.hippiestation.com/job/HippieStation/) [![Krihelimeter](http://www.krihelinator.xyz/badge/HippieStation/HippieStation)](http://www.krihelinator.xyz/repositories/HippieStation/HippieStation) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box)
 
 **Website:** http://www.hippiestation.com <BR>
 **Code:** https://github.com/hippiestation/hippiestation <BR>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## HippieStation 13 [![Build Status](https://jenkins.hippiestation.com/buildStatus/icon?job=HippieStation)](https://jenkins.hippiestation.com/job/HippieStation/) [![Krihelimeter](http://www.krihelinator.xyz/badge/HippieStation/HippieStation)](http://www.krihelinator.xyz/repositories/HippieStation/HippieStation) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box)
+## HippieStation 13 [![Build Status](https://jenkins.hippiestation.com/buildStatus/icon?job=HippieStation)](https://jenkins.hippiestation.com/job/HippieStation/) [![Krihelimeter](http://www.krihelinator.xyz/badge/HippieStation/HippieStation)](http://www.krihelinator.xyz/repositories/HippieStation/HippieStation) [![GitHub forks](https://img.shields.io/github/forks/HippieStation/HippieStation.svg?style=social&label=Fork)](https://github.com/HippieStation/HippieStation#fork-destination-box) 
 
 **Website:** http://www.hippiestation.com <BR>
 **Code:** https://github.com/hippiestation/hippiestation <BR>

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -33522,7 +33522,7 @@
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
@@ -48489,6 +48489,7 @@
 	},
 /obj/item/weapon/stamp/ce,
 /obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/twohanded/rcl/pre_loaded,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
@@ -52364,6 +52365,8 @@
 /obj/item/weapon/electronics/apc,
 /obj/item/weapon/stock_parts/cell/high/plus,
 /obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/twohanded/rcl/pre_loaded,
+/obj/item/weapon/twohanded/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckE" = (
@@ -106908,7 +106911,7 @@ bla
 bmY
 bhh
 boq
-brj
+cWs
 cWv
 bsL
 bum
@@ -107165,7 +107168,7 @@ bkU
 bmX
 bpE
 cWr
-brj
+cWs
 cWw
 bti
 bul


### PR DESCRIPTION


:cl: More Robust Than You
add: Rapid Cable Layers are now on the HippieStation map too, as opposed to just box/meta/etc!
/:cl:
