### PR TITLE
Added all materials + plasma canisters to cargo.

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -116,6 +116,9 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	recipes = GLOB.diamond_recipes
 	. = ..()
 
+/obj/item/stack/sheet/mineral/diamond/twenty
+	amount = 20
+
 /*
  * Uranium
  */
@@ -138,6 +141,9 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.uranium_recipes
 	. = ..()
+
+/obj/item/stack/sheet/mineral/uranium/twenty
+	amount = 20
 
 /*
  * Plasma
@@ -175,6 +181,9 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
 
+/obj/item/stack/sheet/mineral/plasma/twenty
+	amount = 20
+
 /*
  * Gold
  */
@@ -201,6 +210,9 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	recipes = GLOB.gold_recipes
 	. = ..()
 
+/obj/item/stack/sheet/mineral/gold/twenty
+	amount = 20
+
 /*
  * Silver
  */
@@ -226,6 +238,9 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	recipes = GLOB.silver_recipes
 	. = ..()
 
+/obj/item/stack/sheet/mineral/silver/twenty
+	amount = 20
+
 /*
  * Clown
  */
@@ -246,6 +261,10 @@ GLOBAL_LIST_INIT(clown_recipes, list ( \
 /obj/item/stack/sheet/mineral/bananium/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.clown_recipes
 	. = ..()
+
+/obj/item/stack/sheet/mineral/bananium/twenty
+	amount = 20
+
 
 /*
  * Titanium
@@ -273,6 +292,8 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
 
+/obj/item/stack/sheet/mineral/titanium/twenty
+	amount = 20
 
 /*
  * Plastitanium

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -116,9 +116,6 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	recipes = GLOB.diamond_recipes
 	. = ..()
 
-/obj/item/stack/sheet/mineral/diamond/twenty
-	amount = 20
-
 /*
  * Uranium
  */
@@ -141,9 +138,6 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.uranium_recipes
 	. = ..()
-
-/obj/item/stack/sheet/mineral/uranium/twenty
-	amount = 20
 
 /*
  * Plasma
@@ -181,9 +175,6 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
 
-/obj/item/stack/sheet/mineral/plasma/twenty
-	amount = 20
-
 /*
  * Gold
  */
@@ -210,9 +201,6 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	recipes = GLOB.gold_recipes
 	. = ..()
 
-/obj/item/stack/sheet/mineral/gold/twenty
-	amount = 20
-
 /*
  * Silver
  */
@@ -238,9 +226,6 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	recipes = GLOB.silver_recipes
 	. = ..()
 
-/obj/item/stack/sheet/mineral/silver/twenty
-	amount = 20
-
 /*
  * Clown
  */
@@ -261,10 +246,6 @@ GLOBAL_LIST_INIT(clown_recipes, list ( \
 /obj/item/stack/sheet/mineral/bananium/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.clown_recipes
 	. = ..()
-
-/obj/item/stack/sheet/mineral/bananium/twenty
-	amount = 20
-
 
 /*
  * Titanium
@@ -292,8 +273,6 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/titanium/twenty
-	amount = 20
 
 /*
  * Plastitanium

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -497,7 +497,7 @@
 	name = "Plasma Canister"
 	cost = 6000
 	access = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/plasma)
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
 	crate_name = "plasma canister crate"
 	crate_type = /obj/structure/closet/crate/secure
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -493,6 +493,14 @@
 	crate_name = "oxygen canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/science/plasma_canister
+	name = "Plasma Canister"
+	cost = 6000
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/machinery/portable_atmospherics/canister/plasma)
+	crate_name = "plasma canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+
 /datum/supply_pack/engineering/nitrogen
 	name = "Nitrogen Canister"
 	cost = 2000
@@ -1283,6 +1291,48 @@
 	cost = 1000
 	contains = list(/obj/item/stack/sheet/mineral/sandstone/thirty)
 	crate_name = "sandstone blocks crate"
+
+/datum/supply_pack/materials/diamond20
+	name = "20 Diamonds"
+	cost = 50000
+	contains = list(/obj/item/stack/sheet/mineral/diamond/twenty)
+	crate_name = "diamonds crate"
+
+/datum/supply_pack/materials/plasma20
+	name = "20 Plasma Sheets"
+	cost = 6000
+	contains = list(/obj/item/stack/sheet/mineral/plasma/twenty)
+	crate_name = "plasma sheets crate"
+	
+/datum/supply_pack/materials/bananium20
+	name = "20 Bananium Sheets"
+	cost = 100000
+	contains = list(/obj/item/stack/sheet/mineral/bananium/twenty)
+	crate_name = "bananium sheets crate"
+	
+/datum/supply_pack/materials/titanium20
+	name = "20 Titanium Sheets"
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/mineral/titanium/twenty)
+	crate_name = "titanium sheets crate"
+	
+/datum/supply_pack/materials/silver20
+	name = "20 Silver Sheets"
+	cost = 2000
+	contains = list(/obj/item/stack/sheet/mineral/silver/twenty)
+	crate_name = "silver sheets crate"
+	
+/datum/supply_pack/materials/gold20
+	name = "20 Gold Sheets"
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	crate_name = "gold sheets crate"
+
+/datum/supply_pack/materials/uranium20
+	name = "20 Uranium Sheets"
+	cost = 8000
+	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	crate_name = "uranium sheets crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1828,3 +1828,4 @@
 	contains = list(/obj/vehicle/bicycle)
 	crate_name = "Bicycle Crate"
 	crate_type = /obj/structure/closet/crate/large
+	

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -493,14 +493,6 @@
 	crate_name = "oxygen canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/science/plasma_canister
-	name = "Plasma Canister"
-	cost = 6000
-	access = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
-	crate_name = "plasma canister crate"
-	crate_type = /obj/structure/closet/crate/secure
-
 /datum/supply_pack/engineering/nitrogen
 	name = "Nitrogen Canister"
 	cost = 2000
@@ -1291,48 +1283,6 @@
 	cost = 1000
 	contains = list(/obj/item/stack/sheet/mineral/sandstone/thirty)
 	crate_name = "sandstone blocks crate"
-
-/datum/supply_pack/materials/diamond20
-	name = "20 Diamonds"
-	cost = 50000
-	contains = list(/obj/item/stack/sheet/mineral/diamond/twenty)
-	crate_name = "diamonds crate"
-
-/datum/supply_pack/materials/plasma20
-	name = "20 Plasma Sheets"
-	cost = 6000
-	contains = list(/obj/item/stack/sheet/mineral/plasma/twenty)
-	crate_name = "plasma sheets crate"
-	
-/datum/supply_pack/materials/bananium20
-	name = "20 Bananium Sheets"
-	cost = 100000
-	contains = list(/obj/item/stack/sheet/mineral/bananium/twenty)
-	crate_name = "bananium sheets crate"
-	
-/datum/supply_pack/materials/titanium20
-	name = "20 Titanium Sheets"
-	cost = 5000
-	contains = list(/obj/item/stack/sheet/mineral/titanium/twenty)
-	crate_name = "titanium sheets crate"
-	
-/datum/supply_pack/materials/silver20
-	name = "20 Silver Sheets"
-	cost = 2000
-	contains = list(/obj/item/stack/sheet/mineral/silver/twenty)
-	crate_name = "silver sheets crate"
-	
-/datum/supply_pack/materials/gold20
-	name = "20 Gold Sheets"
-	cost = 5000
-	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
-	crate_name = "gold sheets crate"
-
-/datum/supply_pack/materials/uranium20
-	name = "20 Uranium Sheets"
-	cost = 8000
-	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
-	crate_name = "uranium sheets crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1778,4 +1778,3 @@
 	contains = list(/obj/vehicle/bicycle)
 	crate_name = "Bicycle Crate"
 	crate_type = /obj/structure/closet/crate/large
-	

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2516,6 +2516,7 @@
 #include "hippiestation\code\game\objects\items\implants\implanter.dm"
 #include "hippiestation\code\game\objects\items\stacks\medical.dm"
 #include "hippiestation\code\game\objects\items\stacks\stack.dm"
+#include "hippiestation\code\game\objects\items\stacks\sheets\mineral.dm"
 #include "hippiestation\code\game\objects\items\stacks\sheets\sheet_types.dm"
 #include "hippiestation\code\game\objects\items\stacks\tiles\tile_mineral.dm"
 #include "hippiestation\code\game\objects\items\storage\backpack.dm"

--- a/hippiestation/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/hippiestation/code/game/objects/items/stacks/sheets/mineral.dm
@@ -1,0 +1,20 @@
+/obj/item/stack/sheet/mineral/diamond/twenty
+	amount = 20  
+  
+/obj/item/stack/sheet/mineral/uranium/twenty
+	amount = 20
+  
+/obj/item/stack/sheet/mineral/plasma/twenty
+	amount = 20
+  
+/obj/item/stack/sheet/mineral/gold/twenty
+	amount = 20
+  
+/obj/item/stack/sheet/mineral/silver/twenty
+	amount = 20
+  
+/obj/item/stack/sheet/mineral/bananium/twenty
+	amount = 20
+  
+/obj/item/stack/sheet/mineral/titanium/twenty
+	amount = 20

--- a/hippiestation/code/modules/cargo/packs.dm
+++ b/hippiestation/code/modules/cargo/packs.dm
@@ -54,7 +54,7 @@
 /datum/supply_pack/materials/uranium20
 	name = "20 Uranium Sheets"
 	cost = 8000
-	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	contains = list(/obj/item/stack/sheet/mineral/uranium/twenty)
 	crate_name = "uranium sheets crate"
 	
 /datum/supply_pack/science/plasma_canister

--- a/hippiestation/code/modules/cargo/packs.dm
+++ b/hippiestation/code/modules/cargo/packs.dm
@@ -14,3 +14,45 @@
 					/obj/item/shield/riot/roman,
 					/obj/item/shield/riot/roman)
 	crate_name = "Counter holy land invasion crate."
+
+/datum/supply_pack/materials/diamond20
+	name = "20 Diamonds"
+	cost = 50000
+	contains = list(/obj/item/stack/sheet/mineral/diamond/twenty)
+	crate_name = "diamonds crate"
+
+/datum/supply_pack/materials/plasma20
+	name = "20 Plasma Sheets"
+	cost = 6000
+	contains = list(/obj/item/stack/sheet/mineral/plasma/twenty)
+	crate_name = "plasma sheets crate"
+	
+/datum/supply_pack/materials/bananium20
+	name = "20 Bananium Sheets"
+	cost = 100000
+	contains = list(/obj/item/stack/sheet/mineral/bananium/twenty)
+	crate_name = "bananium sheets crate"
+	
+/datum/supply_pack/materials/titanium20
+	name = "20 Titanium Sheets"
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/mineral/titanium/twenty)
+	crate_name = "titanium sheets crate"
+
+/datum/supply_pack/materials/silver20
+	name = "20 Silver Sheets"
+	cost = 2000
+	contains = list(/obj/item/stack/sheet/mineral/silver/twenty)
+	crate_name = "silver sheets crate"
+
+/datum/supply_pack/materials/gold20
+	name = "20 Gold Sheets"
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	crate_name = "gold sheets crate"
+
+/datum/supply_pack/materials/uranium20
+	name = "20 Uranium Sheets"
+	cost = 8000
+	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	crate_name = "uranium sheets crate"

--- a/hippiestation/code/modules/cargo/packs.dm
+++ b/hippiestation/code/modules/cargo/packs.dm
@@ -14,7 +14,7 @@
 					/obj/item/shield/riot/roman,
 					/obj/item/shield/riot/roman)
 	crate_name = "Counter holy land invasion crate."
-
+	
 /datum/supply_pack/materials/diamond20
 	name = "20 Diamonds"
 	cost = 50000
@@ -38,13 +38,13 @@
 	cost = 5000
 	contains = list(/obj/item/stack/sheet/mineral/titanium/twenty)
 	crate_name = "titanium sheets crate"
-
+	
 /datum/supply_pack/materials/silver20
 	name = "20 Silver Sheets"
 	cost = 2000
 	contains = list(/obj/item/stack/sheet/mineral/silver/twenty)
 	crate_name = "silver sheets crate"
-
+	
 /datum/supply_pack/materials/gold20
 	name = "20 Gold Sheets"
 	cost = 5000
@@ -56,3 +56,12 @@
 	cost = 8000
 	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
 	crate_name = "uranium sheets crate"
+	
+/datum/supply_pack/science/plasma_canister
+	name = "Plasma Canister"
+	cost = 6000
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	crate_name = "plasma canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+	


### PR DESCRIPTION
[Changelogs]: 

:cl: # Bondle
add: Added all materials to cargo for 1.0x export price.
add: Added plasma canister to cargo.
/:cl:

[why]: # 
Lowpop means that there are no miners on the station, RnD is at a halt so to amend that, cargo can be used to purchase all the materials. Also, it's kinda dumb that you can't buy a plasma canister from cargo seeing as how they might be limited in the station. Current mat prices are 1.0x the export price ensuring that no credits duping can take place. I'll further test this in-game by seeing what happens when I try to sell the materials.

  