### PR TITLE
The Ultimate Electric Boogaloo Edition Of Syndicate Agents Part 2 Episode 2.5 The Rise Of The Spurdo Sparde

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -170,11 +170,11 @@
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)
 	player_minimum = 0
-
+	
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	item = /obj/item/clothing/shoes/chameleon
 	cost = 2
-    player_minimum = 0
+	player_minimum = 0
 	
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	cost = 2
@@ -184,32 +184,31 @@
 	cost = 2
 	
 /datum/uplink_item/device_tools/syndietome
-    cost = 5
+	cost = 5
 	
 /datum/uplink_item/device_tools/binary
-    cost = 2
+	cost = 2
 	
 /datum/uplink_item/device_tools/singularity_beacon
-    cost = 8
+	cost = 8
 	
 /datum/uplink_item/device_tools/syndicate_bomb
-    cost = 10
+	cost = 10
 	
 /datum/uplink_item/device_tools/syndicate_detonator
-    cost = 1 //Nuke ops already spawn with one
+	cost = 1 //Nuke ops already spawn with one
 	
 /datum/uplink_item/device_tools/jammer
-    cost = 3
+	cost = 3
 	
 /datum/uplink_item/device_tools/codespeak_manual_deluxe
-    cost = 4
+	cost = 4
 	
 /datum/uplink_item/device_tools/autosurgeon
-    name = "Autosurgeon"
-	desc = "A surgery device that instantly implants you with whatever implant has been inserted in it. Infinite uses. \
-			Use a screwdriver to remove an implant from it."
+	name = "Autosurgeon"
+	desc = "A surgery device that instantly implants you with whatever implant has been inserted in it. Infinite uses. Use a screwdriver to remove an implant from it."
 	item = /obj/item/device/autosurgeon
-    cost = 4
+	cost = 4
 	surplus = 60
 	
 /datum/uplink_item/implants/microbomb

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -176,3 +176,53 @@
 	item = /obj/item/grenade/spawnergrenade/cat
 	surplus = 30
 
+/datum/uplink_item/stealthy_tools/chameleon
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)
+	player_minimum = 0
+
+/datum/uplink_item/stealthy_tools/syndigaloshes
+	item = /obj/item/clothing/shoes/chameleon
+	cost = 2
+    player_minimum = 0
+	
+/datum/uplink_item/stealthy_tools/syndigaloshes/nuke
+	cost = 2
+	player_minimum = 0
+	
+/datum/uplink_item/stealthy_tools/mulligan
+	cost = 2
+	
+/datum/uplink_item/device_tools/syndietome
+    cost = 5
+	
+/datum/uplink_item/device_tools/binary
+    cost = 2
+	
+/datum/uplink_item/device_tools/singularity_beacon
+    cost = 8
+	
+/datum/uplink_item/device_tools/syndicate_bomb
+    cost = 10
+	
+/datum/uplink_item/device_tools/syndicate_detonator
+    cost = 1 //Nuke ops already spawn with one
+	
+/datum/uplink_item/device_tools/jammer
+    cost = 3
+	
+/datum/uplink_item/device_tools/codespeak_manual_deluxe
+    cost = 4
+	
+/datum/uplink_item/device_tools/autosurgeon
+    name = "Autosurgeon"
+	desc = "A surgery device that instantly implants you with whatever implant has been inserted in it. Infinite uses. \
+			Use a screwdriver to remove an implant from it."
+	item = /obj/item/device/autosurgeon
+    cost = 4
+	
+/datum/uplink_item/implants/microbomb
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)
+
+/datum/uplink_item/implants/macrobomb
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -220,6 +220,7 @@
 			Use a screwdriver to remove an implant from it."
 	item = /obj/item/device/autosurgeon
     cost = 4
+	surplus = 60
 	
 /datum/uplink_item/implants/microbomb
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -64,16 +64,6 @@
 	cost = 10
 	surplus = 45
 
-/* Sports */
-/datum/uplink_item/badass/sports
-	name = "Sports bundle"
-	desc = "A hand-selected box of paraphernalia from one of the best sports. \
-			Currently available are hockey, wrestling, football, and bowling kits."
-	item = /obj/item/paper
-	cost = 20
-	exclude_modes = list(/datum/game_mode/nuclear)
-	cant_discount = TRUE
-
 /* Holo Parasites */
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
@@ -227,3 +217,31 @@
 
 /datum/uplink_item/implants/macrobomb
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)
+	
+/datum/uplink_item/dangerous/hockey
+	name = "Ka-nada Hockey Set"
+	desc = "Become one of the legends of the most brutal game in space. The items cannot be taken off once you wear them."
+	item = /obj/item/storage/box/syndie_kit/hockey
+	cost = 20
+	exclude_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/dangerous/bowling
+	name = "Bowling Set"
+	desc = "Niko, it's me, your cousin! Let's go bowling."
+	item = /obj/item/storage/box/syndie_kit/bowling
+	cost = 12
+	exclude_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/dangerous/wrestling
+	name = "Wrestling Set"
+	desc = "OH YEAH BROTHERRRR!"
+	item = /obj/item/storage/box/syndie_kit/wrestling
+	cost = 8 //The wrestling set is not as powerful as it once was
+	exclude_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/dangerous/football
+	name = "Football Set"
+	desc = "Actually Rugby."
+	item = /obj/item/storage/box/syndie_kit/football
+	cost = 16
+	exclude_modes = list(/datum/game_mode/nuclear)

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -71,18 +71,7 @@
 	item = /obj/item/storage/box/syndie_kit/guardian
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/badass/sports/spawn_item(turf/loc, obj/item/device/uplink/U)
-	var/list/possible_items = list(
-								"/obj/item/storage/box/syndie_kit/wrestling",
-								"/obj/item/storage/box/syndie_kit/bowling",
-								"/obj/item/storage/box/syndie_kit/hockey",
-								"/obj/item/storage/box/syndie_kit/football"
-								)
-	if(possible_items.len)
-		var/obj/item/I = pick(possible_items)
-		return new I(loc)
-
+	
 /datum/uplink_item/nukeoffer/blastco
 	name = "Unlock the BlastCo(tm) Armory"
 	desc = "Enough gear to fully equip a team with explosive based weaponry."


### PR DESCRIPTION
:cl:
add: Added the autosurgeon to the syndicate uplink. A vastly improved version of what the Chief Medical Officer starts with, it allows you to instantly implant yourself with any implants that you load in it, and it can be re-used indefinitely.
del: Removed the Sports Bundle...
tweak: ...and separated it into its 4 individual possible bundles! You can now choose between the Hockey Set, the Football Set, the Bowling Set and the Wrestling Set, with their own prices based on how good they are! They can be found in the "Loud and Aggressive" section of your uplink.
balance: The Syndicate has recognized the utility of no-slip shoes, and have removed the player count restriction on purchasing them. Nuclear Operatives may now also buy the chameleon kit independently of the player count.
balance: A multitude amount of traitor items had their prices slightly reduced.
tweak: Did you miss the old days when you could rush and suicide-bomb the shuttle as a traitor by blowing all of your TC on one really large bomb implant? Well, you can now do that again! Traitors can now purchase microbomb and macrobomb implants.
/:cl:

I just hope this is actually modularized. Traitors are currently sort of dull, and a lot of them refuse to try gimmicks due to the fear that they will throw away their round. The mulligan's effect can be achieved with a trip to Genetics, never pick the Sports Bundle for the fear that they'll waste all of their TC on the bowling set, the small things that deter people from picking the unique, specialized traitor items in favor of the practical emag or energy sword. Due to their under-usage, the prices of several items have been reduced to encourage players to pick them without that much of a severe consequence to their TC reserves. At the same time, the Sports Bundle has finally been separated into 4 objects. Additionaly, traitors are supposed to be durable and strong, essentialy one-man armies in order to take on the crew. No-slip shoes prevent the usage of water sprays or soaps from easily throwing a traitor's entire round. Due to nuclear operatives being available on lowpop, it was counter-intuitive to pit a single obvious antag against the rest of the crew, so the chameleon kit had its player count restriction removed in order to allow nuclear operatives to be much stealthier, especially the lone ones.