### PR TITLE
Typecache spam in Life is very bad.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2236,6 +2236,7 @@
 #include "hippiestation\code\_globalvars\lists\maintenance_loot.dm"
 #include "hippiestation\code\_globalvars\lists\names.dm"
 #include "hippiestation\code\_globalvars\lists\poll_ignore.dm"
+#include "hippiestation\code\_globalvars\lists\typecache.dm"
 #include "hippiestation\code\_onclick\item_attack.dm"
 #include "hippiestation\code\_onclick\hud\combo.dm"
 #include "hippiestation\code\_onclick\hud\human.dm"

--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -4,9 +4,17 @@
 
 //Note: typecache can only replace istype if you know for sure the thing is at least a datum.
 
-GLOBAL_LIST_INIT(holder_blacklist_typecache, typecacheof(list(
+// Don't show reaction messages in these atoms
+GLOBAL_LIST_INIT(no_reagent_message_typecache, typecacheof(list(
   /obj/effect/particle_effect,
   /obj/effect/decal/cleanable,
   /mob/living,
   /obj/item/reagent_containers/food)
+))
+
+// Don't do state change in these atoms
+GLOBAL_LIST_INIT(no_reagent_statechange_typecache, typecacheof(list(
+  /obj/effect/particle_effect/water,
+  /obj/effect/decal/cleanable,
+  /mob/living)
 ))

--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -1,0 +1,12 @@
+//see: https://github.com/HippieStation/HippieStation/blob/fix-lag/code/_globalvars/lists/typecache.dm
+//please store common type caches here.
+//type caches should only be stored here if used in mutiple places or likely to be used in mutiple places.
+
+//Note: typecache can only replace istype if you know for sure the thing is at least a datum.
+
+GLOBAL_LIST_INIT(holder_blacklist_typecache, typecacheof(list(
+  /obj/effect/particle_effect,
+  /obj/effect/decal/cleanable,
+  /mob/living,
+  /obj/item/reagent_containers/food)
+))

--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -32,27 +32,27 @@
 				if(GAS)
 					if(chem_temp < R.boiling_point)
 						R.reagent_state = LIQUID
-						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.no_reagent_message_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The vapour condenses into a liquid!</span>"))
 
 				if(SOLID)
 					if(chem_temp > R.melting_point)
 						R.reagent_state = LIQUID
-						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.no_reagent_message_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solid chemicals melt into a liquid!</span>"))
 
 				if(LIQUID)
 					if(chem_temp > R.boiling_point)
 						R.reagent_state = GAS
-						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.no_reagent_message_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(4, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solution rapidly boils into a vapour!</span>"))
 
 					else if(chem_temp < R.melting_point)
 						R.reagent_state = SOLID
-						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.no_reagent_message_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solution solidifies!</span>"))
 

--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -18,8 +18,6 @@
 	var/list/cached_reagents = reagent_list
 	var/list/cached_reactions = GLOB.chemical_reactions_list
 	var/datum/cached_my_atom = my_atom
-	var/static/list/holder_blacklist_types = list(/obj/effect/particle_effect, /obj/effect/decal/cleanable, /mob/living, /obj/item/reagent_containers/food)//preventing message spam
-	var/static/list/holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
 	if(flags & REAGENT_NOREACT)
 		return //Yup, no reactions here. No siree.
 

--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -32,27 +32,27 @@
 				if(GAS)
 					if(chem_temp < R.boiling_point)
 						R.reagent_state = LIQUID
-						if(!is_type_in_typecache(cached_my_atom, holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The vapour condenses into a liquid!</span>"))
 
 				if(SOLID)
 					if(chem_temp > R.melting_point)
 						R.reagent_state = LIQUID
-						if(!is_type_in_typecache(cached_my_atom, holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solid chemicals melt into a liquid!</span>"))
 
 				if(LIQUID)
 					if(chem_temp > R.boiling_point)
 						R.reagent_state = GAS
-						if(!is_type_in_typecache(cached_my_atom, holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(4, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solution rapidly boils into a vapour!</span>"))
 
 					else if(chem_temp < R.melting_point)
 						R.reagent_state = SOLID
-						if(!is_type_in_typecache(cached_my_atom, holder_blacklist_typecache) && SSticker.HasRoundStarted())
+						if(!is_type_in_typecache(cached_my_atom, GLOB.holder_blacklist_typecache) && SSticker.HasRoundStarted())
 							for(var/mob/M in viewers(3, T))
 								to_chat(M, ("<span class='notice'>[icon2html(cached_my_atom, viewers(cached_my_atom))] The solution solidifies!</span>"))
 

--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -18,8 +18,8 @@
 	var/list/cached_reagents = reagent_list
 	var/list/cached_reactions = GLOB.chemical_reactions_list
 	var/datum/cached_my_atom = my_atom
-	var/list/holder_blacklist_typecache = list(/obj/effect/particle_effect, /obj/effect/decal/cleanable, /mob/living, /obj/item/reagent_containers/food)//preventing message spam
-	holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
+	var/static/list/holder_blacklist_types = list(/obj/effect/particle_effect, /obj/effect/decal/cleanable, /mob/living, /obj/item/reagent_containers/food)//preventing message spam
+	var/static/list/holder_blacklist_typecache = holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
 	if(flags & REAGENT_NOREACT)
 		return //Yup, no reactions here. No siree.
 

--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -19,7 +19,7 @@
 	var/list/cached_reactions = GLOB.chemical_reactions_list
 	var/datum/cached_my_atom = my_atom
 	var/static/list/holder_blacklist_types = list(/obj/effect/particle_effect, /obj/effect/decal/cleanable, /mob/living, /obj/item/reagent_containers/food)//preventing message spam
-	var/static/list/holder_blacklist_typecache = holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
+	var/static/list/holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
 	if(flags & REAGENT_NOREACT)
 		return //Yup, no reactions here. No siree.
 

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -32,7 +32,7 @@
 		return
 
 	if(atom)
-		if(is_type_in_typecache(atom, no_reagent_statechange_typecache))
+		if(is_type_in_typecache(atom, GLOB.no_reagent_statechange_typecache))
 			return
 		if(istype(atom, /obj/item))
 			var/obj/item/I = atom

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -22,8 +22,6 @@
 
 /datum/reagent/proc/handle_state_change(turf/T, volume, atom)
 	var/touch_msg
-	var/list/holder_blacklist_typecache = list(/obj/effect/particle_effect/water, /obj/effect/decal/cleanable, /mob/living)//blacklisted to prevent spam or other unforeseen consequences
-	holder_blacklist_typecache = typecacheof(holder_blacklist_typecache)
 	if(!istype(T))
 		return
 	if(isspaceturf(T))
@@ -34,7 +32,7 @@
 		return
 
 	if(atom)
-		if(is_type_in_typecache(atom, holder_blacklist_typecache))
+		if(is_type_in_typecache(atom, no_reagent_statechange_typecache))
 			return
 		if(istype(atom, /obj/item))
 			var/obj/item/I = atom


### PR DESCRIPTION
@banthebantz 

```
[13:14:24]typecacheof(/list (/list), null, 0)
[13:14:24]/datum/reagents (/datum/reagents): handle reactions()
[13:14:24]/datum/reagents (/datum/reagents): metabolize(the monkey (513) (/mob/living/carbon/monkey), 1)
[13:14:24]the liver (/obj/item/organ/liver): on life()
[13:14:24]the monkey (513) (/mob/living/carbon/monkey): handle organs()
[13:14:24]the monkey (513) (/mob/living/carbon/monkey): Life(2, 109)
[13:14:24]the monkey (513) (/mob/living/carbon/monkey): Life(2, 109)
[13:14:24]Mobs (/datum/controller/subsystem/mobs): fire(1)
[13:14:24]Mobs (/datum/controller/subsystem/mobs): ignite(1)
[13:14:24]Master (/datum/controller/master): RunQueue()
[13:14:24]Master (/datum/controller/master): Loop()
[13:14:24]Master (/datum/controller/master): StartProcessing(0)
```
I've been digging into why we get so much lag with 50+ players on, this is the main cause I think.

:cl: Jambread
fix: Lag should be significantly reduced on high pop.
/:cl:
