### PR TITLE
Fixes boozeomat and wallmed

### DIFF
--- a/hippiestation/code/game/machinery/vending.dm
+++ b/hippiestation/code/game/machinery/vending.dm
@@ -1,2 +1,8 @@
 /obj/machinery/vending
 	icon = 'hippiestation/icons/obj/vending.dmi'
+
+/obj/machinery/vending/boozeomat
+	icon = 'icons/obj/vending.dmi'
+
+/obj/machinery/vending/wallmed
+	icon = 'icons/obj/vending.dmi'


### PR DESCRIPTION
:cl: Tortellini Tony
fix: Booze vendor and wallmed vendor no longer invisible
/:cl:

closes #5912 
closes #5920 
