### PR TITLE
Revert "Revert "[MIRROR] Late join antagonists will try to target late join players""

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -64,6 +64,7 @@
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE
+	var/late_joiner = FALSE
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -54,9 +54,22 @@
 /datum/objective/proc/find_target()
 	var/list/datum/mind/owners = get_owners()
 	var/list/possible_targets = list()
+	var/try_target_late_joiners = FALSE
+	for(var/I in owners)
+		var/datum/mind/O = I
+		if(O.late_joiner)
+			try_target_late_joiners = TRUE
 	for(var/datum/mind/possible_target in get_crewmember_minds())
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target))
 			possible_targets += possible_target
+	if(try_target_late_joiners)
+		var/list/all_possible_targets = possible_targets.Copy()
+		for(var/I in all_possible_targets)
+			var/datum/mind/PT = I
+			if(!PT.late_joiner)
+				possible_targets -= PT
+		if(!possible_targets.len)
+			possible_targets = all_possible_targets
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
 	update_explanation_text()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -485,6 +485,7 @@
 	. = H
 	new_character = .
 	if(transfer_after)
+		mind.late_joiner = TRUE
 		transfer_character()
 
 /mob/dead/new_player/proc/transfer_character()


### PR DESCRIPTION
Reverts HippieStation/HippieStation#4271

We kinda need this for upstream reasons but we should discuss it before hitting the go button.

TL:DR what this will do is when a latejoin antag is created their murder objectives will try to preference latejoined players. 