### PR TITLE
[/tg/ balancing] Autolathe no longer drains Cargo's APC whenever metal is inserted.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -132,7 +132,7 @@
 				flick("autolathe_o",src)//plays metal insertion animation
 			if (MAT_GLASS)
 				flick("autolathe_r",src)//plays glass insertion animation
-		use_power(amount_inserted * 100)
+		//use_power(amount_inserted * 100) hippie edit - commented out
 	updateUsrDialog()
 
 /obj/machinery/autolathe/Topic(href, href_list)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)
:cl:
fix: Autolathe will no longer drain Cargo's APC when metal is added.
/:cl:

[why]: # 
Whoever coded in the energy drain for the autolathe massively overtuned it. It was set to  amount_inserted * 100. Meaning that if you inserted a stack of 50 metal, it would convert the metal to 50,000 and then multiply it by 100, resulting in it draining _**5,000,000**_ from Cargo's APC. This is so much that the admin spawn "infinite battery" gets drained to 0 instantly upon inserting the metal.

Fixes https://github.com/HippieStation/HippieStation/issues/5644

/tg/ is shit at balance.