### PR TITLE
Dental Implant Activates in Softcrit

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -2,6 +2,7 @@
 #define AB_CHECK_STUN 2
 #define AB_CHECK_LYING 4
 #define AB_CHECK_CONSCIOUS 8
+#define AB_CHECK_SOFTCRIT 16
 
 /datum/action
 	var/name = "Generic Action"
@@ -102,6 +103,9 @@
 	if(check_flags & AB_CHECK_CONSCIOUS)
 		if(owner.stat)
 			return 0
+	if(check_flags & AB_CHECK_SOFTCRIT) 	//Added by
+		if(owner.stat != SOFT_CRIT && owner.stat) // YoYoBatty
+			return 0
 	return 1
 
 /datum/action/proc/UpdateButtonIcon(status_only = FALSE)
@@ -138,7 +142,7 @@
 
 //Presets for item actions
 /datum/action/item_action
-	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_LYING|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_LYING|AB_CHECK_CONSCIOUS|AB_CHECK_SOFTCRIT //Adds softcrit check - YoYoBatty
 	button_icon_state = null
 	// If you want to override the normal icon being the item
 	// then change this to an icon state

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -29,7 +29,7 @@
 	name = "Activate Pill"
 
 /datum/action/item_action/hands_free/activate_pill/Trigger()
-	if(!..())
+	if(owner.stat != CONSCIOUS && owner.stat != SOFT_CRIT )
 		return 0
 	to_chat(owner, "<span class='caution'>You grit your teeth and burst the implanted [target.name]!</span>")
 	add_logs(owner, null, "swallowed an implanted pill", target)

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -26,10 +26,11 @@
 	return 1
 
 /datum/action/item_action/hands_free/activate_pill
+	check_flags = AB_CHECK_SOFTCRIT //Allows us to trigger implant in soft crit - YoYoBatty
 	name = "Activate Pill"
 
 /datum/action/item_action/hands_free/activate_pill/Trigger()
-	if(owner.stat != CONSCIOUS && owner.stat != SOFT_CRIT )
+	if(!..())
 		return 0
 	to_chat(owner, "<span class='caution'>You grit your teeth and burst the implanted [target.name]!</span>")
 	add_logs(owner, null, "swallowed an implanted pill", target)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: The ability to use dental implants in soft crit (-30 hp and above)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I think it's ridiculously silly that you can crawl, whisper and superfart while in softcrit but can't simply bite down to activate something in your mouth. Hopefully you guys will like this.