### PR TITLE
Reverts cloaks to pre rebase

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2567,6 +2567,7 @@
 #include "hippiestation\code\modules\clothing\masks\hailer.dm"
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
 #include "hippiestation\code\modules\clothing\spacesuits\hardsuit.dm"
+#include "hippiestation\code\modules\clothing\suits\cloaks.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"
 #include "hippiestation\code\modules\crafts\shield.dm"
 #include "hippiestation\code\modules\crafts\vest.dm"

--- a/hippiestation/code/modules/clothing/suits/cloaks.dm
+++ b/hippiestation/code/modules/clothing/suits/cloaks.dm
@@ -1,76 +1,41 @@
 /obj/item/clothing/neck/cloak/hos
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/qm
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/cmo
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/ce
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/rd
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/cap
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300
 
 /obj/item/clothing/neck/cloak/hop
-	parent_type = /obj/item/storage
+	parent_type = /obj/item/storage/backpack
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
-	resistance_flags = NONE
-	max_integrity = 300

--- a/hippiestation/code/modules/clothing/suits/cloaks.dm
+++ b/hippiestation/code/modules/clothing/suits/cloaks.dm
@@ -1,41 +1,4 @@
-/obj/item/clothing/neck/cloak/hos
+/obj/item/clothing/neck/cloak
 	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/qm
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/cmo
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/ce
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/rd
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/cap
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = SLOT_BACK
-
-/obj/item/clothing/neck/cloak/hop
-	parent_type = /obj/item/storage/backpack
-	icon = 'icons/obj/clothing/cloaks.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK

--- a/hippiestation/code/modules/clothing/suits/cloaks.dm
+++ b/hippiestation/code/modules/clothing/suits/cloaks.dm
@@ -1,0 +1,76 @@
+/obj/item/clothing/neck/cloak/hos
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/qm
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/cmo
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/ce
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/rd
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/cap
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300
+
+/obj/item/clothing/neck/cloak/hop
+	parent_type = /obj/item/storage
+	icon = 'icons/obj/clothing/cloaks.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_BACK
+	max_w_class = WEIGHT_CLASS_NORMAL
+	max_combined_w_class = 21
+	storage_slots = 21
+	resistance_flags = NONE
+	max_integrity = 300


### PR DESCRIPTION

:cl: 
tweak: Cloaks are now backpacks again and can hold stuff, as before the rebase
/:cl:

[why]: I was asked to make this PR. I have used a hacky way to avoid having to repath the map and several files: i have changed parent_type to /obj/item/storage and copied some variables owned by the backpacks, so now they act just like resprited backpacks: they go on the back(not on the neck anymore), and can hold items just like a backpack. I have tested this simply by adding items and removing, and wearing it,no runtimes and it works correctly...don't ask me how though.
