### PR TITLE
Adds back Fart and scream hotkeys.

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2589,6 +2589,7 @@
 #include "hippiestation\code\modules\jobs\job_types\engineering.dm"
 #include "hippiestation\code\modules\jobs\job_types\medical.dm"
 #include "hippiestation\code\modules\jobs\job_types\science.dm"
+#include "hippiestation\code\modules\keybindings\bindings_hippie.dm"
 #include "hippiestation\code\modules\library\lib_machines.dm"
 #include "hippiestation\code\modules\lighting\lighting_turf.dm"
 #include "hippiestation\code\modules\mentor\follow.dm"

--- a/hippiestation/code/modules/keybindings/bindings_hippie.dm
+++ b/hippiestation/code/modules/keybindings/bindings_hippie.dm
@@ -1,0 +1,10 @@
+/mob/key_down(_key, client/user)
+	if(client.keys_held["Shift"])
+		switch(_key)
+			if("F")
+				emote("fart")
+				return
+			if("S")
+				emote("scream")
+				return
+	return ..()


### PR DESCRIPTION
:cl: GuyonBroadway
fix: Fart and Scream hotkeys have been added back under the new system, due to new fuctionality under this system scream and fart are shift+s and shift+f
/:cl:

