### PR TITLE
Fixed surgery bugs that I introduced

### DIFF
--- a/hippiestation/code/modules/surgery/surgery_step.dm
+++ b/hippiestation/code/modules/surgery/surgery_step.dm
@@ -1,4 +1,7 @@
 /datum/surgery_step/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	// Do what we wanted anyway, but with consequences
+	success(user, target, target_zone, tool, surgery)
+
 	user.visible_message("<span class='warning'>[user] just about succeeds, but makes a mess!</span>", "<span class='warning'>You succeed... just about!</span>")
 	var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(target_zone))
 	var/damage_amount = 20
@@ -14,8 +17,21 @@
 
 	return TRUE
 
-/datum/surgery_step/add_prosthetic/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	// The last stage of this is adding the arm. 
-	// The success() is overridden so I need to override the failure to make sure success is still run (and attaches the body part)
+// Listing failure() overrides that normally return false to return true
+/datum/surgery_step/pacify/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	success(user, target, target_zone, tool, surgery)
-	return ..()
+	..(user, target, target_zone, tool, surgery)
+	
+	return TRUE
+
+/datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	success(user, target, target_zone, tool, surgery)
+	..(user, target, target_zone, tool, surgery)
+	
+	return TRUE
+
+/datum/surgery_step/fix_eyes/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	success(user, target, target_zone, tool, surgery)
+	..(user, target, target_zone, tool, surgery)
+
+	return TRUE

--- a/hippiestation/code/modules/surgery/surgery_step.dm
+++ b/hippiestation/code/modules/surgery/surgery_step.dm
@@ -20,18 +20,18 @@
 // Listing failure() overrides that normally return false to return true
 /datum/surgery_step/pacify/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	success(user, target, target_zone, tool, surgery)
-	..(user, target, target_zone, tool, surgery)
+	..()
 	
 	return TRUE
 
 /datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	success(user, target, target_zone, tool, surgery)
-	..(user, target, target_zone, tool, surgery)
+	..()
 	
 	return TRUE
 
 /datum/surgery_step/fix_eyes/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	success(user, target, target_zone, tool, surgery)
-	..(user, target, target_zone, tool, surgery)
+	..()
 
 	return TRUE


### PR DESCRIPTION
[Changelogs]: There were some procedures which should work but also deal damage, however they never finished. I had another look at the code and changed it so all "failures" actually result in a success as well as return true so that if the step does something (e.g. put dental implant into tooth) it will still do that but also potentially deal damage like intended and also allow the surgery to proceed or finish

Fixes #6321
Fixes #5300

:cl: JohnGinnane
fix: Fixed surgeries not working correctly when they "failed", this includes dental implants
/:cl:
