### PR TITLE
Medbots dispense lollipops on successful medication

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -507,7 +507,7 @@
 			visible_message("[src] retracts its syringe.")
 		update_icon()
 		soft_reset()
-		return
+		return !failed // Hippie - Return whether we medicated the patient or not
 
 	reagent_id = null
 	return

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2923,6 +2923,7 @@
 #include "hippiestation\code\modules\mob\living\silicon\robot\login.dm"
 #include "hippiestation\code\modules\mob\living\simple_animal\floor_cluwne.dm"
 #include "hippiestation\code\modules\mob\living\simple_animal\bot\buttbot.dm"
+#include "hippiestation\code\modules\mob\living\simple_animal\bot\medbot.dm"
 #include "hippiestation\code\modules\mob\living\simple_animal\friendly\cat.dm"
 #include "hippiestation\code\modules\mob\living\simple_animal\gremlin\event.dm"
 #include "hippiestation\code\modules\mob\living\simple_animal\gremlin\gremlin.dm"

--- a/hippiestation/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -9,5 +9,3 @@
 			visible_message("<span class='notice'>[src] dispenses a lollipop.</span>")
 
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-	
-	return .

--- a/hippiestation/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -1,0 +1,13 @@
+/mob/living/simple_animal/bot/medbot/medicate_patient(mob/living/carbon/C)
+	. = ..()
+	if (.)
+		var/obj/item/reagent_containers/food/snacks/lollipop/L = new(C.loc)
+
+		if(C.put_in_hands(L))
+			visible_message("<span class='notice'>[src] dispenses a lollipop into the hands of [C].</span>")
+		else
+			visible_message("<span class='notice'>[src] dispenses a lollipop.</span>")
+
+		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+	
+	return .


### PR DESCRIPTION
Credit to Satou:
![image](https://user-images.githubusercontent.com/3355198/37864058-1e5efb62-2f61-11e8-85bc-a001ec602a98.png)

Screenshot:
![image](https://user-images.githubusercontent.com/3355198/37864092-a5e51f12-2f61-11e8-9a9e-4d25e3b53845.png)

There's really a change I want to do on tg so that the `medicate_patient` proc returns whether injection was successful or not but they're on a code freeze so I've modularised it as best I can for now

:cl: JohnGinnane, Satou Tatsuhiro
add: Medbots drop lollipops on successful injection
/:cl:

tfw no cutie medbot to take care of you when you're sick
