### PR TITLE
Nerfs the clown horn

### DIFF
--- a/hippiestation/code/game/objects/items/clown_items.dm
+++ b/hippiestation/code/game/objects/items/clown_items.dm
@@ -1,4 +1,4 @@
-#define HORN_BRAIN_DAMAGE 10
+#define HORN_BRAIN_DAMAGE 5
 
 /obj/item/bikehorn/golden/retardhorn/attack()
 	flip_mobs()
@@ -17,7 +17,7 @@
 			var/mob/living/carbon/human/H = M
 			if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
 				continue
-		M.adjustBrainLoss(HORN_BRAIN_DAMAGE)
+		M.adjustBrainLoss(HORN_BRAIN_DAMAGE, 75)
 		log_admin("[key_name(user)] dealt brain damage to [key_name(M)] with the Extra annoying bike horn")
 
 #undef HORN_BRAIN_DAMAGE


### PR DESCRIPTION
- The maximum amount of brain damage the horn can give has been limited to 75
- The amount of brain damage per honk has been reduced to 5 from 10