### PR TITLE
Adds MGSV-style cardboard box disguises

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/examine(mob/user, dont_print = FALSE) // Hippie - Allows us to get a normal examine without printing anything
+/mob/living/carbon/examine(mob/user)
 	var/t_He = p_they(TRUE)
 	var/t_His = p_their(TRUE)
 	var/t_his = p_their()
@@ -94,9 +94,6 @@
 
 	msg += "*---------*</span>"
 
-	// Hippie Start - To allow for disguises
-	if (!dont_print)
-		to_chat(user, msg)
+	to_chat(user, msg)
 
-	return msg
-	// Hippie End
+	return msg // Hippie - To allow for disguises

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/examine(mob/user)
+/mob/living/carbon/examine(mob/user, dont_print = FALSE) // Hippie - Allows us to get a normal examine without printing anything
 	var/t_He = p_they(TRUE)
 	var/t_His = p_their(TRUE)
 	var/t_his = p_their()
@@ -94,4 +94,9 @@
 
 	msg += "*---------*</span>"
 
-	to_chat(user, msg)
+	// Hippie Start - To allow for disguises
+	if (!dont_print)
+		to_chat(user, msg)
+
+	return msg
+	// Hippie End

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/examine(mob/user)
+/mob/living/carbon/human/examine(mob/user, dont_print = FALSE) // Hippie - Allows us to get a normal examine without printing anything
 //this is very slightly better than it was because you can use it more places. still can't do \his[src] though.
 	var/t_He = p_they(TRUE)
 	var/t_His = p_their(TRUE)
@@ -317,7 +317,12 @@
 						msg += "<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>\n"
 	msg += "*---------*</span>"
 
-	to_chat(user, msg)
+	// Hippie Start - To allow for disguises
+	if (!dont_print)
+		to_chat(user, msg)
+
+	return msg
+	// Hippie End
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!
 	var/list/dat = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/examine(mob/user, dont_print = FALSE) // Hippie - Allows us to get a normal examine without printing anything
+/mob/living/carbon/human/examine(mob/user)
 //this is very slightly better than it was because you can use it more places. still can't do \his[src] though.
 	var/t_He = p_they(TRUE)
 	var/t_His = p_their(TRUE)
@@ -317,12 +317,9 @@
 						msg += "<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>\n"
 	msg += "*---------*</span>"
 
-	// Hippie Start - To allow for disguises
-	if (!dont_print)
-		to_chat(user, msg)
+	to_chat(user, msg)
 
-	return msg
-	// Hippie End
+	return msg // Hippie - To allow for disguises
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!
 	var/list/dat = list()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -306,7 +306,10 @@
 	temp.Blend(camera_get_icon(turfs, target), ICON_OVERLAY)
 
 	if(!issilicon(user))
-		printpicture(user, temp, mobs, flag)
+		// Hippie Start - MSGV style box disguises
+		var/list/disguises = find_disguises(user, turfs)
+		printpicture(user, temp, mobs, flag, disguises)
+		// Hippie End
 	else
 		aipicture(user, temp, mobs, isAi, blueprints)
 

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2711,6 +2711,7 @@
 #include "hippiestation\code\modules\modular_computers\computers\machinery\modular_console.dm"
 #include "hippiestation\code\modules\modular_computers\NTNet\NTNet_relay.dm.dm"
 #include "hippiestation\code\modules\paperwork\photocopier.dm"
+#include "hippiestation\code\modules\paperwork\photography.dm"
 #include "hippiestation\code\modules\pool\pool_controller.dm"
 #include "hippiestation\code\modules\pool\pool_drain.dm"
 #include "hippiestation\code\modules\pool\pool_main.dm"

--- a/hippiestation/code/modules/paperwork/photography.dm
+++ b/hippiestation/code/modules/paperwork/photography.dm
@@ -1,0 +1,113 @@
+/datum/photo_disguise
+	var/name = ""
+	var/examine_override = ""
+	var/icon/disguise_icon
+
+/obj/item/photo
+	desc = ""
+	var/list/potential_disguises = list()
+
+/obj/structure/closet/cardboard
+	var/datum/photo_disguise/disguise
+	desc = "Just a box. Looks like you could place a photo of someone on it to fool people..."
+
+/obj/item/device/camera/proc/find_disguises(mob/user, list/turfs)
+	var/list/targets = list()
+
+	for(var/turf/T in turfs)
+		for(var/mob/living/carbon/C in T)
+			if (!istype(C))
+				continue
+			if(is_vampire(C))
+				continue
+			if(C.invisibility)
+				continue
+
+			var/datum/photo_disguise/D = new()
+			D.name = C.name
+			D.examine_override = C.examine(user, TRUE) // Don't actually print anything please
+			D.disguise_icon = getFlatIcon(C, no_anim = TRUE)
+
+			LAZYSET(targets, C.name, D)
+
+	return targets
+
+/obj/item/device/camera/printpicture(mob/user, icon/temp, mobs, flag, list/potential_disguises) //Normal camera proc for creating photos
+	var/obj/item/photo/P = new/obj/item/photo(get_turf(src))
+	if(in_range(src, user)) //needed because of TK
+		user.put_in_hands(P)
+	var/icon/small_img = icon(temp)
+	var/icon/ic = icon('icons/obj/items_and_weapons.dmi',"photo")
+	small_img.Scale(8, 8)
+	ic.Blend(small_img,ICON_OVERLAY, 13, 13)
+	P.icon = ic
+	P.img = temp
+	P.desc = mobs
+	P.pixel_x = rand(-10, 10)
+	P.pixel_y = rand(-10, 10)
+
+	if(blueprints)
+		P.blueprints = 1
+		blueprints = 0
+
+	if (potential_disguises)
+		P.potential_disguises = potential_disguises
+	
+/obj/structure/closet/cardboard/attackby(obj/item/W, mob/user, params)
+	// Apply the thing
+	if (istype(W, /obj/item/photo))
+		var/obj/item/photo/P = W
+		if (LAZYLEN(P.potential_disguises) > 0)
+			var/chosen = input("Select a target to disguise as", "Pick target") as null|anything in P.potential_disguises
+
+			if (chosen)
+				var/datum/photo_disguise/D = P.potential_disguises[chosen]
+
+				if (D)
+					to_chat(user, "<span class='notice'>You gently place the cut-out of [chosen] onto the box, careful to make sure it looks genuine.</span>")
+					disguise = D
+					qdel(P)
+
+					if (!opened)
+						icon = null
+						add_overlay(D.disguise_icon)
+	else
+		. = ..()
+
+/obj/structure/closet/cardboard/examine(mob/user)
+	// If you're examining it from far enough away it looks like a regular person
+	if (get_dist(src, user) > 1 && disguise && !opened)
+		to_chat(user, disguise.examine_override)
+		return
+
+	. = ..()
+
+	if (get_dist(src, user) <= 1 && disguise && !opened)
+		to_chat(user, "<span class='warning'>Upon close inspection it looks like a shoddy impersonation of [disguise]!</span>")
+		to_chat(user, "<span class='notice'>Alt-click to remove the impersonation</span>")
+
+/obj/structure/closet/cardboard/AltClick(mob/user)
+	if (disguise)
+		visible_message("<span class='warning'>[user] rips the cut-out of [disguise] from the [src]!<span>")
+		playsound(loc, 'sound/items/poster_ripped.ogg', 100, 1)
+		disguise = null
+
+		if (!opened)
+			cut_overlays()
+			icon = initial(icon)
+	else
+		. = ..()
+
+/obj/structure/closet/cardboard/close(mob/living/user)
+	. = ..()
+
+	if (disguise)
+		icon = null
+		add_overlay(disguise.disguise_icon)
+
+/obj/structure/closet/cardboard/open(mob/living/user)
+	if (!icon)
+		cut_overlays()
+		icon = initial(icon)
+
+	. = ..()

--- a/hippiestation/code/modules/paperwork/photography.dm
+++ b/hippiestation/code/modules/paperwork/photography.dm
@@ -25,7 +25,7 @@
 
 			var/datum/photo_disguise/D = new()
 			D.name = C.name
-			D.examine_override = C.examine(user, TRUE) // Don't actually print anything please
+			D.examine_override = C.examine(null) // Don't actually print anything please
 			D.disguise_icon = getFlatIcon(C, no_anim = TRUE)
 
 			LAZYSET(targets, C.name, D)


### PR DESCRIPTION
You can now use photographs of people to create a cutout of them. When you click on a cardboard box with a photo containing people, a list of potential targets comes up and when you select one it gets applied to the cardboard box. When the box is closed it looks like the person in the photo. You can alt-click the cardboard box to remove the cut-out. If you examine a disguised box from a distance it will work like a normal examine. Movement is still slow and the photo (rightfully) doesn't rotate so slow-moving moonwalking heads are suspicious

Vids:
https://gfycat.com/HardSpotlessAmericanwirehair
https://gfycat.com/ElderlyTenderAmazontreeboa

Pics:
Open from a distance:
![image](https://user-images.githubusercontent.com/3355198/35783239-d74ce5d4-09fb-11e8-983d-943c6298c2ff.png)

Closed from a distance: 
![image](https://user-images.githubusercontent.com/3355198/35783245-e1bf37d8-09fb-11e8-8405-b8c450b9af60.png)

Closed up close:
![image](https://user-images.githubusercontent.com/3355198/35783249-ef2cf40a-09fb-11e8-920c-1855f51a3006.png)

:cl: JohnGinnane
add: You can now use photographs of people to create a cutout of them. When you click on a cardboard box with a photo containing people, a list of potential targets comes up and when you select one it gets applied to the cardboard box. When the box is closed it looks like the person in the photo. You can alt-click the cardboard box to remove the cut-out. If you examine a disguised box from a distance it will work like a normal examine.
/:cl:
