### PR TITLE
Some buffs to clock cult.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2214,6 +2214,8 @@
 #include "hippiestation\code\game\gamemodes\objective_items.dm"
 #include "hippiestation\code\game\gamemodes\clock_cult\geis.dm"
 #include "hippiestation\code\game\gamemodes\clock_cult\sigils.dm"
+#include "hippiestation\code\game\gamemodes\clock_cult\clock_effects\clock_sigils.dm"
+#include "hippiestation\code\game\gamemodes\clock_cult\clock_scriptures\scripture_drivers.dm"
 #include "hippiestation\code\game\gamemodes\messiah\MakeJesus.dm"
 #include "hippiestation\code\game\gamemodes\messiah\miracles.dm"
 #include "hippiestation\code\game\gamemodes\messiah\outfit.dm"

--- a/hippiestation/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/hippiestation/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -1,0 +1,2 @@
+/obj/effect/clockwork/sigil/vitality
+	revive_cost = 100 //Reviving a nerd effectivly consumes valuable componenets as WELL as vitality, fuck having to farm both of those things as the local powergame allready called the shuttle, theres not enough time for that shit.

--- a/hippiestation/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/hippiestation/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -1,0 +1,3 @@
+
+/datum/clockwork_scripture/vanguard
+	channel_time = 5 //Stun immunity is useless if you are already stunned, this means people stand a chance at using it in combat, as opposed to never fucking using it

--- a/hippiestation/code/game/gamemodes/clock_cult/geis.dm
+++ b/hippiestation/code/game/gamemodes/clock_cult/geis.dm
@@ -81,7 +81,7 @@
 	desc = "Charges your slab with divine energy, allowing you to bind a nearby heretic for conversion. This is very obvious and will make your slab visible in-hand."
 	invocations = list("Divinity, grant...", "...me strength...", "...to enlighten...", "...the heathen!")
 	whispered = TRUE
-	channel_time = 20
+	channel_time = 5 // Blood cult get a free instant stun they can use whenever and wherever they want,
 	usage_tip = "Is melee range and does not penetrate mindshield implants. Much more efficient than a Sigil of Submission at low Servant amounts."
 	tier = SCRIPTURE_DRIVER
 	primary_component = GEIS_CAPACITOR
@@ -93,7 +93,7 @@
 	ranged_message = "<span class='sevtug_small'><i>You charge the clockwork slab with divine energy.</i>\n\
 	<b>Left-click a target within melee range to convert!\n\
 	Click your slab to cancel.</b></span>"
-	timeout_time = 100
+	timeout_time = 200
 
 /datum/clockwork_scripture/ranged_ability/geis_prep/run_scripture()
 	var/servants = 0

--- a/hippiestation/code/game/gamemodes/clock_cult/sigils.dm
+++ b/hippiestation/code/game/gamemodes/clock_cult/sigils.dm
@@ -2,6 +2,11 @@
 	tier = SCRIPTURE_SCRIPT
 	usage_tip = "This the primary way to make conversion traps, though it will not penetrate mindshield implants."
 
+/obj/effect/clockwork/sigil/submission
+	alpha = 75 // This makes it hard to see and more useful as an actual trap
+	light_range = 1 //weak light
+	light_power = 1
+
 /obj/effect/temp_visual/ratvar/sigil/accession
 	color = "#AF0AAF"
 	layer = ABOVE_MOB_LAYER


### PR DESCRIPTION



:cl: GuyonBroadway
balance: Made initially casting Geis much faster.
balance: Made casting vanguard much faster, now you can probably use it in a firefight.
balance: Made the Sigil of submission slightly more see-through and harder to see in the dark. 
balance: Vitality matrix now only needs 100 vitality to revive someone, humanize a few monkeys and toss them in.
/:cl:

Image showing how a sigil of submission+transgression (common conversion trap) looks in a light up area and in the dark. 

![image](https://user-images.githubusercontent.com/22083966/30396449-90621230-98c1-11e7-89b0-52f855f3617d.png)

These balances were made taking into account the kind of power blood cult has at an early stage in the game. Blood cult can whip out talismans and stuncuff you before you can even scream and you are unable to communicate where you are so you are basically doomed. 

Vanguard was never used, because the long wind up mean you had to try and use it pre-emptively but the duration was JUST short enough that you ran the risk of it failing on you mid fight, this way it can become a tactical choice that enables you to use it mid fight if you can quickly get to cover. 

The standard two sigils trap was lit up like a fucking Christmas tree in a Dutch brothel, it was useless as a trap as a result. 

The vitality matrix thing was an issue because it was hardly ever used, most of the time you wanted people alive to be converted so it felt counter intuitive to kill someone you could convert to revive someone already converted.  At the cost of losing a potential convert you get just enough vitality to resurrect about three dead cultists. 