### PR TITLE
Removes Saline Glucose overdose.

### DIFF
--- a/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -209,3 +209,6 @@ datum/reagent/medicine/virogone/on_mob_life(mob/living/M)//cures viruses very ef
 			if(D.stage < 1)
 				D.cure()
 	..()
+
+/datum/reagent/medicine/salglu_solution
+	overdose_threshold = 0 //seriously fuck whoever thought this was a good idea.


### PR DESCRIPTION

:cl: GuyonBroadway
balance: Saline Glucose solution no longer has an overdose threshold, chug to your hearts content. 
/:cl:

[why]:Fuck tg balance.

Sure, lets nerf a little chem that does naught but slowly heal peeps over time and is only ever good for those OCD spergs (myself included) who like to keep at %100hp at all times and don't want to use a whole brute patch to do it. 

No, fuck that, salglu is pretty much only good to keep you "topped off" furthermore its the only way ashwalkers can reliably heal and if it overdoses well said ashwalkers are fucked. 