### PR TITLE
Updated hippie code to match tg

### DIFF
--- a/hippiestation/code/game/gamemodes/wizard/spellbook.dm
+++ b/hippiestation/code/game/gamemodes/wizard/spellbook.dm
@@ -540,7 +540,7 @@ F
 
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(0, user, 25)
+	rightandwrong(SUMMON_GUNS, user, 25)
 	active = 1
 	playsound(get_turf(user), 'sound/magic/CastSummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon guns!</span>")
@@ -557,7 +557,7 @@ F
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
-	rightandwrong(1, user, 25)
+	rightandwrong(SUMMON_MAGIC, user, 25)
 	active = 1
 	playsound(get_turf(user), 'sound/magic/CastSummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")


### PR DESCRIPTION
:cl: JohnGinnane
fix: Fixed summon guns/magic rituals for wizard
/:cl:

Looks like some changes casued by https://github.com/HippieStation/HippieStation/pull/5807 meant that `rightandwrong()` took strings for the first argument, rather than numbers, so I updated our version of this proc and tested it and it all works