### PR TITLE
Gives mindshield implants to hotel security staff

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -331,7 +331,6 @@
 	head = /obj/item/clothing/head/helmet/blueshirt
 	back = /obj/item/storage/backpack/security
 	belt = /obj/item/storage/belt/security/full
-	implants = list(/obj/item/implant/mindshield)
 
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -331,6 +331,7 @@
 	head = /obj/item/clothing/head/helmet/blueshirt
 	back = /obj/item/storage/backpack/security
 	belt = /obj/item/storage/belt/security/full
+	implants = list(/obj/item/implant/mindshield)
 
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))

--- a/hippiestation/code/game/objects/structures/ghost_role_spawners.dm
+++ b/hippiestation/code/game/objects/structures/ghost_role_spawners.dm
@@ -1,2 +1,4 @@
 /datum/outfit/hotelstaff
 	implants = list(/obj/item/implant/teleporter/ghost_role)
+/datum/outfit/hotelstaff/security
+	implants = list(/obj/item/implant/mindshield)


### PR DESCRIPTION
[Changelogs]: # mindshields security staff
tweak: hotel security staff are now mindshielded
/:cl:

[why]: # this would allow them to use the energy shotgun, also, for some reason, normal hotel staff are alredy mindshielded