### PR TITLE
Slime scanner changes

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -498,38 +498,3 @@ MASS SPECTROMETER
 	if (T.cores > 1)
 		to_chat(user, "Anomalious slime core amount detected")
 	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")
-	
-/obj/item/device/slime_scanner/afterattack(atom/target, mob/living/user, flag, params)
-	if(flag)
-		return
-if(user.stat || user.eye_blind)
-		return
-	if (!isslime(M))
-		to_chat(user, "<span class='warning'>This device can only scan slimes!</span>")
-		return
-	var/mob/living/simple_animal/slime/T = M
-	to_chat(user, "Slime scan results:")
-	to_chat(user, "[T.colour] [T.is_adult ? "adult" : "baby"] slime")
-	to_chat(user, "Nutrition: [T.nutrition]/[T.get_max_nutrition()]")
-	if (T.nutrition < T.get_starve_nutrition())
-		to_chat(user, "<span class='warning'>Warning: slime is starving!</span>")
-	else if (T.nutrition < T.get_hunger_nutrition())
-		to_chat(user, "<span class='warning'>Warning: slime is hungry</span>")
-	to_chat(user, "Electric change strength: [T.powerlevel]")
-	to_chat(user, "Health: [round(T.health/T.maxHealth,0.01)*100]")
-	if (T.slime_mutation[4] == T.colour)
-		to_chat(user, "This slime does not evolve any further.")
-	else
-		if (T.slime_mutation[3] == T.slime_mutation[4])
-			if (T.slime_mutation[2] == T.slime_mutation[1])
-				to_chat(user, "Possible mutation: [T.slime_mutation[3]]")
-				to_chat(user, "Genetic destability: [T.mutation_chance/2] % chance of mutation on splitting")
-			else
-				to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)")
-				to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
-		else
-			to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]")
-			to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
-	if (T.cores > 1)
-		to_chat(user, "Anomalious slime core amount detected")
-	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -498,3 +498,38 @@ MASS SPECTROMETER
 	if (T.cores > 1)
 		to_chat(user, "Anomalious slime core amount detected")
 	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")
+	
+/obj/item/device/slime_scanner/afterattack(atom/target, mob/living/user, flag, params)
+	if(flag)
+		return
+if(user.stat || user.eye_blind)
+		return
+	if (!isslime(M))
+		to_chat(user, "<span class='warning'>This device can only scan slimes!</span>")
+		return
+	var/mob/living/simple_animal/slime/T = M
+	to_chat(user, "Slime scan results:")
+	to_chat(user, "[T.colour] [T.is_adult ? "adult" : "baby"] slime")
+	to_chat(user, "Nutrition: [T.nutrition]/[T.get_max_nutrition()]")
+	if (T.nutrition < T.get_starve_nutrition())
+		to_chat(user, "<span class='warning'>Warning: slime is starving!</span>")
+	else if (T.nutrition < T.get_hunger_nutrition())
+		to_chat(user, "<span class='warning'>Warning: slime is hungry</span>")
+	to_chat(user, "Electric change strength: [T.powerlevel]")
+	to_chat(user, "Health: [round(T.health/T.maxHealth,0.01)*100]")
+	if (T.slime_mutation[4] == T.colour)
+		to_chat(user, "This slime does not evolve any further.")
+	else
+		if (T.slime_mutation[3] == T.slime_mutation[4])
+			if (T.slime_mutation[2] == T.slime_mutation[1])
+				to_chat(user, "Possible mutation: [T.slime_mutation[3]]")
+				to_chat(user, "Genetic destability: [T.mutation_chance/2] % chance of mutation on splitting")
+			else
+				to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)")
+				to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
+		else
+			to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]")
+			to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
+	if (T.cores > 1)
+		to_chat(user, "Anomalious slime core amount detected")
+	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,6 +2387,7 @@
 #include "hippiestation\code\modules\admin\verbs\testdummy.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
+#include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\preferences.dm"
 #include "hippiestation\code\modules\client\preferences_savefile.dm"
 #include "hippiestation\code\modules\client\loadout\glasses.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,7 +2387,6 @@
 #include "hippiestation\code\modules\admin\verbs\testdummy.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
-#include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\preferences.dm"
 #include "hippiestation\code\modules\client\preferences_savefile.dm"
 #include "hippiestation\code\modules\client\loadout\glasses.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2348,6 +2348,7 @@
 #include "hippiestation\code\game\objects\items\devices\meeseeks_box.dm"
 #include "hippiestation\code\game\objects\items\devices\multitool.dm"
 #include "hippiestation\code\game\objects\items\devices\powersink.dm"
+#include "hippiestation\code\game\objects\items\devices\scanners.dm"
 #include "hippiestation\code\game\objects\items\grenades\chem_grenade.dm"
 #include "hippiestation\code\game\objects\items\grenades\clusterbuster.dm"
 #include "hippiestation\code\game\objects\items\grenades\spawnergrenade.dm"

--- a/hippiestation/code/game/objects/items/devices/scanners.dm
+++ b/hippiestation/code/game/objects/items/devices/scanners.dm
@@ -1,0 +1,34 @@
+/obj/item/device/slime_scanner/afterattack(atom/target, mob/living/user, flag, params)
+	if(flag)
+		return
+if(user.stat || user.eye_blind)
+		return
+	if (!isslime(M))
+		to_chat(user, "<span class='warning'>This device can only scan slimes!</span>")
+		return
+	var/mob/living/simple_animal/slime/T = M
+	to_chat(user, "Slime scan results:")
+	to_chat(user, "[T.colour] [T.is_adult ? "adult" : "baby"] slime")
+	to_chat(user, "Nutrition: [T.nutrition]/[T.get_max_nutrition()]")
+	if (T.nutrition < T.get_starve_nutrition())
+		to_chat(user, "<span class='warning'>Warning: slime is starving!</span>")
+	else if (T.nutrition < T.get_hunger_nutrition())
+		to_chat(user, "<span class='warning'>Warning: slime is hungry</span>")
+	to_chat(user, "Electric change strength: [T.powerlevel]")
+	to_chat(user, "Health: [round(T.health/T.maxHealth,0.01)*100]")
+	if (T.slime_mutation[4] == T.colour)
+		to_chat(user, "This slime does not evolve any further.")
+	else
+		if (T.slime_mutation[3] == T.slime_mutation[4])
+			if (T.slime_mutation[2] == T.slime_mutation[1])
+				to_chat(user, "Possible mutation: [T.slime_mutation[3]]")
+				to_chat(user, "Genetic destability: [T.mutation_chance/2] % chance of mutation on splitting")
+			else
+				to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)")
+				to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
+		else
+			to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]")
+			to_chat(user, "Genetic destability: [T.mutation_chance] % chance of mutation on splitting")
+	if (T.cores > 1)
+		to_chat(user, "Anomalious slime core amount detected")
+	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")

--- a/hippiestation/code/game/objects/items/devices/scanners.dm
+++ b/hippiestation/code/game/objects/items/devices/scanners.dm
@@ -1,7 +1,7 @@
 /obj/item/device/slime_scanner/afterattack(atom/target, mob/living/user, flag, params)
 	if(flag)
 		return
-if(user.stat || user.eye_blind)
+	if(user.stat || user.eye_blind)
 		return
 	if (!isslime(M))
 		to_chat(user, "<span class='warning'>This device can only scan slimes!</span>")

--- a/hippiestation/code/game/objects/items/devices/scanners.dm
+++ b/hippiestation/code/game/objects/items/devices/scanners.dm
@@ -3,10 +3,10 @@
 		return
 	if(user.stat || user.eye_blind)
 		return
-	if (!isslime(M))
+	if (!isslime(target))
 		to_chat(user, "<span class='warning'>This device can only scan slimes!</span>")
 		return
-	var/mob/living/simple_animal/slime/T = M
+	var/mob/living/simple_animal/slime/T = target
 	to_chat(user, "Slime scan results:")
 	to_chat(user, "[T.colour] [T.is_adult ? "adult" : "baby"] slime")
 	to_chat(user, "Nutrition: [T.nutrition]/[T.get_max_nutrition()]")


### PR DESCRIPTION
[Changelogs]: # Slime scanners can be used from inside the console

:cl: Slime scanner upgrade
tweak: slime scanners can now be used at range and through cameras, enbling it to be used from the slime management console
/:cl:

[why]: # slime scanners are almost not used, except when rushing rainbow slimes, because of the need to be right next to the slime to use it, since it takes a bit too much time and click, and this pr removes that inconvinience
