### PR TITLE
Adds logging to Shadowlings in the hivemind

### DIFF
--- a/hippiestation/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/hippiestation/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -269,6 +269,7 @@
 			to_chat(M, my_message)
 		if(M in GLOB.dead_mob_list)
 			to_chat(M, "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [my_message]")
+	log_say("[user.real_name]/[user.key] : [text]")
 
 
 


### PR DESCRIPTION
previously Shadowlings were not logged when they spoke in the hivemind (but thralls were logged)

:cl: Thefastfoodguy
add: Adds logging to Shadowlings in the hivemind
/:cl:
