### PR TITLE
Voice Of God for Wizard Spellbooks and a gun, Part 2

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2515,7 +2515,6 @@
 #include "hippiestation\code\modules\surgery\dethralling.dm"
 #include "hippiestation\code\modules\surgery\gender_reassignment.dm"
 #include "hippiestation\code\modules\surgery\organ_internal.dm"
-#include "hippiestation\code\modules\surgery\organs\autosurgeon.dm"
 #include "hippiestation\code\modules\surgery\organs\butts.dm"
 #include "hippiestation\code\modules\surgery\organs\ears.dm"
 #include "hippiestation\code\modules\surgery\organs\eyes.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2515,6 +2515,7 @@
 #include "hippiestation\code\modules\surgery\dethralling.dm"
 #include "hippiestation\code\modules\surgery\gender_reassignment.dm"
 #include "hippiestation\code\modules\surgery\organ_internal.dm"
+#include "hippiestation\code\modules\surgery\organs\autosurgeon.dm"
 #include "hippiestation\code\modules\surgery\organs\butts.dm"
 #include "hippiestation\code\modules\surgery\organs\ears.dm"
 #include "hippiestation\code\modules\surgery\organs\eyes.dm"

--- a/hippiestation/code/game/gamemodes/wizard/spellbook.dm
+++ b/hippiestation/code/game/gamemodes/wizard/spellbook.dm
@@ -307,6 +307,12 @@
 	category = "Assistance"
 	cost = 1 // It forces the wizard to stay still during combat and it was designed for non-antag miner use in mind.
 
+/datum/spellbook_entry/item/gun
+	name = "Deagle"
+	desc = "'The answer? Use a gun.'"
+	item_path = /obj/item/gun/ballistic/automatic/pistol/deagle
+	cost = 1 //And if that don't work? Use more gun.
+
 /datum/spellbook_entry/item/bookofdarkness
 	name = "Book of Darkness"
 	desc = "A forbidden tome, previously outlawed from the Wizard Federation for containing necromancy that is now being redistributed. Contains a powerful artifact that gets stronger with every soul it claims, a stunning spell that deals heavy damage to a single target, an incorporeal move spell and a spell that lets you explode corpses. Comes with a cool set of powerful robes as well that can carry the Staff of Revenant."

--- a/hippiestation/code/game/gamemodes/wizard/spellbook.dm
+++ b/hippiestation/code/game/gamemodes/wizard/spellbook.dm
@@ -151,7 +151,7 @@
 	name = "Mindswap"
 	spell_type = /obj/effect/proc_holder/spell/targeted/mind_transfer
 	category = "Mobility"
-F
+
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
 	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall
@@ -299,6 +299,13 @@ F
 
 /obj/item/spellbook/oneuse/smoke/lesser //Chaplain smoke book
 	spell = /obj/effect/proc_holder/spell/targeted/smoke/lesser
+
+/datum/spellbook_entry/item/colossus
+	name = "Voice Of God"
+	desc = "An auto-surgeon containing magical vocal cords carefully harvested from slain Lavaland Colossi. It forces people to obey certain commands. Does not work over radio or on deaf people. Will drop upon resurrecting as a lich."
+	item_path = /obj/item/device/autosurgeon/colossus
+	category = "Assistance"
+	cost = 1 // It forces the wizard to stay still during combat and it was designed for non-antag miner use in mind.
 
 /datum/spellbook_entry/item/bookofdarkness
 	name = "Book of Darkness"

--- a/hippiestation/code/modules/surgery/organs/autosurgeon.dm
+++ b/hippiestation/code/modules/surgery/organs/autosurgeon.dm
@@ -1,0 +1,2 @@
+/obj/item/device/autosurgeon/colossus
+	starting_organ = /obj/item/organ/vocal_cords/colossus


### PR DESCRIPTION
:cl:
add: Added an autosurgeon containing Voice Of God vocal cords, available for 1 spell point under the "Assistance" category.
add: Also added a deagle gun, because not every situation can be fixed with spells alone. Available for 1 spell point under the "Offensive"/"Regular" category.
/:cl:
Antags could always use more gimmicky items available for them. Wizards should have more magic-themed gimmicky items, however, the PR also contains an actual gun in reference to this : 
https://www.youtube.com/watch?v=4cZqRzHnI8s