### PR TITLE
Fixes enthralling knockdown

### DIFF
--- a/hippiestation/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/hippiestation/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -204,7 +204,7 @@
 					to_chat(user, "<span class='notice'>You begin preparing [target]'s mind as a blank slate...</span>")
 					user.visible_message("<span class='warning'>[user]'s palms flare a bright red against [target]'s temples!</span>")
 					to_chat(target, "<span class='danger'>A terrible red light floods your mind. You collapse as conscious thought is wiped away.</span>")
-					target.Knockdown(12)
+					target.Knockdown(120)
 					if(target.isloyal())
 						to_chat(user, "<span class='notice'>They are protected by an implant. You begin to shut down the nanobots in their brain - this will take some time..</span>")
 						user.visible_message("<span class='warning'>[user] pauses, then dips their head in concentration!</span>")


### PR DESCRIPTION
1.2 seconds -> 12 seconds


:cl: Thefastfoodguy
fix: The knockdown during enthralling now lasts 12 seconds as opposed to 1.2 seconds
/:cl:

