### PR TITLE
Fixes No-Slip shoes not actually being no-slip.

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -158,7 +158,7 @@
 	player_minimum = 0
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
-	item = /obj/item/clothing/shoes/chameleon
+	item = /obj/item/clothing/shoes/chameleon/noslip // you have to be a real doofus to forget to add the /noslip part
 	cost = 2
 	player_minimum = 0
 


### PR DESCRIPTION
[Changelogs]: # 

:cl: KawaiiBigBoss
fix: Noslips now actually work.
/:cl:

[why]: # Some (((genius))) on our end forgot to actually make the uplink sell no-slip shoes. Instead all they did was sell chameleon shoes.

Fixes [this](https://hippiestation.com/threads/fix-no-slips.8324/)