### PR TITLE
Syndicate Black Friday - Sales all around! (Uplink Price rebalance)

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -169,12 +169,6 @@
 /datum/uplink_item/stealthy_tools/mulligan
 	cost = 2
 
-/datum/uplink_item/device_tools/syndietome
-	cost = 5
-
-/datum/uplink_item/device_tools/binary
-	cost = 2
-
 /datum/uplink_item/device_tools/singularity_beacon
 	cost = 8
 
@@ -273,93 +267,38 @@
 	cost = 8
 
 /datum/uplink_item/device_tools/syndietome
-	name = "Syndicate Tome"
-	desc = "Using rare artifacts acquired at great cost, the syndicate has reverse engineered \
-			the seemingly magical books of a certain cult. Though lacking the esoteric abilities \
-			of the originals, these inferior copies are still quite useful, being able to provide \
-			both weal and woe on the battlefield, even if they do occasionally bite off a finger."
-	item = /obj/item/storage/book/bible/syndicate
 	cost = 2
 
 /datum/uplink_item/device_tools/binary
-	name = "Binary Translator Key"
-	desc = "A key that, when inserted into a radio headset, allows you to listen to and talk with silicon-based lifeforms, \
-			such as AI units and cyborgs, over their private binary channel. Caution should \
-			be taken while doing this, as unless they are allied with you, they are programmed to report such intrusions."
-	item = /obj/item/device/encryptionkey/binary
 	cost = 2
-	surplus = 75
 
 /datum/uplink_item/device_tools/codespeak_manual
-	name = "Codespeak Manual"
 	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which makes you look like an obvious traitor to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. One use."
-	item = /obj/item/codespeak_manual
 	cost = 0
 	limited_stock = 4
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/codespeak_manual_deluxe
-	name = "Deluxe Codespeak Manual"
 	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which makes you look like an obvious traitor to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. This is the deluxe edition, which has unlimited uses. Now you and your club can get lynched together!"
 	cost = 3
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/martialarts
-	name = "Martial Arts Scroll"
-	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
-			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
-	item = /obj/item/sleeping_carp_scroll
 	cost = 12
-	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/throwingweapons
-	name = "Box of Throwing Weapons"
-	desc = "A box of shurikens and reinforced bolas from ancient Earth martial arts. They are highly effective \
-			 throwing weapons. The bolas can knock a target down and the shurikens will embed into limbs."
-	item = /obj/item/storage/box/syndie_kit/throwing_weapons
 	cost = 2
 
 /datum/uplink_item/stealthy_weapons/dart_pistol
-	name = "Dart Pistol"
-	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
-			space a small item can."
-	item = /obj/item/gun/syringe/syndicate
 	cost = 3
-	surplus = 50
 
 /datum/uplink_item/suits/hardsuit
-	name = "Syndicate Hardsuit"
-	desc = "The feared suit of a syndicate nuclear agent. Features slightly better armoring and a built in jetpack \
-			that runs off standard atmospheric tanks. When the built in helmet is deployed your identity will be \
-			protected, even in death, as the suit cannot be removed by outside forces. Toggling the suit in and out of \
-			combat mode will allow you all the mobility of a loose fitting uniform without sacrificing armoring. \
-			Additionally the suit is collapsible, making it small enough to fit within a backpack. \
-			Nanotrasen crew who spot these suits are known to panic."
-	item = /obj/item/clothing/suit/space/hardsuit/syndi
 	cost = 7
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/surgerybag
-	name = "Syndicate Surgery Duffel Bag"
-	desc = "The Syndicate surgery duffel bag is a toolkit containing all surgery tools, surgical drapes, \
-			a Syndicate brand MMI, a straitjacket, and a muzzle."
-	item = /obj/item/storage/backpack/duffelbag/syndie/surgery
 	cost = 1
 
 /datum/uplink_item/role_restricted/ancient_jumpsuit
-	name = "Ancient Jumpsuit"
-	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."
-	item = /obj/item/clothing/under/color/grey/glorf
 	cost = 0
 	limited_stock = 4
-	restricted_roles = list("Assistant")
-	surplus = 0
 
 /datum/uplink_item/role_restricted/reverse_revolver
-	name = "Reverse Revolver"
-	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
-	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a box of hugs. Honk."
 	cost = 13
-	item = /obj/item/storage/box/hug/reverse_revolver
-	restricted_roles = list("Clown")

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -302,3 +302,6 @@
 
 /datum/uplink_item/role_restricted/reverse_revolver
 	cost = 13
+	
+/datum/uplink_item/dangerous/powerfist
+	cost = 6

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -28,14 +28,14 @@
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user for around 15 to 20 mintues."
 	exclude_modes = list(/datum/game_mode/nuclear)
 	item = /obj/item/storage/box/syndie_kit/imp_mindslave
-	cost = 8
+	cost = 6
 	surplus = 20
 
 /datum/uplink_item/implants/greatermindslave
 	name = "Greater Mindslave Implant"
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user, it does not expire like a regular mindslave implant."
 	item = /obj/item/storage/box/syndie_kit/imp_gmindslave
-	cost = 16
+	cost = 10
 
 /* Botany */
 /datum/uplink_item/role_restricted/lawnmower
@@ -45,12 +45,11 @@
 	cost = 14
 	item = /obj/vehicle/lawnmower/emagged
 
-/datum/uplink_item/role_restricted/echainsaw
+/datum/uplink_item/dangerous/echainsaw
 	name = "Energy Chainsaw"
 	desc = "An incredibly deadly modified chainsaw with plasma-based energy blades instead of metal and a slick black-and-red finish. While it rips apart matter with extreme efficiency, it is heavy, large, and monstrously loud."
-	restricted_roles = list("Botanist", "Chef", "Bartender")
 	item = /obj/item/twohanded/required/chainsaw/energy
-	cost = 16
+	cost = 14
 
 /* Glock */
 /datum/uplink_item/dangerous/g17
@@ -128,28 +127,28 @@
 /datum/uplink_item/dangerous/butterfly
 	name = "Energy Butterfly Knife"
 	desc = "A highly lethal and concealable knife that causes critical backstab damage when used with harm intent."
-	cost = 12//80 backstab damage and armour pierce isn't a fucking joke
+	cost = 8//80 backstab damage and armour pierce isn't a fucking joke
 	item = /obj/item/melee/transforming/butterfly/energy
 	surplus = 15
 
 /datum/uplink_item/dangerous/beenade
 	name = "Bee delivery grenade"
 	desc = "This grenade is filled with several random posionous bees. Fun for the whole family!"
-	cost = 4
+	cost = 2
 	item = /obj/item/grenade/spawnergrenade/beenade
 	surplus = 30
 
 /datum/uplink_item/dangerous/gremlin
 	name = "Gremlin delivery grenade"
 	desc = "This grenade is filled with several gremlins. Fun for RnD and engineering!"
-	cost = 4
+	cost = 2
 	item = /obj/item/grenade/spawnergrenade/gremlin
 	surplus = 30
 
 /datum/uplink_item/dangerous/cat
 	name = "Feral cat grenade"
 	desc = "This grenade is filled with 5 feral cats in stasis. Upon activation, the feral cats are awoken and unleashed unto unlucky bystanders."
-	cost = 5
+	cost = 3
 	item = /obj/item/grenade/spawnergrenade/cat
 	surplus = 30
 
@@ -188,14 +187,11 @@
 /datum/uplink_item/device_tools/jammer
 	cost = 3
 
-/datum/uplink_item/device_tools/codespeak_manual_deluxe
-	cost = 4
-
 /datum/uplink_item/device_tools/autosurgeon
 	name = "Autosurgeon"
 	desc = "A surgery device that instantly implants you with whatever implant has been inserted in it. Infinite uses. Use a screwdriver to remove an implant from it."
 	item = /obj/item/device/autosurgeon
-	cost = 4
+	cost = 1
 	surplus = 60
 
 /datum/uplink_item/implants/microbomb
@@ -235,7 +231,7 @@
 			 for a long time to execute a target so be sure to have them restrained and if you should be interrupted\
 			 then news of your failure will be broadcast to the station."
 	item = /obj/item/melee/execution_sword
-	cost = 3 //Its weaker than an energy dagger and cannot be concealed.
+	cost = 1 //Its weaker than an energy dagger and cannot be concealed.
 	surplus = 30 //Theres a good chance this will end up in surplus crates, so its a great way to add a little spice to any meme round.
 
 /datum/uplink_item/dangerous/guardian
@@ -274,4 +270,96 @@
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Incompatible with weaponry or the hulk mutation."
 	item = /obj/item/clothing/gloves/fingerless/rapid
-	cost = 10
+	cost = 8
+
+/datum/uplink_item/device_tools/syndietome
+	name = "Syndicate Tome"
+	desc = "Using rare artifacts acquired at great cost, the syndicate has reverse engineered \
+			the seemingly magical books of a certain cult. Though lacking the esoteric abilities \
+			of the originals, these inferior copies are still quite useful, being able to provide \
+			both weal and woe on the battlefield, even if they do occasionally bite off a finger."
+	item = /obj/item/storage/book/bible/syndicate
+	cost = 2
+
+/datum/uplink_item/device_tools/binary
+	name = "Binary Translator Key"
+	desc = "A key that, when inserted into a radio headset, allows you to listen to and talk with silicon-based lifeforms, \
+			such as AI units and cyborgs, over their private binary channel. Caution should \
+			be taken while doing this, as unless they are allied with you, they are programmed to report such intrusions."
+	item = /obj/item/device/encryptionkey/binary
+	cost = 2
+	surplus = 75
+
+/datum/uplink_item/device_tools/codespeak_manual
+	name = "Codespeak Manual"
+	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which makes you look like an obvious traitor to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. One use."
+	item = /obj/item/codespeak_manual
+	cost = 0
+	limited_stock = 4
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/device_tools/codespeak_manual_deluxe
+	name = "Deluxe Codespeak Manual"
+	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which makes you look like an obvious traitor to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. This is the deluxe edition, which has unlimited uses. Now you and your club can get lynched together!"
+	cost = 3
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_weapons/martialarts
+	name = "Martial Arts Scroll"
+	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
+			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
+	item = /obj/item/sleeping_carp_scroll
+	cost = 12
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_weapons/throwingweapons
+	name = "Box of Throwing Weapons"
+	desc = "A box of shurikens and reinforced bolas from ancient Earth martial arts. They are highly effective \
+			 throwing weapons. The bolas can knock a target down and the shurikens will embed into limbs."
+	item = /obj/item/storage/box/syndie_kit/throwing_weapons
+	cost = 2
+
+/datum/uplink_item/stealthy_weapons/dart_pistol
+	name = "Dart Pistol"
+	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
+			space a small item can."
+	item = /obj/item/gun/syringe/syndicate
+	cost = 3
+	surplus = 50
+
+/datum/uplink_item/suits/hardsuit
+	name = "Syndicate Hardsuit"
+	desc = "The feared suit of a syndicate nuclear agent. Features slightly better armoring and a built in jetpack \
+			that runs off standard atmospheric tanks. When the built in helmet is deployed your identity will be \
+			protected, even in death, as the suit cannot be removed by outside forces. Toggling the suit in and out of \
+			combat mode will allow you all the mobility of a loose fitting uniform without sacrificing armoring. \
+			Additionally the suit is collapsible, making it small enough to fit within a backpack. \
+			Nanotrasen crew who spot these suits are known to panic."
+	item = /obj/item/clothing/suit/space/hardsuit/syndi
+	cost = 7
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/device_tools/surgerybag
+	name = "Syndicate Surgery Duffel Bag"
+	desc = "The Syndicate surgery duffel bag is a toolkit containing all surgery tools, surgical drapes, \
+			a Syndicate brand MMI, a straitjacket, and a muzzle."
+	item = /obj/item/storage/backpack/duffelbag/syndie/surgery
+	cost = 1
+
+/datum/uplink_item/role_restricted/ancient_jumpsuit
+	name = "Ancient Jumpsuit"
+	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."
+	item = /obj/item/clothing/under/color/grey/glorf
+	cost = 0
+	limited_stock = 4
+	restricted_roles = list("Assistant")
+	surplus = 0
+
+/datum/uplink_item/role_restricted/reverse_revolver
+	name = "Reverse Revolver"
+	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
+	The revolver itself is actually real. Only clumsy people, and clowns, can fire it normally. Comes in a box of hugs. Honk."
+	cost = 13
+	item = /obj/item/storage/box/hug/reverse_revolver
+	restricted_roles = list("Clown")


### PR DESCRIPTION
:cl: KawaiiBigBoss
balance: Altered the price of several traitor items.
tweak: Mindslave Implant is now 6 TC (from 8)
tweak: Greater Mindslave implant is now 10 TC (from 16)
tweak: Energy Chainsaw is now 14 TC (from 16)
tweak: Removed role restrictions on the energy chainsaw.
tweak: Energy Butterfly Knife, or Balisong, is now 8 TC (from 12)
tweak: Autosurgeon is now 1 TC (from 4)
tweak: Executioner's Sword is now 1 TC (from 3)
tweak: Gloves of the North Star is now 8 TC (from 10)
tweak: Syndicate Tome is now 2 TC (from 5, 9 on /tg/ branch)
tweak: Gremlin Grenade, Beenade, and Catnade have all had their prices shaved by 2 (2, 2, and 3 TC from 4, 4, and 5 TC respectively)
tweak: Powerfist is now 6 TC (from 8)
tweak: Codespeak Manual is now 0 TC (from 2 TC) but can only be purchased 4 times because Bawb got scared
tweak: Deluxe Codespeak Manual is now 3 TC (from 4 TC)
tweak: Altered the descriptions of the Codespeak and Deluxe Codespeak manuals
tweak: Martial Arts Scroll, or Sleeping Carp Scroll, is now 12 TC (from 17)
tweak: Box of Throwing Weapons is now 2 TC (from 3)
tweak: Dart Pistol is now 3 TC (from 4)
tweak: Syndicate Hardsuit, or is now 7 TC (from 8)
tweak: Syndicate Surgery Bag is now 1 TC (from 3)
tweak: Ancient Jumpsuit is now 0 TC (from 20) but can only be purchased 4 times because Bawb got scared
tweak: Reverse Revolver is now 13 TC (from 14)
/:cl:

Changes:
Mindslave Implant, 8 to 6 TC.
Reason: Nobody ever uses these, thanks to their time limit. The best you could do is create a grey tide, but with only one person your options are limited.

Greater Mindslave Implant: 16 to 10 TC.
Reason: Even less people use these. Blood Brother is this item but for free.

Energy Chainsaw: Available for all crew. 16 to 14 TC.
Reason: Is rarely seen due to the role restrictions, and doesn't really have much of a reason to be restricted after Chainsaws became craftable.
Is more or less a slightly worse version of the pre-rebase traitor chainsaw, and there are generally better options for mass murder such as the Lawnmower that the Botanists already get, or the Double Esword. 14 TC was the original price of ye olde chainsaw any how.

Energy Butterfly: 12 to 8 TC.
Reason: Inferior esword with a good gimmick and armor piercing. Has no reason to be as expensive as an ebow.

Autosurgeon: 4 to 1 TC.
Reason: You can already do surgery on yourself, the CMO already spawns with an autosurgeon, and the Nuke Ops do too. Come on!

Execution Sword: 3 to 1 TC.
Reason: Willing to raise to 2 TC, but for now this item kinda sucks. As strong as a fire extinguisher with a slow hit rate, but an incredibly funny gimmick. Not as good as an Energy Dagger nor as easy to conceal.

Gloves of the North Star: 10 to 8 TC.
Reason: Another gimmicky item. Fun, and the RNG stunlocks are great, but lacking compared to other items.

Syndicate Tome: 9 to 2 TC.
Reason: A bible that can also deal the damage of an edagger, and without the ability to conceal, and it reveals that you're a traitor to anyone who reads it?
Garbage!

All of the summon grenades: X to 2 or 3 TC.
Reason: The Beenade, Gremlin grenade, and Cat grenade are more of a nuisance or a gimmick than anything of real use. They usually get gunned down before they kill anyone.
Feral Cat grenade is a bit more expensive at 3 TC, but the rest are at 2.

Powerfist: 8 to 6 TC.
Reason: Got hit by the /tg/ grudgecode train. Isn't nearly as good as it was before.

Binary Encryption Key: 5 to 2 TC.
Reason: You can just talk to your subverted AI over the PDA.

Codespeak Manual: 2 to 0 TC. Limited Stock: 4.
Reason: Makes you an obvious traitor. Absolutely worthless, honestly. Bawb got scared and wanted a limited stock if it was 0 TC, so here you go.

Deluxe Codespeak Manual: 4 to 3 TC.
Reason: Makes you look like an obvious traitor. Being able to have a club of obvious traitors does not change this.

Martial Arts Scroll: 17 to 12 TC.
Reason: This is probably a controversial change, but the thing has seen some use and actually kind of sucks. It's good if you can stun someone, however its odd functions weigh it down. On top of that, not being able to use ranged weaponry and being melee only is suicide against Security, even if you can block their taser shots.

Box of Throwing Weapons: 3 to 2 TC.
Reason: Shurikens are strong, but the bola can already be crafted on their own and aren't as good as something like the DRAGNet.

Dart Pistol: 4 to 3 TC.
Reason: You can get a syringe gun literally anywhere else. But due to the existence of the chemical kit, this shouldn't have its price dropped too much.

Syndicate Hardsuit: 8 to 7 TC.
Reason: Nuke Ops get this for free, and while armor is great it won't save you from stuns or cuffs. Still a very solid item.

Syndicate Surgery Bag: 3 to 1 TC.
Reason: Due to the Autosurgeon nerf, this is pretty much necessary. On top of that it gives you a bunch of items you can already easily get on your own.

Ancient Jumpsuit: 20 to 0 TC. Limited Stock: 4.
Reason: Joke item, it's just a grey jumpsuit.

Reverse Revolver: 14 to 13 TC.
Reason: Joke item, easy to spot and can't be used if the Clown relinquishes his dignity and takes mutadone. Besides that, it's the only gun the Clown can reliably fire outside of the pie cannon.

"Why are you lowering all the costs of these items? SS13 is a game, you're not supposed to win."
I'm not lowering the price of things like the esword for a reason. Too many gimmicks right now are simply too expensive, and rely on the players you fight against to be bad in order to really succeed. Doing this will allow more people to do their gimmicks easier with more traitor items.
Also, a lot of these items simply suck. They have no reason to be as expensive as they are.

Willing to alter the prices of other items or raise/lower some others.