### PR TITLE
[/tg/ Balancing] Unfucks the Spray Cleaner

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2916,6 +2916,7 @@
 #include "hippiestation\code\modules\reagents\reagent_containers\glass.dm"
 #include "hippiestation\code\modules\reagents\reagent_containers\patch.dm"
 #include "hippiestation\code\modules\reagents\reagent_containers\solid_reagent.dm"
+#include "hippiestation\code\modules\reagents\reagent_containers\spray.dm"
 #include "hippiestation\code\modules\reagents\reagent_containers\syringes.dm"
 #include "hippiestation\code\modules\research\message_server.dm"
 #include "hippiestation\code\modules\research\rdmachines.dm"

--- a/hippiestation/code/modules/reagents/reagent_containers/spray.dm
+++ b/hippiestation/code/modules/reagents/reagent_containers/spray.dm
@@ -1,6 +1,4 @@
 /obj/item/reagent_containers/spray/cleaner
-	name = "space cleaner"
-	desc = "BLAM!-brand non-foaming space cleaner!"
 	volume = 250
 	list_reagents = list("cleaner" = 250)
 	amount_per_transfer_from_this = 5

--- a/hippiestation/code/modules/reagents/reagent_containers/spray.dm
+++ b/hippiestation/code/modules/reagents/reagent_containers/spray.dm
@@ -1,0 +1,7 @@
+/obj/item/reagent_containers/spray/cleaner
+	name = "space cleaner"
+	desc = "BLAM!-brand non-foaming space cleaner!"
+	volume = 250
+	list_reagents = list("cleaner" = 250)
+	amount_per_transfer_from_this = 5
+	stream_amount = 5

--- a/hippiestation/code/modules/reagents/reagent_containers/spray.dm
+++ b/hippiestation/code/modules/reagents/reagent_containers/spray.dm
@@ -4,4 +4,4 @@
 	volume = 250
 	list_reagents = list("cleaner" = 250)
 	amount_per_transfer_from_this = 5
-	stream_amount = 5
+	stream_amount = 10


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Kawaii-Big-Boss
fix: Spray Cleaner is no longer retarded.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

#7060 brought us "wonderful" changes to the Spray Cleaner. It reduced the volume it could hold to 100, made it so that you only apply two units to a tile, and nerfed spray cleaner probably because he didn't like being spray tanned/slipped with water or lube.

You could still use pest spray for this, c'mon. No need to make the janitor's bottle only good for spray cleaner.