### PR TITLE
Remove logging from the PRMirror script

### DIFF
--- a/hippiestation/tools/merge-upstream-pull-request.sh
+++ b/hippiestation/tools/merge-upstream-pull-request.sh
@@ -7,18 +7,6 @@ set -C # noclobber
 
 BASE_BRANCH_NAME="upstream-merge-"
 BASE_PULL_URL="https://api.github.com/repos/tgstation/tgstation/pulls"
-LOG_FILE="../logs/$BASE_BRANCH_NAME$1.log"
-
-# Close STDOUT file descriptor
-exec 1<&-
-# Close STDERR FD
-exec 2<&-
-
-# Open STDOUT as $LOG_FILE file for read and write.
-exec 1<>$LOG_FILE
-
-# Redirect STDERR to STDOUT
-exec 2>&1
 
 # Ensure the current directory is a git directory
 if [ ! -d .git ]; then


### PR DESCRIPTION
This allows us to read the input from stdout/stderr and act on it from the PRMirrorer
