### PR TITLE
make slimes eat a little faster

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -248,10 +248,10 @@
 			return
 		attacked += 5
 		if(nutrition >= 100) //steal some nutrition. negval handled in life()
-			nutrition -= (50 + (40 * M.is_adult))
-			M.add_nutrition(50 + (40 * M.is_adult))
+			nutrition -= (100 + (80 * M.is_adult))
+			M.add_nutrition(100 + (80 * M.is_adult))
 		if(health > 0)
-			M.adjustBruteLoss(-10 + (-10 * M.is_adult))
+			M.adjustBruteLoss(-20 + (-20 * M.is_adult))
 			M.updatehealth()
 
 /mob/living/simple_animal/slime/attack_animal(mob/living/simple_animal/M)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -248,10 +248,10 @@
 			return
 		attacked += 5
 		if(nutrition >= 100) //steal some nutrition. negval handled in life()
-			nutrition -= (100 + (80 * M.is_adult))
-			M.add_nutrition(100 + (80 * M.is_adult))
+			nutrition -= (100 + (80 * M.is_adult)) // hippie start - changed from nutrition -= (50 + (40 * M.is_adult))
+			M.add_nutrition(100 + (80 * M.is_adult)) // changed from M.add_nutrition(50 + (40 * M.is_adult))
 		if(health > 0)
-			M.adjustBruteLoss(-20 + (-20 * M.is_adult))
+			M.adjustBruteLoss(-20 + (-20 * M.is_adult)) // Hippie end M.adjustBruteLoss(-10 + (-10 * M.is_adult))
 			M.updatehealth()
 
 /mob/living/simple_animal/slime/attack_animal(mob/living/simple_animal/M)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -248,10 +248,10 @@
 			return
 		attacked += 5
 		if(nutrition >= 100) //steal some nutrition. negval handled in life()
-			nutrition -= (100 + (80 * M.is_adult)) // hippie start - changed from nutrition -= (50 + (40 * M.is_adult))
-			M.add_nutrition(100 + (80 * M.is_adult)) // changed from M.add_nutrition(50 + (40 * M.is_adult))
+			nutrition -= (100 + (80 * M.is_adult)) // hippie - changed from `nutrition -= (50 + (40 * M.is_adult))`
+			M.add_nutrition(100 + (80 * M.is_adult)) // hippie - changed from `M.add_nutrition(50 + (40 * M.is_adult))`
 		if(health > 0)
-			M.adjustBruteLoss(-20 + (-20 * M.is_adult)) // Hippie end M.adjustBruteLoss(-10 + (-10 * M.is_adult))
+			M.adjustBruteLoss(-20 + (-20 * M.is_adult)) // Hippie - changed from `M.adjustBruteLoss(-10 + (-10 * M.is_adult))`
 			M.updatehealth()
 
 /mob/living/simple_animal/slime/attack_animal(mob/living/simple_animal/M)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,6 +2387,7 @@
 #include "hippiestation\code\modules\admin\verbs\testdummy.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
+#include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\preferences.dm"
 #include "hippiestation\code\modules\client\preferences_savefile.dm"
 #include "hippiestation\code\modules\client\loadout\glasses.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2387,7 +2387,6 @@
 #include "hippiestation\code\modules\admin\verbs\testdummy.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
-#include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\preferences.dm"
 #include "hippiestation\code\modules\client\preferences_savefile.dm"
 #include "hippiestation\code\modules\client\loadout\glasses.dm"


### PR DESCRIPTION
[Changelogs]: # slime will now eat faster

:cl: xTrainx
tweak: slime will now eat faster, and get more nutrition
/:cl:

[why]: # got some request from user to make xenobio a bit more viable since round here tends to laST 30 minutes, so slime will now eat faster, reducing downtime when farming slimes