### PR TITLE
Nerf to stun-gun type 1

### DIFF
--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -37,7 +37,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 0
 	throwforce = 5
-	stunforce = 100
+	stunforce = 70
 	hitcost = 100
 	throw_hit_chance = 20
 	attack_verb = list("poked")


### PR DESCRIPTION
:cl: GuyonBroadway
balance: Stun gun now has its stun time reduced to 7 seconds from 10.
/:cl:

Closes:https://github.com/HippieStation/HippieStation/pull/5861
This is one of two ideas to tweak the stungun so its a little less absurd.

Popnotes, who designed the stunguns, said he wanted them to replace the telebaton as a tool for heads of staff to get undsirables out their office as opposed to the stunlock you to death item that was the telebaton. 

However its recharge time is as long as its stun time so kekety fucking kek it stunlocks you anyway... good fucking job popnotes!

![image](https://user-images.githubusercontent.com/22083966/34847823-863eefa6-f714-11e7-9880-7ba59e7fa33c.png)
