### PR TITLE
Hardsuit hazard warning messages (Fixes autism)

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2530,6 +2530,7 @@
 #include "hippiestation\code\modules\clothing\head\helmet.dm"
 #include "hippiestation\code\modules\clothing\masks\hailer.dm"
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
+#include "hippiestation\code\modules\clothing\spacesuits\hardsuit.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"
 #include "hippiestation\code\modules\crafts\shield.dm"
 #include "hippiestation\code\modules\crafts\vest.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2530,7 +2530,6 @@
 #include "hippiestation\code\modules\clothing\head\helmet.dm"
 #include "hippiestation\code\modules\clothing\masks\hailer.dm"
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
-#include "hippiestation\code\modules\clothing\spacesuits\hardsuit.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"
 #include "hippiestation\code\modules\crafts\shield.dm"
 #include "hippiestation\code\modules\crafts\vest.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2532,6 +2532,7 @@
 #include "hippiestation\code\modules\clothing\head\helmet.dm"
 #include "hippiestation\code\modules\clothing\masks\hailer.dm"
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
+#include "hippiestation\code\modules\clothing\spacesuits\hardsuit.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"
 #include "hippiestation\code\modules\crafts\shield.dm"
 #include "hippiestation\code\modules\crafts\vest.dm"

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1,7 +1,6 @@
 
 	//Baseline hardsuits
 /obj/item/clothing/head/helmet/space/hardsuit
-	..()
 	var/next_warn_rad = 0
 	var/warn_rad_cooldown = 120
 
@@ -15,7 +14,6 @@
 	.=..()
 
 /obj/item/clothing/suit/space/hardsuit
-	..()
 	var/next_warn_acid = 0
 	var/warn_acid_cooldown = 100
 

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -8,7 +8,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
 	if (prob(33))
-		if ( next_warn_rad > world.time  )
+		if (next_warn_rad > world.time )
 			return
 		next_warn_rad = world.time + warn_rad_cooldown
 		display_visor_message("Radiation present, seek distance from source!")
@@ -22,9 +22,10 @@
 
 /obj/item/clothing/suit/space/hardsuit/acid_act()
 	if (prob(33))
-		if(next_warn_acid > world.time)
-			return
-		next_warn_acid = world.time + warn_acid_cooldown
-		helmet.display_visor_message("Corrosive Chemical Detected!")
+		if(helmet)
+			if(next_warn_acid > world.time)
+				return
+			next_warn_acid = world.time + warn_acid_cooldown
+			helmet.display_visor_message("Corrosive Chemical Detected!")
 	.=..()
 

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1,0 +1,33 @@
+
+	//Baseline hardsuits
+/obj/item/clothing/head/helmet/space/hardsuit
+	..()
+	var/next_warn_rad = 0
+	var/warn_rad_cooldown = 120
+
+/obj/item/clothing/suit/space/hardsuit/proc/display_suit_message(var/msg)
+	var/mob/wearer = loc
+	if(msg && ishuman(wearer))
+		wearer.show_message("<b><span class='robot'>[msg]</span></b>", 1)
+
+/obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
+	..()
+	if (prob(33))
+		if ( next_warn_rad > world.time  )
+			return
+		next_warn_rad = world.time + warn_rad_cooldown
+		display_visor_message("Radiation present, seek distance from source!")
+
+/obj/item/clothing/suit/space/hardsuit
+	..()
+	var/next_warn_acid = 0
+	var/warn_acid_cooldown = 100
+
+/obj/item/clothing/suit/space/hardsuit/acid_act()
+	..()
+	if (prob(33))
+		if(next_warn_acid > world.time)
+			return
+		next_warn_acid = world.time + warn_acid_cooldown
+		helmet.display_visor_message("Corrosive Chemical Detected!")
+

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -5,29 +5,26 @@
 	var/next_warn_rad = 0
 	var/warn_rad_cooldown = 120
 
-/obj/item/clothing/suit/space/hardsuit/proc/display_suit_message(var/msg)
-	var/mob/wearer = loc
-	if(msg && ishuman(wearer))
-		wearer.show_message("<b><span class='robot'>[msg]</span></b>", 1)
 
 /obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
-	..()
 	if (prob(33))
 		if ( next_warn_rad > world.time  )
 			return
 		next_warn_rad = world.time + warn_rad_cooldown
 		display_visor_message("Radiation present, seek distance from source!")
+	.=..()
 
 /obj/item/clothing/suit/space/hardsuit
 	..()
 	var/next_warn_acid = 0
 	var/warn_acid_cooldown = 100
 
+
 /obj/item/clothing/suit/space/hardsuit/acid_act()
-	..()
 	if (prob(33))
 		if(next_warn_acid > world.time)
 			return
 		next_warn_acid = world.time + warn_acid_cooldown
 		helmet.display_visor_message("Corrosive Chemical Detected!")
+	.=..()
 

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1,29 +1,26 @@
-
-	//Baseline hardsuits
 /obj/item/clothing/head/helmet/space/hardsuit
 	var/next_warn_rad = 0
 	var/warn_rad_cooldown = 120
-
-
-/obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
-	if (prob(33))
-		if (next_warn_rad > world.time )
-			return
-		next_warn_rad = world.time + warn_rad_cooldown
-		display_visor_message("Radiation present, seek distance from source!")
-	.=..()
 
 /obj/item/clothing/suit/space/hardsuit
 	var/next_warn_acid = 0
 	var/warn_acid_cooldown = 100
 
+/obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
+	..()
+
+	if (prob(33))
+		if (next_warn_rad > world.time)
+			return
+		next_warn_rad = world.time + warn_rad_cooldown
+		display_visor_message("Radiation present, seek distance from source!")
 
 /obj/item/clothing/suit/space/hardsuit/acid_act()
+	..()
+
 	if (prob(33))
 		if(helmet)
 			if(next_warn_acid > world.time)
 				return
 			next_warn_acid = world.time + warn_acid_cooldown
 			helmet.display_visor_message("Corrosive Chemical Detected!")
-	.=..()
-


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: Visual warning messages from radiation proximity and acid attacks to all hardsuits.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)


It's intended to help new players or players with audio issues be slightly more aware of hazards around them. I'm looking at adding more things in the future.

I fucked up my last pull request so I'm reopening this on a proper dedicated branch.