### PR TITLE
Bomb suit buffs + integrated doppler array

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -74,10 +74,10 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
 
 	if(integrated)
-		var/obj/item/clothing/head/helmet/space/hardsuit/helm = loc
-		if(!helm || !istype(helm, /obj/item/clothing/head/helmet/space/hardsuit))
+		var/obj/item/clothing/head/helm = loc
+		if(!helm || !istype(helm, /obj/item/clothing/head))
 			return
-		helm.display_visor_message("Explosion detected! Epicenter: [devastation_range], Outer: [heavy_impact_range], Shock: [light_impact_range]")
+		helm.display_helmet_message("Explosion detected! Epicenter: [devastation_range], Outer: [heavy_impact_range], Shock: [light_impact_range]") //Allows bombsuit explosion messages too
 	else
 		for(var/message in messages)
 			say(message)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2522,7 +2522,6 @@
 #include "hippiestation\code\game\machinery\autolathe.dm"
 #include "hippiestation\code\game\machinery\cell_charger.dm"
 #include "hippiestation\code\game\machinery\cryo.dm"
-#include "hippiestation\code\game\machinery\doppler_array.dm"
 #include "hippiestation\code\game\machinery\reagent_forge.dm"
 #include "hippiestation\code\game\machinery\reagent_material_manipulator.dm"
 #include "hippiestation\code\game\machinery\reagent_sheet.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2658,6 +2658,7 @@
 #include "hippiestation\code\modules\clothing\shoes\magboots.dm"
 #include "hippiestation\code\modules\clothing\spacesuits\hardsuit.dm"
 #include "hippiestation\code\modules\clothing\suits\cloaks.dm"
+#include "hippiestation\code\modules\clothing\suits\utility.dm"
 #include "hippiestation\code\modules\crafting\recipies.dm"
 #include "hippiestation\code\modules\crafts\shield.dm"
 #include "hippiestation\code\modules\crafts\vest.dm"

--- a/hippiestation/code/modules/clothing/suits/utility.dm
+++ b/hippiestation/code/modules/clothing/suits/utility.dm
@@ -1,3 +1,8 @@
+/obj/item/clothing/head/proc/display_helmet_message(var/msg)
+	var/mob/wearer = loc
+	if(msg && ishuman(wearer))
+		wearer.show_message("[icon2html(src, wearer)]<b><span class='robot'>[msg]</span></b>", 1)
+
 /obj/item/clothing/head/bomb_hood
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 20,"energy" = 10, "bomb" = 100, "bio" = 50, "rad" = 25, "fire" = 80, "acid" = 50)
 	var/obj/machinery/doppler_array/integrated/bomb_radar
@@ -9,4 +14,9 @@
 
 /obj/item/clothing/head/bomb_hood/Initialize()
 	. = ..()
+	START_PROCESSING(SSobj, src)
 	bomb_radar = new /obj/machinery/doppler_array/integrated(src)
+
+/obj/item/clothing/head/helmet/space/hardsuit/Destroy()
+	. = ..()
+	STOP_PROCESSING(SSobj, src)

--- a/hippiestation/code/modules/clothing/suits/utility.dm
+++ b/hippiestation/code/modules/clothing/suits/utility.dm
@@ -1,0 +1,12 @@
+/obj/item/clothing/head/bomb_hood
+	armor = list("melee" = 25, "bullet" = 10, "laser" = 20,"energy" = 10, "bomb" = 100, "bio" = 50, "rad" = 25, "fire" = 80, "acid" = 50)
+	var/obj/machinery/doppler_array/integrated/bomb_radar
+
+/obj/item/clothing/suit/bomb_suit
+	slowdown = 1.5
+	armor = list("melee" = 25, "bullet" = 10, "laser" = 20,"energy" = 10, "bomb" = 100, "bio" = 50, "rad" = 25, "fire" = 80, "acid" = 50)
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/screwdriver, /obj/item/wirecutters)
+
+/obj/item/clothing/head/bomb_hood/Initialize()
+	. = ..()
+	bomb_radar = new /obj/machinery/doppler_array/integrated(src)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: Integrated doppler array to bomb suit hood.
balance: Slight buffs to armour for consistency between similar full-body protective suits + slowdown decreased from 2 to 1.5.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I think this will make the bomb suit a more desirable and valuable piece of equipment when dealing with 
high explosives on the station seeing how it's often neglected in favour of hardsuits such as the RD or Captains.
