### PR TITLE
Fixes war op pop limit.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 1  // hippie-code: Changed this som ops may ALWAYS declare war.
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 /obj/item/device/nuclear_challenge


### PR DESCRIPTION
:cl: GuyonBroadway
fix: Nuke ops can now declare war at any time for a scaling amount of tc
/:cl:

[why]: John Ported the change when tg refactored antags into a module but forgot to set the pop limit.