### PR TITLE
Stop shitlording with spesslube plz

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -60,6 +60,13 @@
 	var/turf/T = get_turf(src)
 	var/smoke_test = locate(/obj/effect/particle_effect/smoke) in T
 	if(on && !smoke_test)
+	//"HEY FOLKS I HAZ NU ID 4 TOPLEL MEEMZ LE SPESS LUBE IN LE VAPE NAYSH MACHEEEN LOLOLOLOL"
+		if(locate(/datum/reagent/lube) in reagents.reagent_list)
+			var/datum/effect_system/reagents_explosion/e = new()
+			e.set_up(3, src.loc, 3, 3, message = 1)
+			e.start()
+			//You could add in a nice text here, like "The machine humms ominously as the rotors start working faster due to the lube."
+	//Else work normally
 		var/datum/effect_system/smoke_spread/chem/smoke_machine/smoke = new()
 		smoke.set_up(reagents, setting, efficiency, T)
 		smoke.start()


### PR DESCRIPTION
A little surprise to everyone who tries to get cancerous.

[Changelogs]: # Changes how the smonk machine vapes dankly with spess lube. One way to stop from having all the halls  lubed. You could also change the pull request to only apply after a certain amount has been chosen for the smoke machine if you want to nerf that, but honestly, I feel it is an okay punishment

:cl: Anti-shitlord smoke machine
balance: Made mass lubing via smoke machine impossible.
/:cl:

[why]: # (looks at newfags trying le chem memes for the first time) Does this really need any explanation?
