### PR TITLE
Buffs the Energy Balisong's backstab damage.

### DIFF
--- a/hippiestation/code/game/objects/items/butterfly_knives.dm
+++ b/hippiestation/code/game/objects/items/butterfly_knives.dm
@@ -76,7 +76,7 @@
 	desc = "A vicious carbon fibre blade and plasma tip allow for unparelled precision strikes against fat Nanotrasen backsides"
 	force_on = 20
 	throwforce_on = 20
-	backstabforce = 80
+	backstabforce = 125
 	item_state_on = "balisong"
 	icon_state = "butterflyknife0"
 	icon_state_on = "butterflyknife_syndie"

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -127,7 +127,7 @@
 /datum/uplink_item/dangerous/butterfly
 	name = "Energy Butterfly Knife"
 	desc = "A highly lethal and concealable knife that causes critical backstab damage when used with harm intent."
-	cost = 8//80 backstab damage and armour pierce isn't a fucking joke
+	cost = 8
 	item = /obj/item/melee/transforming/butterfly/energy
 	surplus = 15
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Kawaii-Big-Boss
balance: Energy Balisong now deals 125 brute on backstab.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I really want the Energy Balisong to be an item worth its price, an item based around backstabs sounds like it'd be a lot of fun to use - but unfortunately it falls short.

The backstab can, obviously, only be used when you're behind someone. This is very hard to pull off in-game without stunning someone and tying them to a chair, and then going ham on their spine. If they see the balisong, they'll usually run away and unless you have a gun on you to stun them - you won't get that backstab. If you _do_ stun them, you can't backstab them unless they get tied to a chair. By that point they're most likely handcuffed and with any other weapon you could have killed them or at least crit them - particularly the Energy Sword.
If you want it to be sneaky and be an item that requires you sneak up behind co-workers who don't know how to examine you or click on a tile to look there, you'll be disappointed. You might kill an AFK cargo tech, a miner or a chef but you won't get the active crew who are usually smart enough to keep their distance.

Without the Backstab mechanic, you're paying for an item 4x the price of the Energy Dagger for only 2 extra brute damage. It's unfortunately underpowered and overpriced.

The crit-on-backstab would make the Energy Balisong's backstab at least a bit more worth it if you somehow manage to land it, and it would offset the fact that this item is barely better than the Edagger. However, until an item can properly combo with the Energy Balisong - I doubt we'll be seeing much of it.