### PR TITLE
Hotel sec now gets TPed back when attempting to leave hotel

### DIFF
--- a/hippiestation/code/game/objects/structures/ghost_role_spawners.dm
+++ b/hippiestation/code/game/objects/structures/ghost_role_spawners.dm
@@ -1,4 +1,4 @@
 /datum/outfit/hotelstaff
 	implants = list(/obj/item/implant/teleporter/ghost_role)
 /datum/outfit/hotelstaff/security
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/teleporter/ghost_role)


### PR DESCRIPTION

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: xTrainx
tweak: hotel sec can't leave hotel
/:cl:

[why]: # so they cant metagrudge antag, also  hotel sec in station doesn't just make it valid, but is straight up bannable, who could have guessed
