### PR TITLE
Removes surplus crate player limit

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -251,3 +251,7 @@
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor)
+
+
+/datum/uplink_item/badass/surplus
+	player_minimum = 0


### PR DESCRIPTION
:cl: GuyonBroadway
balance: Removed the population limit on the surplus crate
/:cl:

[why]: Fuck tg balancing.