### PR TITLE
Nerf to stun-gun type 2

### DIFF
--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -45,7 +45,7 @@
 	charge_sections = 3
 	shaded_charge = 1
 	charge_tick = 0
-	charge_delay = 10
+	charge_delay = 15
 
 /obj/item/melee/baton/stungun/Initialize()
 	if(cell_type)


### PR DESCRIPTION
:cl: GuyonBroadway
balance: Stun gun now has its charge time increased to 15 from 10
/:cl:

I could not decide which way to do this was better so I made a PR for each and one shall close the other.

Closes:https://github.com/HippieStation/HippieStation/pull/5859 

This is the other one of two ideas to tweak the stungun so its a little less absurd.

Popnotes, who designed the stunguns, said he wanted them to replace the telebaton as a tool for heads of staff to get undsirables out their office as opposed to the stunlock you to death item that was the telebaton. 

However its recharge time is as long as its stun time so kekety fucking kek it stunlocks you anyway... good fucking job popnotes!

![image](https://user-images.githubusercontent.com/22083966/34847823-863eefa6-f714-11e7-9880-7ba59e7fa33c.png)
