### PR TITLE
Returns the Syndicate Revolver to its former glory

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -273,6 +273,7 @@
 #include "code\datums\recipe.dm"
 #include "code\datums\riding.dm"
 #include "code\datums\ruins.dm"
+#include "code\datums\saymode.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\soullink.dm"
 #include "code\datums\spawners_menu.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -273,7 +273,6 @@
 #include "code\datums\recipe.dm"
 #include "code\datums\riding.dm"
 #include "code\datums\ruins.dm"
-#include "code\datums\saymode.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\soullink.dm"
 #include "code\datums\spawners_menu.dm"

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,5 @@
 /obj/item/projectile/bullet/magnum
 	damage = 60
-	speed = 0.8
-	armour_penetration = 10
 
 /obj/item/projectile/bullet/c38 // Detectives .38 revolver
 	knockdown = 0

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/magnum
-	damage = 45
+	damage = 60
 	speed = 0.8
-	armour_penetration = 30
+	armour_penetration = 10
 
 /obj/item/projectile/bullet/c38 // Detectives .38 revolver
 	knockdown = 0

--- a/hippiestation/code/modules/research/designs/autolathe_designs.dm
+++ b/hippiestation/code/modules/research/designs/autolathe_designs.dm
@@ -1,8 +1,3 @@
 // nah
 /datum/design/a357
-	name = "Ammo Box (.357)"
-	id = "a357"
-	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 60000)
-	build_path = /obj/item/ammo_box/a357
-	category = list("hacked", "Security")

--- a/hippiestation/code/modules/research/designs/autolathe_designs.dm
+++ b/hippiestation/code/modules/research/designs/autolathe_designs.dm
@@ -1,2 +1,8 @@
+// nah
 /datum/design/a357
-	build_type = null //rip infinite ammo
+	name = "Ammo Box (.357)"
+	id = "a357"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 60000)
+	build_path = /obj/item/ammo_box/a357
+	category = list("hacked", "Security")

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -67,7 +67,7 @@
 	cost = 1
 
 /datum/uplink_item/dangerous/revolver
-	cost = 10
+	cost = 13
 	surplus = 45
 
 /datum/uplink_item/nukeoffer/blastco
@@ -123,7 +123,7 @@
 			are dirt cheap but aren't as effective as .357 rounds."
 
 /datum/uplink_item/ammo/revolver
-	cost = 2
+	cost = 3
 
 /datum/uplink_item/dangerous/butterfly
 	name = "Energy Butterfly Knife"


### PR DESCRIPTION
:cl: KawaiiBigBoss
add: .357 ammo can now once again be made in the autolathe, but it has a higher price.
del: PopNotes
tweak: .357 ammo boxes now cost 60000 instead of 30000.
balance: The Syndicate Revolver now deals 60 damage instead of 45.
balance: The Syndicate Revolver now costs 13 TC instead of 10.
balance: The Syndicate Revolver's armor penetration has been removed.
/:cl:

PopNotes grudgecoded the Syndicate Revolver, and it somehow slipped through. Simply unacceptable.

This will return the old Syndicate Revolver while also (probably) nerfing the so-called "Roma Strat".