### PR TITLE
Fixes hydropnics trays taking double chems.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -246,9 +246,9 @@
 
 	if(self_sustaining)
 		if(istype(src, /obj/machinery/hydroponics/soil))
-			add_atom_colour(rgb(255,223,0), FIXED_COLOUR_PRIORITY)
+			add_atom_colour(rgb(255, 175, 0), FIXED_COLOUR_PRIORITY)
 		else
-			add_overlay(mutable_appearance('icons/obj/hydroponics/equipment.dmi', "gaia_blessing"))
+			overlays += mutable_appearance('icons/obj/hydroponics/equipment.dmi', "gaia_blessing")
 		set_light(3)
 
 	update_icon_hoses()
@@ -732,8 +732,6 @@
 			reagent_source.reagents.trans_to(S,split)
 			if(istype(reagent_source, /obj/item/reagent_containers/food/snacks) || istype(reagent_source, /obj/item/reagent_containers/pill))
 				qdel(reagent_source)
-			else
-				reagent_source.reagents.trans_to(S,split)
 
 			H.applyChemicals(S, user)
 


### PR DESCRIPTION
Turns out we modified hydroponics.dm ages ago before tg removed ambrosia gaia and never changed it back when they readded it, as a result we had a second reagents transfer call and hey ho there you go.

All i did was just copy the tg file to us, added bonus of less conflicts. 

:cl: GuyonBroadway
fix: fixed the bug where hydroponics trays were taking more reagents than they should. 
/:cl:

