### PR TITLE
pushes a fix to reagent on_tick being removed

### DIFF
--- a/hippiestation/code/controllers/subsystem/reagent_states.dm
+++ b/hippiestation/code/controllers/subsystem/reagent_states.dm
@@ -1,5 +1,5 @@
 SUBSYSTEM_DEF(reagent_states)
-	name = "Reagent States"
+	name = "Reagents"
 	priority = 40
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -2,6 +2,18 @@
 	reagent_state = LIQUID//since reagent states are now interchangeable it makes sense for them to all start as liquids preventing unnescessary messages
 	var/boiling_point = 500//the point at which a reagent changes from a liquid to a gaseous state
 	var/melting_point = 273//the point at which a reagent changes from a liquid to a solid state
+	var/processes = FALSE
+
+/datum/reagent/New()
+	..()
+	if(processes)
+		START_PROCESSING(SSreagent_states, src)
+
+/datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
+	. = ..()
+	if(processes)
+		STOP_PROCESSING(SSreagent_states, src)
+	holder = null
 
 /datum/reagent/proc/FINISHONMOBLIFE(mob/living/M)
 	current_cycle++

--- a/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -8,8 +8,12 @@
 
 /datum/reagent/cryogenic_fluid/process()
 	if(holder)
-		holder.chem_temp = max(holder.chem_temp - 5, TCMB)
-		..()
+		data++
+		holder.chem_temp = max(holder.chem_temp - 15, TCMB)
+
+	if(data >= 13)
+		STOP_PROCESSING(SSreagent_states, src)
+	..()
 
 /datum/reagent/cryogenic_fluid/on_mob_life(mob/living/M) //not very pleasant but fights fires
 	M.adjust_fire_stacks(-2)

--- a/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -4,16 +4,18 @@
 	description = "Extremely cold superfluid used to put out fires that will viciously freeze people on contact causing severe pain and burn damage, weak if ingested."
 	color = "#b3ffff"
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	processes = TRUE
+
+/datum/reagent/cryogenic_fluid/process()
+	if(holder)
+		holder.chem_temp = max(holder.chem_temp - 5, TCMB)
+		..()
 
 /datum/reagent/cryogenic_fluid/on_mob_life(mob/living/M) //not very pleasant but fights fires
 	M.adjust_fire_stacks(-2)
 	M.adjustStaminaLoss(2)
 	M.adjustBrainLoss(1)
 	M.bodytemperature = max(M.bodytemperature - 10, TCMB)
-	return ..()
-
-/datum/reagent/cryogenic_fluid/on_tick()
-	holder.chem_temp = max(holder.chem_temp - 5, TCMB)
 	return ..()
 
 /datum/reagent/cryogenic_fluid/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
@@ -92,26 +94,29 @@
 	id = "emit_on"
 	description = "It's rather radioactive and glowing painfully bright, you feel the need to RUN!"
 	color = "#1211FB"
+	processes = TRUE
 
-/datum/reagent/emit_on/on_tick()
-	playsound(get_turf(holder.my_atom), 'sound/weapons/emitter.ogg', 50, 1)
-	for(var/direction in GLOB.cardinals)
-		var/obj/item/projectile/beam/emitter/P = new /obj/item/projectile/beam/emitter(get_turf(holder.my_atom))
-		switch(direction)
-			if(1)
-				P.yo = 20
-				P.xo = 0
-			if(2)
-				P.yo = 0
-				P.xo = 20
-			if(4)
-				P.yo = 0
-				P.xo = -20
-			if(8)
-				P.yo = -20
-				P.xo = 0
-		P.fire()
-	holder.remove_reagent(src.id,10,safety = 1)
+/datum/reagent/emit_on/process()
+	if(holder)
+		playsound(get_turf(holder.my_atom), 'sound/weapons/emitter.ogg', 50, 1)
+		for(var/direction in GLOB.cardinals)
+			var/obj/item/projectile/beam/emitter/P = new /obj/item/projectile/beam/emitter(get_turf(holder.my_atom))
+			switch(direction)
+				if(1)
+					P.yo = 20
+					P.xo = 0
+				if(2)
+					P.yo = 0
+					P.xo = 20
+				if(4)
+					P.yo = 0
+					P.xo = -20
+				if(8)
+					P.yo = -20
+					P.xo = 0
+			P.fire()
+		holder.remove_reagent(src.id,10,safety = 1)
+	..()
 
 /datum/reagent/emit_on/on_mob_life(mob/living/M)
 	M.apply_effect(5,IRRADIATE,0)
@@ -128,6 +133,7 @@
 	id = "superboom"
 	description = "An absurdly unstable chemical prone to causing gigantic explosions when even slightly disturbed. Only an idiot would attempt to create this."
 	color = "#13BC5E"
+	processes = TRUE
 
 /datum/reagent/superboom/on_mob_life(mob/living/M)
 	if(M.m_intent == MOVE_INTENT_RUN && current_cycle <= 5)
@@ -146,8 +152,8 @@
 	holder.clear_reagents()
 	..()
 
-/datum/reagent/superboom/on_tick()
-	if(prob(0.5)) //even if you do nothing it can explode
+/datum/reagent/superboom/process()
+	if(prob(0.5) && holder) //even if you do nothing it can explode
 		var/location = get_turf(holder.my_atom)
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(round(volume, 1), location, 0, 0, message = 0)

--- a/hippiestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -286,25 +286,27 @@
 	toxpwr = 2
 	acidpwr = 15
 	data = 0
+	processes = TRUE
 
 /datum/reagent/toxin/acid/hydrazine/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(1)
 	M.dizziness++
 	..()
 
-/datum/reagent/toxin/acid/hydrazine/on_tick()
-	data++
-	if(prob(2) && data > 40) //randomly creates small explosions or fireballs but has a delay so it doesn't just kill people while they're still mixing
-		var/location = get_turf(holder.my_atom)
-		holder.remove_reagent(src.id,5,safety = 1)
-		switch(prob(50))
-			if(TRUE)
-				var/datum/effect_system/reagents_explosion/e = new()
-				e.set_up(rand(1, 3), location, 0, 0, message = 1)
-				e.start()
-			if(FALSE)
-				for(var/turf/F in range(1,location))
-					new /obj/effect/hotspot(F)
+/datum/reagent/toxin/acid/hydrazine/process()
+	if(holder)
+		data++
+		if(prob(2) && data > 40) //randomly creates small explosions or fireballs but has a delay so it doesn't just kill people while they're still mixing
+			var/location = get_turf(holder.my_atom)
+			holder.remove_reagent(src.id,5,safety = 1)
+			switch(prob(50))
+				if(TRUE)
+					var/datum/effect_system/reagents_explosion/e = new()
+					e.set_up(rand(1, 3), location, 0, 0, message = 1)
+					e.start()
+				if(FALSE)
+					for(var/turf/F in range(1,location))
+						new /obj/effect/hotspot(F)
 	..()
 
 /datum/reagent/toxin/sazide//replacement for cyanide, causes scaling oxyloss followed by sleeping and eye+liver damage
@@ -373,7 +375,7 @@
 	color = "#EFD6D0"
 	taste_description = "dizzying sweetness"
 	taste_mult = 2.0
-	
+
 /datum/reagent/toxin/impgluco/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar",0.8*REM)
 	..()
@@ -386,7 +388,7 @@
 	color = "#F6F1D2"
 	taste_description = "ungodly sweetness"
 	taste_mult = 5.0
-	
+
 /datum/reagent/toxin/gluco/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar", 4*REM)
 	if(prob(15))
@@ -402,7 +404,7 @@
 	reagent_state = LIQUID
 	color = "#853358"
 	taste_description = "salty and sour"
-	
+
 /datum/reagent/toxin/screech/on_mob_life(mob/living/M)
 	var/chance = 10
 	switch(current_cycle)


### PR DESCRIPTION
Reagent_states SS now called reagents for the sake of clarity.
Reagents on new and on destroy can selectively call for processing in Reagents SS  based on a var.
All former reagent_on_tick()s replaced with process() to prepare for removal.