### PR TITLE
Changeling absorbing is much faster now

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -42,7 +42,7 @@
 				target.take_overall_damage(40)
 
 		SSblackbox.add_details("changeling_powers","Absorb DNA|[i]")
-		if(!do_mob(user, target, 150))
+		if(!do_mob(user, target, 70))
 			to_chat(user, "<span class='warning'>Our absorption of [target] has been interrupted!</span>")
 			changeling.isabsorbing = 0
 			return


### PR DESCRIPTION
:cl:
tweak: Changelings absorbing total time has been reduced from 45 seconds to 24 seconds.
/:cl:

This is PopNotes' PR 2.0 . I am aware that the change is very, very controversial, but I believe, that at the moment, absorbing is extremely annoying. One of the changeling's core abilities is very slow to use and almost no one actually uses it, despite being the only thing that allows them to re-adapt their abilities. 