### PR TITLE
Adds autosurgeon to cargo

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,6 +2387,7 @@
 #include "hippiestation\code\modules\admin\verbs\testdummy.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
+#include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\preferences.dm"
 #include "hippiestation\code\modules\client\preferences_savefile.dm"
 #include "hippiestation\code\modules\client\loadout\glasses.dm"

--- a/hippiestation/code/modules/cargo/packs.dm
+++ b/hippiestation/code/modules/cargo/packs.dm
@@ -1,0 +1,5 @@
+/datum/supply_pack/medical/Autosurgeon
+	name = "Autosurgeon Crate"
+	cost = 8000
+	contains = list(/obj/item/device/autosurgeon)
+	crate_name = "Autosurgeon crate"


### PR DESCRIPTION
Making multiple pills and getting your beaker back can be quite a pain in the butt, so I thought I would propose a small change that puts the beaker directly in the user's hand on ejection, so that it doesn't drown in pills.

[Changelogs]: #You can now buy Autosurgeon at cargo
🆑 Autosurgeon added to cargo
Add: Adds autosurgeon to cargo console to be bough for 8000 point
/🆑

[why]: # this way, it doesnt buff scince, but cargo, a different department, and would encourage department working with each other for the greater good.