### PR TITLE
Adds a nice cluwne mask to the autodrobe.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2322,6 +2322,7 @@
 #include "hippiestation\code\game\objects\items\staples.dm"
 #include "hippiestation\code\game\objects\items\stunbaton.dm"
 #include "hippiestation\code\game\objects\items\twohanded.dm"
+#include "hippiestation\code\game\objects\items\vending_items.dm"
 #include "hippiestation\code\game\objects\items\weaponry.dm"
 #include "hippiestation\code\game\objects\items\circuitboards\machine_circuitboards.dm"
 #include "hippiestation\code\game\objects\items\devices\meeseeks_box.dm"

--- a/hippiestation/code/game/machinery/vending_types.dm
+++ b/hippiestation/code/game/machinery/vending_types.dm
@@ -385,7 +385,8 @@ AUTODROBE
 		/obj/item/clothing/shoes/roman = 1,
 		/obj/item/shield/riot/roman = 1,
 		/obj/item/skub = 3,
-		/obj/item/clothing/gloves/color/white/soft = 2
+		/obj/item/clothing/gloves/color/white/soft = 2,
+		/obj/item/clothing/mask/hippie/cluwne/happy_cluwne = 1
 		)
 
 /*

--- a/hippiestation/code/game/objects/items/vending_items.dm
+++ b/hippiestation/code/game/objects/items/vending_items.dm
@@ -1,0 +1,6 @@
+
+/obj/item/vending_refill/autodrobe
+	machine_name = "AutoDrobe"
+	icon_state = "refill_costume"
+	charges = list(32, 2, 5)
+	init_charges = list(32, 2, 5)

--- a/hippiestation/code/modules/clothing/mask.dm
+++ b/hippiestation/code/modules/clothing/mask.dm
@@ -18,7 +18,7 @@
 
 /obj/item/clothing/mask/hippie/cluwne/happy_cluwne
 	name = "Happy Cluwne Mask"
-	desc = "The mask of a poor cluwne that has been scrubbed of its curse by the Nanotrasen supernatural machinations division. Garunteed to be %99 curse free and %99.9 not haunted."
+	desc = "The mask of a poor cluwne that has been scrubbed of its curse by the Nanotrasen supernatural machinations division. Guaranteed to be %99 curse free and %99.9 not haunted. "
 	flags_1 = MASKINTERNALS_1
 	alternate_screams = list('hippiestation/sound/voice/cluwnelaugh1.ogg','hippiestation/sound/voice/cluwnelaugh2.ogg','hippiestation/sound/voice/cluwnelaugh3.ogg')
 

--- a/hippiestation/code/modules/clothing/mask.dm
+++ b/hippiestation/code/modules/clothing/mask.dm
@@ -1,3 +1,5 @@
+#define CLUWNEDOWN 50
+
 /obj/item/clothing/mask/hippie/cluwne
 	name = "clown wig and mask"
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
@@ -21,6 +23,7 @@
 	desc = "The mask of a poor cluwne that has been scrubbed of its curse by the Nanotrasen supernatural machinations division. Guaranteed to be %99 curse free and %99.9 not haunted. "
 	flags_1 = MASKINTERNALS_1
 	alternate_screams = list('hippiestation/sound/voice/cluwnelaugh1.ogg','hippiestation/sound/voice/cluwnelaugh2.ogg','hippiestation/sound/voice/cluwnelaugh3.ogg')
+	var/can_cluwne = TRUE
 
 /obj/item/clothing/mask/hippie/cluwne/happy_cluwne/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -28,21 +31,31 @@
 	var/mob/living/carbon/human/H = user
 	if(slot == slot_wear_mask)
 		H.add_screams(src.alternate_screams)
+		if(prob(1) && can_cluwne) // Its %99 curse free!
+			log_admin("[key_name(H)] was made into a cluwne by [src]")
+			message_admins("[key_name(H)] got cluwned by [src]")
+			to_chat(H, "<span class='userdanger'>The masks straps suddenly tighten to your face and your thoughts are erased by a horrible green light!</span>")
+			H.dropItemToGround(src)
+			H.cluwneify()
+			qdel(src)
+		else if(prob(0.1) && can_cluwne) //And %99.9 free form being haunted by vengeful jester-like entites.
+			var/turf/T = get_turf(src)
+			var/mob/living/simple_animal/hostile/floor_cluwne/S = new(T)
+			S.Acquire_Victim(user)
+			log_admin("[key_name(user)] summoned a floor cluwne using the [src]")
+			message_admins("[key_name(user)] summoned a floor cluwne using the [src]")
+			to_chat(H, "<span class='warning'>The mask suddenly slips off your face and... slides under the floor?</span>")
+			to_chat(H, "<i>...dneirf uoy ot gnoleb ton seod tahT</i>")
+			qdel(src)
+		else if(can_cluwne)
+			can_cluwne = FALSE
+			addtimer(CALLBACK(src, .proc/re_cluwne), CLUWNEDOWN)
+
 	else
 		H.reindex_screams()
-	if(prob(1)) // Its %99 curse free!
-		log_admin("[key_name(H)] was made into a cluwne by [src]")
-		message_admins("[key_name(H)] got cluwned by [src]")
-		to_chat(H, "<span class='userdanger'>The masks straps suddenly tighten to your face and your thoughts are erased by a horrible green light!</span>")
-		H.dropItemToGround(src)
-		H.cluwneify()
-		qdel(src)
-	else if(prob(0.1)) //And %99.9 free form being haunted by vengeful jester-like entites.
-		var/turf/T = get_turf(src)
-		var/mob/living/simple_animal/hostile/floor_cluwne/S = new(T)
-		S.Acquire_Victim(user)
-		log_admin("[key_name(user)] summoned a floor cluwne using the [src]")
-		message_admins("[key_name(user)] summoned a floor cluwne using the [src]")
-		to_chat(H, "<span class='warning'>The mask suddenly slips off your face and... slides under the floor?</span>")
-		to_chat(H, "<i>...dneirf uoy ot gnoleb ton seod tahT</i>")
-		qdel(src)
+
+/obj/item/clothing/mask/hippie/cluwne/happy_cluwne/proc/re_cluwne()
+	if(!can_cluwne)
+		can_cluwne = TRUE
+
+#undef CLUWNEDOWN

--- a/hippiestation/code/modules/clothing/mask.dm
+++ b/hippiestation/code/modules/clothing/mask.dm
@@ -15,3 +15,34 @@
 		var/mob/living/carbon/human/H = user
 		H.dna.add_mutation(CLUWNEMUT)
 	return
+
+/obj/item/clothing/mask/hippie/cluwne/happy_cluwne
+	name = "Happy Cluwne Mask"
+	desc = "The mask of a poor cluwne that has been scrubbed of its curse by the Nanotrasen supernatural machinations division. Garunteed to be %99 curse free and %99.9 not haunted."
+	flags_1 = MASKINTERNALS_1
+	alternate_screams = list('hippiestation/sound/voice/cluwnelaugh1.ogg','hippiestation/sound/voice/cluwnelaugh2.ogg','hippiestation/sound/voice/cluwnelaugh3.ogg')
+
+/obj/item/clothing/mask/hippie/cluwne/happy_cluwne/equipped(mob/user, slot)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(slot == slot_wear_mask)
+		H.add_screams(src.alternate_screams)
+	else
+		H.reindex_screams()
+	if(prob(1)) // Its %99 curse free!
+		log_admin("[key_name(H)] was made into a cluwne by [src]")
+		message_admins("[key_name(H)] got cluwned by [src]")
+		to_chat(H, "<span class='userdanger'>The masks straps suddenly tighten to your face and your thoughts are erased by a horrible green light!</span>")
+		H.dropItemToGround(src)
+		H.cluwneify()
+		qdel(src)
+	else if(prob(0.1)) //And %99.9 free form being haunted by vengeful jester-like entites.
+		var/turf/T = get_turf(src)
+		var/mob/living/simple_animal/hostile/floor_cluwne/S = new(T)
+		S.Acquire_Victim(user)
+		log_admin("[key_name(user)] summoned a floor cluwne using the [src]")
+		message_admins("[key_name(user)] summoned a floor cluwne using the [src]")
+		to_chat(H, "<span class='warning'>The mask suddenly slips off your face and... slides under the floor?</span>")
+		to_chat(H, "<i>...dneirf uoy ot gnoleb ton seod tahT</i>")
+		qdel(src)


### PR DESCRIPTION
:cl: GuyonBroadway
add: Thanks to the efforts of the Nanotrasen supernatural machinations division we've been able to clear the cursed magic out of the mounds of cluwne masks left behind after so many wizard rampages. Guaranteed to be %99 curse free and %99.9 not haunted. Now you can scream like a cluwne and send your fellow crew mates into a murderous frenzy! Available in the premium section of your nearest autodrobe!
/:cl:

[why]: Honk!