### PR TITLE
*STILL TESTING - DO NOT MERGE* Adds Vibrancy Trait

### DIFF
--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -16,6 +16,25 @@
 /datum/trait/monochromatic/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/monochrome)
 
+/datum/trait/vibrancy
+	name = "Vibrancy"
+	desc = "You must have taken some of the good stuff, because everything looks way brighter and far more vibrant!"
+	value = 0
+	lose_text = "<span class='notice'>It seems like everything is not so vibrant anymore...</span>"
+
+/datum/trait/vibrancy/add()
+	if(trait_holder.client_colour == client_colour.monochrome)
+		to_chat(trait_holder, "<span class='warning'>You feel your vibrant vision having no effect because of your monochromacy!</span>")
+		sleep(20) //Don't want the two messages to pop up instantly, muh immershun
+		trait_holder.remove()
+	else
+		trait_holder.add_client_colour(/datum/client_colour/vibrant)
+		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
+
+
+/datum/trait/vibrancy/remove()
+	trait_holder.remove_client_colour(/datum/client_colour/vibrant)
+
 /datum/trait/super_lungs
 	name = "Super Lungs"
 	desc = "Your extra powerful lungs allow you to scream much louder than normal, at the cost of losing more oxygen whenever you scream."

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -16,9 +16,22 @@
 /datum/trait/monochromatic/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/monochrome)
 
+/datum/trait/greyscale_vision
+	name = "Old School Vision"
+	desc = "Did you get stuck in an old video recorder? You can only see in black and white!"
+	value = 0
+	gain_text = "<span class='notice'>...Huh? You can't see colour anymore!"
+	lose_text = "<span class='notice'>You can see colour again!"
+
+/datum/trait/greyscale_vision/add()
+	trait_holder.add_client_colour(/datum/client_colour/greyscale)
+
+/datum/trait/greyscale_vision/remove()
+	trait_holder.remove_client_colour(/datum/client_colour/greyscale)
+
 /datum/trait/inverted_vision
 	name = "Inverted Colour Vision"
-	desc = "You see colours as the reverse of what they would normally be. Though... everything also seems duller..."
+	desc = "You see red and blue colours as reversed."
 	gain_text = "<span class='notice'>You feel like you're seeing colours differently.</span>"
 	lose_text = "<span class='notice'>You feel like you're seeing colours normally again.</span>"
 
@@ -28,6 +41,8 @@
 /datum/trait/inverted_vision/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/inverted)
 
+//I'm going to leave this code in here just in case we figure out how to do it properly, but for now leave this disabled - it doesn't work
+/*
 /datum/trait/vibrancy
 	name = "Vibrancy"
 	desc = "You must have taken some of the good stuff, because everything looks way brighter and far more vibrant!"
@@ -43,8 +58,11 @@
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
 
+		//The vibrancy trait won't get removed if you have monochromacy because when traits get added at roundstart, it doesn't currently call the add proc, so there's probably no use for all of this
+
 /datum/trait/vibrancy/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/vibrant)
+*/
 
 /datum/trait/super_lungs
 	name = "Super Lungs"

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -30,8 +30,6 @@
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
-		fixinggg
-
 
 /datum/trait/vibrancy/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/vibrant)

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -30,7 +30,7 @@
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
-		f
+
 
 /datum/trait/vibrancy/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/vibrant)

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -16,6 +16,18 @@
 /datum/trait/monochromatic/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/monochrome)
 
+/datum/trait/inverted_vision
+	name = "Inverted Colour Vision"
+	desc = "You see colours as the reverse of what they would normally be. Though... everything also seems duller..."
+	gain_text = "<span class='notice'>You feel like you're seeing colours differently.</span>"
+	lose_text = "<span class='notice'>You feel like you're seeing colours normally again.</span>"
+
+/datum/trait/inverted_vision/add()
+	trait_holder.add_client_colour(/datum/client_colour/inverted)
+
+/datum/trait/inverted_vision/remove()
+	trait_holder.remove_client_colour(/datum/client_colour/inverted)
+
 /datum/trait/vibrancy
 	name = "Vibrancy"
 	desc = "You must have taken some of the good stuff, because everything looks way brighter and far more vibrant!"

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -22,11 +22,11 @@
 	value = 0
 	lose_text = "<span class='notice'>It seems like everything is not so vibrant anymore...</span>"
 
-/datum/trait/vibrancy/add() = /datum/client_colour
-	if(trait_holder.client_colour == client_colour.monochrome)
+/datum/trait/vibrancy/add()
+	if (locate(/datum/client_colour/monochrome) in trait_holder.client_colours)
 		to_chat(trait_holder, "<span class='warning'>You feel your vibrant vision having no effect because of your monochromacy!</span>")
 		sleep(20) //Don't want the two messages to pop up instantly, muh immershun
-		trait_holder.remove()
+		remove()
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -22,7 +22,7 @@
 	value = 0
 	lose_text = "<span class='notice'>It seems like everything is not so vibrant anymore...</span>"
 
-/datum/trait/vibrancy/add()
+/datum/trait/vibrancy/add() = /datum/client_colour
 	if(trait_holder.client_colour == client_colour.monochrome)
 		to_chat(trait_holder, "<span class='warning'>You feel your vibrant vision having no effect because of your monochromacy!</span>")
 		sleep(20) //Don't want the two messages to pop up instantly, muh immershun
@@ -30,7 +30,6 @@
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
-
 
 /datum/trait/vibrancy/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/vibrant)

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -30,6 +30,7 @@
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
+		fixinggg
 
 
 /datum/trait/vibrancy/remove()

--- a/hippiestation/code/datums/traits/neutral.dm
+++ b/hippiestation/code/datums/traits/neutral.dm
@@ -30,6 +30,7 @@
 	else
 		trait_holder.add_client_colour(/datum/client_colour/vibrant)
 		to_chat(trait_holder, "<span class='notice'>You feel like everything has gotten brighter and more colourful.</span>")
+		f
 
 /datum/trait/vibrancy/remove()
 	trait_holder.remove_client_colour(/datum/client_colour/vibrant)

--- a/hippiestation/code/modules/client/client_colour.dm
+++ b/hippiestation/code/modules/client/client_colour.dm
@@ -1,3 +1,3 @@
 /datum/client_colour/vibrant
-	colour = list(rgb(255,255,255), rgb(255,255,255), rgb(255,255,255), rgb(255,255,255))
+	colour = list(rgb(200,0,0), rgb(0,200,0), rgb(0,0,200), rgb(108,80,47))
 	priority = 1 //Monochromacy will override this cause otherwise who knows what will happen

--- a/hippiestation/code/modules/client/client_colour.dm
+++ b/hippiestation/code/modules/client/client_colour.dm
@@ -1,23 +1,32 @@
-#define red_colour rgb(-255,127,128)
-#define green_colour rgb(127,-255,128)
-#define blue_colour rgb(128,127,-255)
-#define colour_alpha rgb(-255,-255,-255)
+//The compiler got angry when I tried capitalising the defines so I've left them uncapitalised - sorry
+#define red_colour rgb(0, 0, 255)
+#define green_colour rgb(0, 255, 0)
+#define blue_colour rgb(255, 0, 0)
+#define colour_alpha rgb(0,0,0)
 #define colour_sum list(red_colour, green_colour, blue_colour, colour_alpha)
-#define colour_sum_redux list(-1,0,0,0, 0,-1,0,0, 0,0,-1,0, 0,0,0,1, 1,1,1,0)
-#define colour_vibrant list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 1,1,1,0)
+#define colour_sum_redux list(-1,0,0,0, 0,-1,0,0, 0,0,-1,0, 0,0,0,1, 1,1,1,0) //This was the attempt at making inverted colours
+#define colour_vibrant list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 1,1,1,0) //This was the attempt at vibrancy, by setting the colours to their normal values and adding the constant I thought I'd be able to stack the constant on top but... that didn't work :(
+
+var/thenewcolour = rgb2hsl(red_colour)
 
 var/vibrant_colour_sum_multiplier = 2
 
 #define vibrant_summed colour_sum
 
+//None of the above is needed for this code to work but I'll leave it here in case someone finds a use for it
+
 /datum/client_colour/vibrant
-	colour = list(rgb(colour_sum,0,0), rgb(0,colour_sum,0), rgb(0,0,colour_sum))
-	priority = 1 //Monochromacy will override this cause otherwise who knows what will happen
+	colour = rgb(255,255,255) //This just changes everything to white - leaving it here in case someone wants to experiment or figures out how to do this one properly
+	priority = 1 //Higher priority number = will override all other colour sets more
 
 /datum/client_colour/inverted
-	colour = list(colour_sum_redux)
+	colour = list(rgb(0,0,255), rgb(0,255,0), rgb(255,0,0)) //For some reason changing the green causes weird things to happen so I can't change the green... yet
 	priority = 2
 
-/datum/client_colour/faded
+/datum/client_colour/greyscale
+	colour = list(rgb(80,80,80), rgb(80,80,80), rgb(80,80,80), rgb(0,0,0))
+	priority = 4
+
+/datum/client_colour/faded //This one isn't used yet in a trait but I left it here cause it looks pretty cool
 	colour = list(rgb(255,85,85), rgb(85,255,85), rgb(85,85,255), rgb(0,0,0))
-	priority = 2 //This will override vibrant
+	priority = 3

--- a/hippiestation/code/modules/client/client_colour.dm
+++ b/hippiestation/code/modules/client/client_colour.dm
@@ -1,3 +1,23 @@
+#define red_colour rgb(-255,127,128)
+#define green_colour rgb(127,-255,128)
+#define blue_colour rgb(128,127,-255)
+#define colour_alpha rgb(-255,-255,-255)
+#define colour_sum list(red_colour, green_colour, blue_colour, colour_alpha)
+#define colour_sum_redux list(-1,0,0,0, 0,-1,0,0, 0,0,-1,0, 0,0,0,1, 1,1,1,0)
+#define colour_vibrant list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 1,1,1,0)
+
+var/vibrant_colour_sum_multiplier = 2
+
+#define vibrant_summed colour_sum
+
 /datum/client_colour/vibrant
-	colour = list(rgb(200,0,0), rgb(0,200,0), rgb(0,0,200), rgb(108,80,47))
+	colour = list(rgb(colour_sum,0,0), rgb(0,colour_sum,0), rgb(0,0,colour_sum))
 	priority = 1 //Monochromacy will override this cause otherwise who knows what will happen
+
+/datum/client_colour/inverted
+	colour = list(colour_sum_redux)
+	priority = 2
+
+/datum/client_colour/faded
+	colour = list(rgb(255,85,85), rgb(85,255,85), rgb(85,85,255), rgb(0,0,0))
+	priority = 2 //This will override vibrant

--- a/hippiestation/code/modules/client/client_colour.dm
+++ b/hippiestation/code/modules/client/client_colour.dm
@@ -1,0 +1,3 @@
+/datum/client_colour/vibrant
+	colour = list(rgb(255,255,255), rgb(255,255,255), rgb(255,255,255), rgb(255,255,255))
+	priority = 1 //Monochromacy will override this cause otherwise who knows what will happen


### PR DESCRIPTION
Added a new trait: Vibrancy

This is supposed to be like the opposite of the Monochromacy trait - it will make you see colours far more brightly and vibrantly than normal. It'll be a neutral trait cause fuck needing points to get traits lmao. Also it will be overridden by Monochromacy if you pick both at the same time because you can't see brighter colours if you can't see colours

Why - cause extra colour is cool as heck yo