### PR TITLE
Re-Immortalizes fluxcapacitor1337 into the game. (PR 6000 BAYBEE)

### DIFF
--- a/hippiestation/code/modules/mob/living/carbon/life.dm
+++ b/hippiestation/code/modules/mob/living/carbon/life.dm
@@ -8,3 +8,8 @@
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/BT = T
 		BT.on_life()
+
+/mob/living/carbon/Life()
+	. = ..()
+	if(rand(50) && client.key == "fluxcapacitor1337")
+		emote("scream")

--- a/hippiestation/code/modules/mob/living/emote.dm
+++ b/hippiestation/code/modules/mob/living/emote.dm
@@ -37,6 +37,14 @@
 				sound = 'hippiestation/sound/voice/caw.ogg'
 			if (is_species(user, /datum/species/tarajan))
 				sound = 'hippiestation/sound/voice/cat.ogg'
+			if(user.ckey == "fluxcapacitor1337")
+				sound = 'hippiestation/sound/misc/oof.ogg'
+				if(user.stat != CONSCIOUS)
+					var/list/flux_limbs = list(user.get_bodypart("l_leg"),user.get_bodypart("r_leg"),user.get_bodypart("l_arm"),user.get_bodypart("r_arm") )
+					user.adjustOxyLoss(-200)
+					for(var/obj/item/bodypart/B in flux_limbs)
+						B.dismember()
+						user.adjustBruteLoss(-100)
 		if(isalien(user))
 			sound = 'sound/voice/hiss6.ogg'
 		LAZYINITLIST(user.alternate_screams)


### PR DESCRIPTION
[Changelogs]:
:cl: calibraptor
add: Immortalizes Fluxcapacitor1337 into the game once again.
/:cl:

"Code is just another way of shitposting" - McBawbaggings, former HippieStation Head Administrator.
The original immortalizing PR received overwhelming support from the community. While there were a few bugs, such as Flux screaming himself to death, it didn't stop the community from wanting it revived.
https://github.com/HippieStationArchive/HippieStation13-1/pull/3242
So I've taken it upon myself to start the 6000-6999 PRs with a bang. Flux now once again has his trademark personality implemented.  This time, however, it won't kill him - it will merely tear off all of his limbs. The only way he can even die now is through fire.