### PR TITLE
Reduces Tourette Stun Time

### DIFF
--- a/hippiestation/code/datums/mutations.dm
+++ b/hippiestation/code/datums/mutations.dm
@@ -55,3 +55,7 @@
 	visible_message("<span class='danger'>[src]'s body glows green, the glow dissipating only to leave behind a cluwne formerly known as [src]!</span>", \
 					"<span class='danger'>Your brain feels like it's being torn apart, and after a short while, you notice that you've become a cluwne!</span>")
 	flash_act()
+
+/datum/mutation/human/tourettes/on_life(mob/living/carbon/human/owner)
+	if(prob(10) && owner.stat == CONSCIOUS)
+		owner.Stun(50)

--- a/hippiestation/code/datums/mutations.dm
+++ b/hippiestation/code/datums/mutations.dm
@@ -58,4 +58,4 @@
 
 /datum/mutation/human/tourettes/on_life(mob/living/carbon/human/owner)
 	if(prob(10) && owner.stat == CONSCIOUS)
-		owner.Stun(50)
+		owner.Stun(100)

--- a/hippiestation/code/datums/mutations.dm
+++ b/hippiestation/code/datums/mutations.dm
@@ -60,3 +60,13 @@
 	if(prob(10) && owner.stat == CONSCIOUS)
 		owner.Stun(100)
 		switch(rand(1, 3))
+			if(1)
+				owner.emote("twitch")
+			if(2 to 3)
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
+		var/x_offset_old = owner.pixel_x
+		var/y_offset_old = owner.pixel_y
+		var/x_offset = owner.pixel_x + rand(-2,2)
+		var/y_offset = owner.pixel_y + rand(-1,1)
+		animate(owner, pixel_x = x_offset, pixel_y = y_offset, time = 1)
+		animate(owner, pixel_x = x_offset_old, pixel_y = y_offset_old, time = 1)

--- a/hippiestation/code/datums/mutations.dm
+++ b/hippiestation/code/datums/mutations.dm
@@ -59,3 +59,4 @@
 /datum/mutation/human/tourettes/on_life(mob/living/carbon/human/owner)
 	if(prob(10) && owner.stat == CONSCIOUS)
 		owner.Stun(100)
+		switch(rand(1, 3))


### PR DESCRIPTION
:cl:
tweak: Tourette's stun time has been reduced from 20 seconds to 10 seconds.
/:cl:

Tourette is extremely annoying and has a relatively high chance of appearing in just 30 seconds, because each roll is made per tick. This means you can repeatedly get stunlocked for more than 2 minutes if you're unlucky, completely helpless as you automatically swear on the radio.
