### PR TITLE
Adds nice soft gloves.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2297,6 +2297,7 @@
 #include "hippiestation\code\modules\clothing\shoe.dm"
 #include "hippiestation\code\modules\clothing\suit.dm"
 #include "hippiestation\code\modules\clothing\under.dm"
+#include "hippiestation\code\modules\clothing\gloves\softgloves.dm"
 #include "hippiestation\code\modules\clothing\masks\hailer.dm"
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"

--- a/hippiestation/code/game/machinery/vending_types.dm
+++ b/hippiestation/code/game/machinery/vending_types.dm
@@ -382,7 +382,8 @@ AUTODROBE
 		/obj/item/clothing/under/roman = 1,
 		/obj/item/clothing/shoes/roman = 1,
 		/obj/item/shield/riot/roman = 1,
-		/obj/item/skub = 3
+		/obj/item/skub = 3,
+		/obj/item/clothing/gloves/color/white/soft = 2
 		)
 
 /*

--- a/hippiestation/code/modules/clothing/gloves/softgloves.dm
+++ b/hippiestation/code/modules/clothing/gloves/softgloves.dm
@@ -2,15 +2,16 @@
 	name = "soft gloves"
 	desc = "These gloves are very soft and feel nice to touch."
 
-/datum/species/help(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	if(user.gloves && istype(user.gloves, /obj/item/clothing/gloves/color/white/soft))
-		if(target.a_intent != INTENT_HELP)
+/obj/item/clothing/gloves/color/white/soft/Touch(mob/living/carbon/human/target,proximity)
+	var/mob/M = loc
+	if(ishuman(target))
+		if(M.a_intent == INTENT_HELP && target.a_intent != INTENT_HELP)
 			target.a_intent = INTENT_HELP
 			target.hud_used.action_intent.icon_state = "[target.a_intent]" //Else we get your intent being one thing and your hud another.
-			target.visible_message("<span class='notice'>[user] gives [target] a hug, they look happier!</span>", \
-									"<span class='warning'>[user] hugs you and you feel a bit nicer.</span>")
+			target.visible_message("<span class='notice'>[M] gives [target] a hug, they look happier!</span>", \
+									"<span class='warning'>[M] hugs you and you feel a bit nicer.</span>")
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		else
-			..() // If they have help intent carry on as normal
+			.= TRUE
+		else .= FALSE
 	else
-		..() // If you are not wearing soft gloves carry on as normal
+		.= FALSE

--- a/hippiestation/code/modules/clothing/gloves/softgloves.dm
+++ b/hippiestation/code/modules/clothing/gloves/softgloves.dm
@@ -1,0 +1,16 @@
+/obj/item/clothing/gloves/color/white/soft
+	name = "soft gloves"
+	desc = "These gloves are very soft and feel nice to touch."
+
+/datum/species/help(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	if(user.gloves && istype(user.gloves, /obj/item/clothing/gloves/color/white/soft))
+		if(target.a_intent != INTENT_HELP)
+			target.a_intent = INTENT_HELP
+			target.hud_used.action_intent.icon_state = "[target.a_intent]" //Else we get your intent being one thing and your hud another.
+			target.visible_message("<span class='notice'>[user] gives [target] a hug, they look happier!</span>", \
+									"<span class='warning'>[user] hugs you and you feel a bit nicer.</span>")
+			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		else
+			..() // If they have help intent carry on as normal
+	else
+		..() // If you are not wearing soft gloves carry on as normal

--- a/hippiestation/code/modules/clothing/gloves/softgloves.dm
+++ b/hippiestation/code/modules/clothing/gloves/softgloves.dm
@@ -8,10 +8,18 @@
 		if(M.a_intent == INTENT_HELP && target.a_intent != INTENT_HELP)
 			target.a_intent = INTENT_HELP
 			target.hud_used.action_intent.icon_state = "[target.a_intent]" //Else we get your intent being one thing and your hud another.
-			target.visible_message("<span class='notice'>[M] gives [target] a hug, they look happier!</span>", \
+			if(!emagged)
+				target.visible_message("<span class='notice'>[M] gives [target] a hug, they look happier!</span>", \
 									"<span class='warning'>[M] hugs you and you feel a bit nicer.</span>")
-			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+			else
+				to_chat(M, "<span class='notice'>You hug [target] so gently they hardly feel it, they still look happier.</span>")
 			.= TRUE
 		else .= FALSE
 	else
 		.= FALSE
+
+/obj/item/clothing/gloves/color/white/soft/emag_act(mob/user)
+	if(!emagged)
+		to_chat(user,"<span class='warning'>The electrostatic charge in the card somehow makes the gloves even softer!</span>")
+		emagged = TRUE

--- a/hippiestation/code/modules/jobs/job_types/civilian.dm
+++ b/hippiestation/code/modules/jobs/job_types/civilian.dm
@@ -2,7 +2,13 @@
 	access = list(ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
 
+/datum/outfit/job/clown
+	gloves = /obj/item/clothing/gloves/color/white/soft
+
 /datum/job/mime
 	access = list(ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
+
+/datum/outfit/job/mime
+	gloves = /obj/item/clothing/gloves/color/white/soft //Having little access to any other
 


### PR DESCRIPTION
:cl: Guyonbroadway
add: Clowns and mimes now start the game with soft gloves, when you click someone with help intent using these gloves it will set their intent to help.
add: You can also get an extra pair from the autodrobe with a coin.
/:cl:

Mostly to finally deal with those situations where some fuckwit is walking down a 1x1 maint tunnel and refuses to switch to help intent and is all like "**DUDE WTF!! MOVE!!**"

It will also be a godsend during blob rounds for the same reason. 
