### PR TITLE
Atmos unary devices can now be analyzed

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -858,6 +858,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 			else if (istype(A, /obj/machinery/atmospherics/pipe))
 				var/obj/machinery/atmospherics/pipe/P = A
 				atmosanalyzer_scan(P.parent.air, user, P)
+			else if (istype(A, /obj/machinery/atmospherics/components/unary))
+				var/obj/machinery/atmospherics/components/unary/U = A
+				atmosanalyzer_scan(U.airs[1], user, U)
 			else if (istype(A, /obj/machinery/power/rad_collector))
 				var/obj/machinery/power/rad_collector/RC = A
 				if(RC.loaded_tank)

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -19,6 +19,12 @@
 	update_icon()
 	..(intact)
 
+/obj/machinery/atmospherics/components/unary/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/device/analyzer))
+		atmosanalyzer_scan(airs[1], user)
+	else
+		return ..()
+
 /obj/machinery/atmospherics/components/unary/proc/assign_uid_vents()
 	uid = num2text(gl_uid++)
 	return uid


### PR DESCRIPTION
Adds to ability for PDA's and analyzer to check the atmos contents of unary devices such as pumps, vents, large air tanks, freezers/heaters, cryo, etc.

All credit goes to this TG PR:

https://github.com/tgstation/tgstation/pull/36485

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
tweak: Unary devices can now be analyzed using gas scanners. This means stuff like vents, scrubbers, cryo tubes, or heaters/freezers.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
