### PR TITLE
Fixes a long overdue oversight in taser bolt charge cost.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2512,6 +2512,7 @@
 #include "hippiestation\code\modules\power\port_gen.dm"
 #include "hippiestation\code\modules\power\singularity\particle_accelerator\particle_control.dm"
 #include "hippiestation\code\modules\projectiles\ammunition\ammo_casings.dm"
+#include "hippiestation\code\modules\projectiles\ammunition\energy.dm"
 #include "hippiestation\code\modules\projectiles\boxes_magazines\external_mag.dm"
 #include "hippiestation\code\modules\projectiles\guns\grenade_launcher.dm"
 #include "hippiestation\code\modules\projectiles\guns\ballistic\pistols.dm"

--- a/hippiestation/code/modules/projectiles/ammunition/energy.dm
+++ b/hippiestation/code/modules/projectiles/ammunition/energy.dm
@@ -1,0 +1,5 @@
+/obj/item/ammo_casing/energy/electrode
+	e_cost = 125
+
+/obj/item/ammo_casing/energy/electrode/hos
+	e_cost = 125


### PR DESCRIPTION
:cl: GuyonBroadway
balance: ON a full charge the hybrid taser and HoS gun can now shoot 8 times, up from 5.
/:cl:

[why]: Back when I was doing the stuns rework my ethos was "about four punks on a full clip of charge if you land every shot" For whatever reason, it getting overwritten or I forgot or something, this is not the case. This fixes this oversight. 