### PR TITLE
Fixes a LINDA runtime

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -94,7 +94,8 @@
 	if(!isturf(loc) && command)
 		return
 	var/turf/T = get_turf(loc)
-	T.air_update_turf(command)
+	if(T) //because we need this for some shitty reason
+		T.air_update_turf(command)
 
 /turf/air_update_turf(command = 0)
 	if(command)


### PR DESCRIPTION
this should hopefully fix the #3083 runtime

```Runtime in LINDA_system.dm,97: Cannot execute null.air update turf().
proc name: air update turf (/atom/proc/air_update_turf)