### PR TITLE
Ripleys can no longer gib people, downstream edition

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -80,7 +80,7 @@
 	target.visible_message("<span class='danger'>[chassis] drills [target] with [src].</span>", \
 						"<span class='userdanger'>[chassis] drills [target] with [src].</span>")
 	add_logs(user, target, "attacked", "[name]", "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD)
+	if(target.stat == DEAD && !ishuman(target))
 		if(target.butcher_results)
 			target.harvest(chassis)//Butcher the mob with our drill.
 		else


### PR DESCRIPTION
:cl: armhulen
balance: ripleys can't gib humans.
/:cl:

your resident awesome maintainer MRTY wants to add hugbox ripleys that hug people instead of gib them he's doing it only for downstream anyways (he died or something i dunno) so lets just have this pr'd so tg remains hugbox free. TY!

what MRTY has to say on the matter:
"wtf this is op"
closes #32025 (our master!)