### PR TITLE
Fixes arclumins grave.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,6 +2387,7 @@
 #include "hippiestation\code\game\objects\structures\false_walls.dm"
 #include "hippiestation\code\game\objects\structures\ghost_role_spawners.dm"
 #include "hippiestation\code\game\objects\structures\manned_turret.dm"
+#include "hippiestation\code\game\objects\structures\memiruak.dm"
 #include "hippiestation\code\game\objects\structures\tables_racks.dm"
 #include "hippiestation\code\game\objects\structures\tank_dispenser.dm"
 #include "hippiestation\code\game\objects\structures\watercloset.dm"

--- a/hippiestation/code/game/objects/structures/memiruak.dm
+++ b/hippiestation/code/game/objects/structures/memiruak.dm
@@ -1,0 +1,3 @@
+/obj/structure/fluff/arc
+	name = "Arclumin's Grave"
+	desc = "Rest in peace you magnificent spaceman!"


### PR DESCRIPTION
I'm not even going to put a changelog on this one, this should have been a thing from the start...

Arc was the man who helped me into ss13 coding, I basically owe all the memes I ever made to him.  He was the craziest bastard and the most magnificent spessmen. 

The sprite is OK but Arclumin was OUR DUDE! Above all else we should not be leavign space for "future dead coders" because we all hope that it never happens again. At least not in our memory, and the memorial to the dead is no place for any kind of message or politics. Its our way of remembering and thanking our dear departed arclumin, the memester who poured his soul into our  shittly little fringe game, and we were better off for it.

Rest in peace buddy, you were one of the best. 