### PR TITLE
Liquid nerfs

### DIFF
--- a/hippiestation/code/game/objects/effects/decals/cleanable/human.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/human.dm
@@ -1,6 +1,6 @@
 /obj/effect/decal/cleanable/blood/Initialize()
 	. = ..()
-	if(bloodiness >= 100 && prob(30))
+	if(bloodiness >= 100 && prob(30) && !istype(src, /obj/effect/decal/cleanable/blood/footprints))
 		var/datum/reagent/blood/B = new
 		B.handle_state_change(get_turf(src), 6)
 		return INITIALIZE_HINT_QDEL

--- a/hippiestation/code/game/objects/liquid.dm
+++ b/hippiestation/code/game/objects/liquid.dm
@@ -1,6 +1,6 @@
 #define LIQUID_TICKS_UNTIL_THROTTLE 50
 #define LIQUID_TICKS_UNTIL_WAKE_UP 200 //failsafe to make sure sleeping liquids aren't failing to distribute depth
-#define REAGENT_TO_DEPTH 2//one 'depth' per 2u
+#define REAGENT_TO_DEPTH 4//one 'depth' per 4u
 #define MAX_INITIAL_DEPTH 25
 #define LERP(a, b, amount) (amount ? (a + (b - a) * amount) : (a + (b - a) * 0.5))
 
@@ -275,10 +275,12 @@
 		var/mob/living/carbon/C = AM
 		if(C.movement_type & FLYING)
 			return FALSE
+
+			return FALSE
 		var/turf/T = get_turf(src)
-		if(old.elevation > T.elevation && C.mob_has_gravity())
+		if(old.elevation > T.elevation && C.mob_has_gravity() && C.m_intent != MOVE_INTENT_WALK)
 			var/elevation_difference = old.elevation - T.elevation
-			C.Knockdown(elevation_difference * 5)
+			C.Knockdown(elevation_difference * 4)
 			to_chat(C, "<span class='userdanger'>You slip off the edge of [old] and plunge straight into the liquid!</span>")
 			playsound(C, 'hippiestation/sound/effects/splash.ogg', 60, 1, 1)
 			C.emote("cough")

--- a/hippiestation/code/game/objects/structures/drain.dm
+++ b/hippiestation/code/game/objects/structures/drain.dm
@@ -20,7 +20,7 @@
 	counter++
 	for(var/obj/effect/liquid/L in view(4, src))
 		if(!L.is_static && L.viscosity)
-			var/chance = Clamp(30 / L.viscosity, 10, 100)
+			var/chance = Clamp(50 / L.viscosity, 15, 100)
 			if(get_dist(src,L) < 2)
 				qdel(L)
 			else if(prob(chance))
@@ -45,6 +45,19 @@
 				desc += " It looks permanently sealed!"
 		return
 	..()
+
+/obj/structure/drain/AltClick(mob/living/user)
+	if(isobserver(user))
+		return
+
+	if (!user.canUseTopic(src))
+		to_chat(user, "<span class='info'>You can't do this right now!</span>")
+		return
+	if(!isprocessing)
+		to_chat(user, "<span class='info'>You activate [src] via a digital switch.</span>")
+		START_PROCESSING(SSobj, src)
+	else
+		to_chat(user, "<span class='info'>[src] is already active!</span>")
 
 /obj/structure/drain/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
:cl: banthebantz
balance: Bloody footprints no longer have a chance to spawn liquid
balance: Tiles of lower elevation will no longer slip you if you walk and have a slightly shorter stun time
balance: Reagent to liquid conversion rate has been halved
balance: Drains have been buffed slightly and can now be activated manually with altclick
/:cl:
fastmerge please

