### PR TITLE
Gives mining a ripley at roundstart.

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -40131,27 +40131,15 @@
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "bKn" = (
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel,
+/obj/mecha/working/ripley/mining_roundstart,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/quartermaster/miningdock)
 "bKo" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKp" = (
-/obj/structure/closet/crate,
+/obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKq" = (
@@ -69282,6 +69270,19 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"dcz" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/quartermaster/miningdock)
+"dcA" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 
 (1,1,1) = {"
 aaa
@@ -91021,7 +91022,7 @@ bxu
 bxy
 bxy
 bGj
-bHA
+dcz
 bHA
 bKl
 bxy
@@ -91280,7 +91281,7 @@ bEK
 byE
 byE
 byE
-byE
+dcA
 bGi
 apQ
 apQ

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2236,6 +2236,7 @@
 #include "hippiestation\code\game\machinery\doors\blastco.dm"
 #include "hippiestation\code\game\machinery\pipe\pipe_dispenser.dm"
 #include "hippiestation\code\game\mecha\mech_fabricator.dm"
+#include "hippiestation\code\game\mecha\working\ripley.dm"
 #include "hippiestation\code\game\objects\crafts.dm"
 #include "hippiestation\code\game\objects\inflatables.dm"
 #include "hippiestation\code\game\objects\noose.dm"

--- a/hippiestation/code/game/mecha/working/ripley.dm
+++ b/hippiestation/code/game/mecha/working/ripley.dm
@@ -1,0 +1,28 @@
+/obj/mecha/working/ripley/mining_roundstart
+	desc = "A complimentary APLU fitted with an array of tools suitable for mining, \
+			courtesy of the Nanotrasen geological exploitation department.  \
+			Don't forget to bring your minerals to the hard working boys at R&D \
+			and not to pinch the ORM so they can upgrade it for you."
+	name = "\improper APLU \"Miner\""
+
+/obj/mecha/working/ripley/mining/Initialize()
+	. = ..()
+	if(prob(15)) // Maybe get a diamond drill one every few rounds.
+		var/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/D = new
+		D.attach(src)
+	else
+		var/obj/item/mecha_parts/mecha_equipment/drill/D = new
+		D.attach(src)
+
+	if(prob(30)) //Or perhaps a free plasma cutter!
+		var/obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/P = new
+		P.attach(src)
+
+	cargo.Add(new /obj/structure/ore_box(src)) //Starts with its own nice little ore box.
+
+	//A free clamp too, gosh am I generous!
+	var/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/HC = new
+	HC.attach(src)
+
+	var/obj/item/mecha_parts/mecha_equipment/mining_scanner/scanner = new //And a free scanner just for you!
+	scanner.attach(src)

--- a/hippiestation/code/game/mecha/working/ripley.dm
+++ b/hippiestation/code/game/mecha/working/ripley.dm
@@ -5,7 +5,7 @@
 			and not to pinch the ORM so they can upgrade it for you."
 	name = "\improper APLU \"Miner\""
 
-/obj/mecha/working/ripley/mining/Initialize()
+/obj/mecha/working/ripley/mining_roundstart/Initialize()
 	. = ..()
 	if(prob(15)) // Maybe get a diamond drill one every few rounds.
 		var/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/D = new


### PR DESCRIPTION
:cl: GuyonBroadway
add: There is now a free Mining Ripley at the mining shuttle dock. Please wait a moment for me to get some popcorn before you murder each other over it. 
/:cl:

We used to have this prebase, but in order to minimise conflicts with any lavaland changes I made a small adjustment to the mining dock on map to accommodate it. 

It starts with a basic drill, clamp and ore scanner, it has a small chance to spawn with a plasma cutter and an even smaller chance to spawn with a diamond drill in place of a normal drill. 

Image of the map edit. 
![image](https://user-images.githubusercontent.com/22083966/30444688-ae686fd0-997b-11e7-8d53-55a32927d9b8.png)

