### PR TITLE
You can no longer drop the clown shoes once you put them on your feet.

### DIFF
--- a/hippiestation/code/game/objects/items/clown_items.dm
+++ b/hippiestation/code/game/objects/items/clown_items.dm
@@ -24,3 +24,7 @@
 		log_admin("[key_name(user)] dealt brain damage to [key_name(M)] with the Extra annoying bike horn")
 
 #undef HORN_BRAIN_DAMAGE
+
+/obj/item/clothing/shoes/clown_shoes/equipped/equipped(mob/user, slot)
+	if(slot == slot_shoes)
+		flags_1 |= NODROP_1

--- a/hippiestation/code/game/objects/items/clown_items.dm
+++ b/hippiestation/code/game/objects/items/clown_items.dm
@@ -24,7 +24,3 @@
 		log_admin("[key_name(user)] dealt brain damage to [key_name(M)] with the Extra annoying bike horn")
 
 #undef HORN_BRAIN_DAMAGE
-
-/obj/item/clothing/shoes/clown_shoes/equipped/equipped(mob/user, slot)
-	if(slot == slot_shoes)
-		flags_1 |= NODROP_1

--- a/hippiestation/code/modules/clothing/shoes/miscellaneous.dm
+++ b/hippiestation/code/modules/clothing/shoes/miscellaneous.dm
@@ -1,0 +1,3 @@
+/obj/item/clothing/shoes/clown_shoes/equipped/equipped(mob/user, slot)
+	if(slot == slot_shoes)
+		flags_1 |= NODROP_1


### PR DESCRIPTION
:cl:
tweak: The clown shoes can no longer be taken off your feet.
/:cl:

Once a clown, always a clown. I dislike seeing clowns taking a metaphorical dump on the nature of clowns by taking off their shoes and taking mutadone, as the "strategy" is as of more recently. When you pick a clown, you willingly acknowledge the clown's upsides and downsides. People shouldn't pick clown only for the free slips.