### PR TITLE
Fixed invisible cutters

### DIFF
--- a/hippiestation/code/game/objects/items/storage/tools.dm
+++ b/hippiestation/code/game/objects/items/storage/tools.dm
@@ -11,6 +11,7 @@
 	icon = 'hippiestation/icons/obj/tools.dmi'
 	icon_state = "cutters_nuke"
 	toolspeed = 0.5
+	random_color = FALSE
 
 /obj/item/weldingtool/syndicate
 	name = "Precision welding tool"


### PR DESCRIPTION
[Changelogs]: Was just as simple as setting `random_color` to false to stop `New()` from changing the icon to something else. Fixes #4187 

:cl: JohnGinnane
fix: Fixed the syndicate wire cutters being invisible
/:cl:

![image](https://user-images.githubusercontent.com/3355198/33803580-6cd39172-dd8b-11e7-9d06-e2cd177a2090.png)
