### PR TITLE
Lowers Syndicate Banhammer price to 6 TC and removes its Nuke Ops exclusion

### DIFF
--- a/hippiestation/code/game/objects/items/weaponry.dm
+++ b/hippiestation/code/game/objects/items/weaponry.dm
@@ -36,7 +36,7 @@
 	icon_state = "toyhammertagged"
 	throwforce = 20
 	force = 20
-	armour_penetration = 100 //Target will be downed in 5 hits before they knew what happened."
+	armour_penetration = 100 //Target will be downed in 5 hits before they know what happened.
 
 /obj/item/banhammer/syndicate/attack(mob/M, mob/user)
 	. = ..()

--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -253,9 +253,8 @@
 	name = "Syndicate Banhammer"
 	desc = "By inserting small kinetic pounders into a banhammer, the banhammer becomes a dangerous object that is able to kill people before they even realize what happened. Completely stealthy unless someone examines it. Don't try this at home."
 	item = /obj/item/banhammer/syndicate
-	cost = 10
+	cost = 6
 	surplus = 10
-	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/badass/surplus
 	player_minimum = 0


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Kawaii-Big-Boss
balance: Lowered Syndicate Banhammer price to 6 TC.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I used the Syndicate Banhammer earlier with your average stun + weapon murderbone, and I thought that despite the 100% armor piercing, I was dealing less damage than the esword.
So I went to a test server to compare how fast you'll crit someone with these weapons.

Energy Sword: 8 TC.
Syndicate Banhammer: 10 TC.

Hits Until Crit Vs;

Average Crewmember (no armor)
Energy Sword: _4 hits._
Syndicate Banhammer: _5 hits._

Security Officer
Energy Sword: _4 hits._
Syndicate Banhammer: _5 hits._

Head of Security
Energy Sword: _4 hits._
Syndicate Banhammer: _5 hits._

## The Syndicate Banhammer is not worth 10 TC when it deals less damage than the Esword on average.