### PR TITLE
adds gps to SCP coffee machine ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/scp_294.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scp_294.dmm
@@ -80,6 +80,9 @@
 /obj/effect/turf_decal/tile/beige/side{
 	dir = 1
 	},
+/obj/item/device/gps{
+	gpstag = "Break Room"
+	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/powered/scp_294)
 "an" = (


### PR DESCRIPTION
added a gps to the strange coffee machine space ruin so true space explorers can find it as opposed to the ruin being unexplored 99% of the time.
I closed the previous PR cause I had hippie station dme checked for some reason 
add: gps to space ruins
