### PR TITLE
Prevents server lagging with chems

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -29,7 +29,7 @@
 		if(alpha < 160)
 			set_opacity(0) //if we were blocking view, we aren't now because we're fading out
 		stoplag()
-
+/*mirrored so smoke processes with reagents subsystem instead
 /obj/effect/particle_effect/smoke/New()
 	..()
 	create_reagents(500)
@@ -44,7 +44,7 @@
 	STOP_PROCESSING(SSobj, src)
 	INVOKE_ASYNC(src, .proc/fade_out)
 	QDEL_IN(src, 10)
-
+*/
 /obj/effect/particle_effect/smoke/process()
 	lifetime--
 	if(lifetime < 1)

--- a/hippiestation/code/controllers/subsystem/reagent_states.dm
+++ b/hippiestation/code/controllers/subsystem/reagent_states.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(reagent_states)
 	priority = 40
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	var/deleting = FALSE
 
 	var/list/currentrun = list()
 	var/list/processing = list()
@@ -25,7 +26,14 @@ SUBSYSTEM_DEF(reagent_states)
 			thing.process(wait)
 		else
 			SSreagent_states.processing -= thing
-		if (MC_TICK_CHECK)
+		if(MC_TICK_CHECK)
+			if(!deleting && cost > 2000)
+				deleting = TRUE
+				for(var/I in GLOB.smoke)
+					qdel(I)
+				for(var/I in GLOB.vapour)
+					qdel(I)
+				deleting = FALSE
 			return
 
 /datum/controller/subsystem/reagent_states/Recover()

--- a/hippiestation/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/hippiestation/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -1,14 +1,21 @@
-/obj/effect/particle_effect/smoke
-	alpha = 0
-
-
-/obj/effect/particle_effect/smoke/New(loc)
+GLOBAL_LIST_EMPTY(smoke)
+/obj/effect/particle_effect/smoke/New()
 	..()
-	addtimer(CALLBACK(src, /obj/effect/particle_effect/.proc/smokefoam_fade_in), 0)
+	LAZYADD(GLOB.smoke, src)
+	create_reagents(500)
+	START_PROCESSING(SSreagent_states, src)
 
-/obj/effect/particle_effect/smoke/kill_smoke()
-	..()
-	animate(src, alpha = 0, time = 10)
+
+/obj/effect/particle_effect/smoke/Destroy()
+	LAZYREMOVE(GLOB.smoke, src)
+	STOP_PROCESSING(SSreagent_states, src)
+	return ..()
+
+/obj/effect/particle_effect/smoke/proc/kill_smoke()
+	LAZYREMOVE(GLOB.smoke, src)
+	STOP_PROCESSING(SSreagent_states, src)
+	INVOKE_ASYNC(src, .proc/fade_out)
+	QDEL_IN(src, 10)
 
 /obj/effect/particle_effect/smoke/chem/process()
 	if(..() && reagents)

--- a/hippiestation/code/game/objects/effects/effect_system/effects_vapour.dm
+++ b/hippiestation/code/game/objects/effects/effect_system/effects_vapour.dm
@@ -36,6 +36,7 @@
 
 	..()
 
+GLOBAL_LIST_EMPTY(vapour)
 /obj/effect/particle_effect/vapour
 	name = "vapour"
 	icon = 'icons/effects/tile_effects.dmi'
@@ -50,15 +51,18 @@
 
 /obj/effect/particle_effect/vapour/Initialize()
 	. = ..()
+	LAZYADD(GLOB.vapour, src)
 	create_reagents(50)//used just for in air reactions
 	START_PROCESSING(SSreagent_states, src)
 
 
 /obj/effect/particle_effect/vapour/Destroy()
+	LAZYREMOVE(GLOB.vapour, src)
 	STOP_PROCESSING(SSreagent_states, src)
 	return ..()
 
 /obj/effect/particle_effect/vapour/proc/kill_vapour()
+	LAZYREMOVE(GLOB.vapour, src)
 	STOP_PROCESSING(SSreagent_states, src)
 	qdel(src)
 

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -60,7 +60,7 @@
 				V.reagent_type = src
 			log_game("Reagent vapour of type [src.name] was released at [COORD(T)] Last Fingerprint: [touch_msg] ")
 //liquid
-	var/list/chempile_reagent_blacklist = list("water", "lube", "bleach", "cleaner", "colorful_reagent", "condensedcapsaicin", "radium", "thermite")//add stuff that doesn't make sense/is too op for turfchems
+	var/list/chempile_reagent_blacklist = list("water", "lube", "bleach", "cleaner", "colorful_reagent", "condensedcapsaicin", "radium", "thermite", "smoke_powder")//add stuff that doesn't make sense/is too op for turfchems
 	if(src.reagent_state == LIQUID)
 		if(src.id in chempile_reagent_blacklist)
 			return

--- a/hippiestation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/hippiestation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -78,6 +78,10 @@
 
 //over reaction stuff
 /datum/chemical_reaction/proc/over_reaction(datum/reagents/holder, created_volume)
+	if(istype(holder, /obj/effect/decal/cleanable/chempile))//smoke spam in chempiles is a big fat sausage of a NO
+		holder.clear_reagents()
+		return
+
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/chem/S = new
 	S.attach(location)
@@ -85,7 +89,7 @@
 	if(S)
 		S.set_up(holder, 4, location, 0)
 		S.start()
-	if(holder && holder.my_atom)
+	if(holder)
 		holder.clear_reagents()
 
 /datum/chemical_reaction/over_reactible
@@ -203,15 +207,12 @@
 	required_reagents = list("uranium" = 1 , "sparky" = 4 , "volt" = 2)
 	bluespace_recipe = TRUE
 
-/datum/chemical_reaction/over_reactible/emit_on
+/datum/chemical_reaction/emit_on
 	name = "Emittrium_on"
 	id = "emit_on"
 	results = list("emit_on" = 1)
 	required_reagents = list("emit" = 1)
 	required_temp = 400
-	can_overheat = TRUE
-	overheat_threshold = 900
-	exothermic_gain = 400
 
 /datum/chemical_reaction/over_reactible/dizinc
 	name = "Diethyl Mercury"


### PR DESCRIPTION
:cl: banthebantz
fix: Lag caused by chucklefucks creating looping smoke grenades should be fixed
/:cl:

Smoke processing moved to the reagents SS. 
Reagents SS now automatically kills all smoke and vapour if the cost goes over 2000 and it's being tick checked.
Over reactions can no longer occur in chempiles causing server destroying lag loops.
Smoke powder is blacklisted from chempiles for similar reasons.
Glowing emittrium over reaction removed because it just sucks.
