### PR TITLE
Smoke machine board in tech storage.

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -25171,7 +25171,6 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
-/obj/machinery/smoke_machine,
 /mob/living/simple_animal/bot/cleanbot{
 	name = "C.L.E.A.N."
 	},
@@ -38548,6 +38547,7 @@
 /obj/item/circuitboard/machine/clonescanner,
 /obj/item/circuitboard/machine/clonepod,
 /obj/item/circuitboard/computer/scan_consolenew,
+/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGE" = (


### PR DESCRIPTION
:cl: Tortellini Tony
tweak: Smoke machine is now a board available in tech storage.
/:cl:

Don't know why somebody added a fully assembled one at roundstart...even /tg/ doesn't have that.

Closes #4367