### PR TITLE
Wizard shoes are now no-slip.

### DIFF
--- a/hippiestation/code/modules/clothing/shoe.dm
+++ b/hippiestation/code/modules/clothing/shoe.dm
@@ -56,3 +56,4 @@
 
 /obj/item/clothing/shoes/sandal/magic
 	flags_1 = NOSLIP_1
+	desc = "A pair of sandals imbued with magic. Keeps you from slipping."

--- a/hippiestation/code/modules/clothing/shoe.dm
+++ b/hippiestation/code/modules/clothing/shoe.dm
@@ -53,3 +53,6 @@
 	item_state = "guardboots"
 	icon = 'hippiestation/icons/obj/clothing/shoes.dmi'
 	alternate_worn_icon = 'hippiestation/icons/mob/feet.dmi'
+
+/obj/item/clothing/shoes/sandal/magic
+	flags_1 = NOSLIP_1


### PR DESCRIPTION
[Changelogs]:
:cl: KawaiiBigBoss
fix: soap no longer insta-kills wizard
/:cl:

[why]: 
This was intended to be in the original PR, but as previously stated my git went Chernobyl.
What this does is prevents the Wizard from instantly dying because he slipped on soap or water vapor, because he dropped his staff. Traitors can buy no-slips too, so it's not that much of a stretch.
