### PR TITLE
Fixed our icons not loading

### DIFF
--- a/hippiestation/code/game/atoms.dm
+++ b/hippiestation/code/game/atoms.dm
@@ -2,7 +2,7 @@
     var/icon_hippie
 
 /atom/proc/check_hippie_icon()
-    if (!icon || !icon_state || !icon_hippie || !initialized)
+    if (!icon || !icon_state || !icon_hippie)
         return
 
     var/icon/I = new (icon_hippie)


### PR DESCRIPTION
I added a last minute change to check it atom is initialised but they aren't at this point so the icons were all reverted to /tg/

my bad

Maybe speedmerge as it's an important-ish fix

![image](https://user-images.githubusercontent.com/3355198/38059049-e73e087e-32dc-11e8-9430-f9c250ba760c.png)

🆑 JohnGinnane
fix: Fixed our sprites not loading
/🆑
