### PR TITLE
Adds boxstation supermatter and port engineering

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -152,11 +152,13 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aaB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/open/floor/plating,
 /area/security/prison)
 "aaC" = (
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
 /area/security/prison)
 "aaD" = (
@@ -191,6 +193,7 @@
 /area/security/prison)
 "aaI" = (
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/security/prison)
 "aaJ" = (
@@ -290,6 +293,7 @@
 "aaZ" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aba" = (
@@ -465,9 +469,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "abF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "abG" = (
@@ -484,9 +486,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "abI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "abJ" = (
@@ -7778,14 +7778,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "asb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Air In";
-	on = 1
-	},
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -45612,6 +45610,7 @@
 	},
 /area/tcommsat/computer)
 "cjb" = (
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -50652,6 +50651,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
@@ -51078,9 +51078,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cwL" = (
@@ -51101,9 +51099,10 @@
 /area/engine/engineering)
 "cwM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cwO" = (
 /obj/machinery/firealarm{
@@ -51112,9 +51111,7 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cwP" = (
 /turf/open/floor/engine/n2,
@@ -51421,17 +51418,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cxN" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cxO" = (
 /obj/machinery/light/small,
@@ -51729,9 +51724,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cyB" = (
 /obj/structure/lattice,
@@ -52006,7 +51999,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52081,7 +52074,7 @@
 "czf" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/engine/engineering)
 "czg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -52103,9 +52096,7 @@
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "czk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
@@ -52376,7 +52367,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czM" = (
@@ -52481,6 +52472,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czX" = (
@@ -52510,9 +52504,6 @@
 "cAa" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/bot,
@@ -52672,7 +52663,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cAx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52968,7 +52959,7 @@
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBp" = (
 /obj/structure/table,
@@ -52984,7 +52975,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBr" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -53119,6 +53110,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "cBK" = (
@@ -53147,7 +53142,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBM" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
@@ -53155,7 +53150,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBN" = (
 /obj/machinery/computer/rdconsole/production,
@@ -53163,12 +53158,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBO" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -53211,7 +53206,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -53312,6 +53307,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -53370,6 +53369,7 @@
 	name = "Power Storage";
 	req_access_txt = "32"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cCs" = (
@@ -53393,7 +53393,7 @@
 /area/engine/engineering)
 "cCv" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCw" = (
 /obj/machinery/light/small{
@@ -53571,7 +53571,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCY" = (
 /obj/structure/table,
@@ -53579,7 +53579,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCZ" = (
 /obj/structure/table,
@@ -53601,7 +53601,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDa" = (
 /obj/structure/table,
@@ -53613,7 +53613,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDb" = (
 /obj/structure/table,
@@ -53628,7 +53628,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDc" = (
 /obj/structure/table,
@@ -53642,7 +53642,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDd" = (
 /obj/structure/cable{
@@ -53660,7 +53660,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDe" = (
 /obj/structure/table,
@@ -53674,17 +53674,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDg" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDh" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -54398,6 +54398,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cEX" = (
@@ -54410,6 +54411,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cEY" = (
@@ -54422,6 +54424,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cEZ" = (
@@ -54434,6 +54437,7 @@
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_x = 32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cFb" = (
@@ -54763,7 +54767,7 @@
 "cGe" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/engine/engineering)
 "cGg" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -54873,9 +54877,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"cGC" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "cGD" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -57862,6 +57863,20 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"dzE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "dBI" = (
 /obj/machinery/power/grounding_rod,
 /obj/effect/turf_decal/bot,
@@ -57959,9 +57974,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "dPZ" = (
 /obj/machinery/camera{
@@ -58148,7 +58161,7 @@
 /obj/item/electronics/airlock,
 /obj/item/electronics/apc,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "ePF" = (
 /obj/structure/cable/yellow{
@@ -58162,6 +58175,12 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"eQD" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -58329,13 +58348,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
-"frE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "frQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58354,7 +58366,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel{
 	name = "floor"
@@ -58423,6 +58435,20 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/wrench,
 /turf/open/floor/plating,
+/area/engine/port_engineering)
+"fXx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
 /area/engine/port_engineering)
 "fZx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58501,7 +58527,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "goo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -58519,9 +58545,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "grx" = (
 /obj/machinery/the_singularitygen/tesla,
@@ -58593,9 +58617,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "gFd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58799,9 +58821,7 @@
 /obj/machinery/vending/tool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "hwn" = (
 /obj/structure/cable{
@@ -58884,7 +58904,7 @@
 /area/engine/port_engineering)
 "hFg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -58896,14 +58916,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hJr" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "hJw" = (
 /obj/structure/grille,
@@ -58954,6 +58974,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hYN" = (
@@ -58975,9 +58998,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "icl" = (
 /obj/item/device/multitool,
@@ -59012,7 +59033,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -59096,9 +59117,7 @@
 "iyD" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "iza" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -59118,6 +59137,12 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Singularity";
 	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
@@ -59159,9 +59184,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "iFp" = (
 /obj/structure/cable{
@@ -59313,10 +59336,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"jjk" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "jjM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -59587,6 +59606,10 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"kqx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/prison)
 "krk" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable/yellow{
@@ -59601,7 +59624,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "kvn" = (
@@ -59631,9 +59653,7 @@
 	},
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "kJK" = (
 /obj/structure/cable{
@@ -59667,7 +59687,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/engine/port_engineering)
 "kWH" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -59783,9 +59803,7 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "lpx" = (
 /obj/structure/lattice,
@@ -59867,9 +59885,7 @@
 /obj/item/stack/medical/ointment,
 /obj/item/storage/inflatable,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "lFD" = (
 /obj/structure/closet/cardboard,
@@ -59975,14 +59991,11 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "lVq" = (
 /obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "lYW" = (
 /obj/structure/reflector/single/anchored{
@@ -60353,11 +60366,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"nsQ" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "ntM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60546,9 +60554,7 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "oaV" = (
 /obj/structure/cable{
@@ -60572,7 +60578,9 @@
 "oln" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/emitter/anchored,
+/obj/machinery/power/emitter/anchored{
+	state = 2
+	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
 "olo" = (
@@ -60643,7 +60651,7 @@
 	pixel_y = 1;
 	d2 = 2
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "oAG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60687,7 +60695,7 @@
 "oGE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -60848,15 +60856,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"pjv" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pjL" = (
 /obj/structure/guillotine,
 /turf/open/floor/plasteel/dark,
@@ -60900,7 +60899,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "pqD" = (
@@ -61073,6 +61071,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "qeU" = (
@@ -61494,6 +61493,12 @@
 	id = "Singularity";
 	name = "radiation shutters"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
 "skx" = (
@@ -61569,7 +61574,7 @@
 /area/engine/port_engineering)
 "stg" = (
 /obj/machinery/computer/station_alert,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "stN" = (
 /obj/structure/cable{
@@ -61706,9 +61711,7 @@
 /obj/structure/rack,
 /obj/item/device/flashlight/flare,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "sOH" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -61744,7 +61747,8 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/emitter/anchored{
-	dir = 1
+	dir = 1;
+	state = 2
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
@@ -61778,7 +61782,7 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "tbT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -61816,10 +61820,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tdK" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
 "tes" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -61842,7 +61842,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "tjD" = (
 /obj/structure/cable/yellow{
@@ -61893,6 +61893,21 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"tnv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "tqz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61934,8 +61949,7 @@
 /area/space/nearstation)
 "tEM" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "tFb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -62085,7 +62099,7 @@
 /obj/item/book/manual/engineering_singularity_safety,
 /obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "urE" = (
 /obj/effect/spawner/structure/window,
@@ -62153,9 +62167,7 @@
 	pixel_y = -24;
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "uMY" = (
 /obj/structure/cable{
@@ -62179,9 +62191,7 @@
 /obj/structure/rack,
 /obj/item/device/multitool,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "uPH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62246,6 +62256,7 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/maintenance/department/electrical)
 "vcj" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "vcY" = (
@@ -62356,7 +62367,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel{
 	name = "floor"
@@ -62378,6 +62389,9 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -62390,6 +62404,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -62495,7 +62513,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "waY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62677,6 +62695,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -62716,9 +62738,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "wPw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/door/poddoor{
 	id = "Secure Storage 2";
 	name = "secure storage"
@@ -62814,6 +62833,18 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"xeB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "xfx" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
@@ -62826,9 +62857,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "xil" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62840,12 +62869,17 @@
 "xit" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "xjp" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "xjH" = (
 /obj/structure/lattice,
@@ -63018,6 +63052,13 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"xOg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xOu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -63063,6 +63104,10 @@
 	id = "Singularity";
 	name = "radiation shutters"
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
 "xYc" = (
@@ -63081,7 +63126,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -63100,7 +63145,7 @@
 /obj/item/storage/inflatable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "yah" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -77222,11 +77267,11 @@ ncA
 twn
 twn
 twn
-twn
-rdO
+ncA
+ncA
 kVT
-rdO
-rdO
+ncA
+ncA
 twn
 twn
 twn
@@ -81586,7 +81631,7 @@ hJr
 oUK
 xgB
 cUz
-kfK
+tnv
 hgw
 hgw
 meC
@@ -82876,10 +82921,10 @@ uJZ
 wmy
 mlU
 wAW
-mlU
-mlU
-mlU
-mlU
+xeB
+fXx
+fXx
+dzE
 mlU
 vxM
 mlU
@@ -83134,8 +83179,8 @@ kYh
 dmH
 xYs
 fyu
-paC
-paC
+eQD
+eQD
 vuq
 srQ
 hFg
@@ -88919,10 +88964,10 @@ aan
 aas
 aaB
 aaI
-aav
-aav
+adb
+adb
 aaZ
-aav
+adb
 abF
 aca
 acv
@@ -89946,11 +89991,11 @@ aai
 aan
 aaw
 aaC
-aav
-aav
-aav
-aav
-aav
+kqx
+kqx
+kqx
+kqx
+kqx
 abI
 aca
 acy
@@ -93399,7 +93444,7 @@ csR
 ctX
 cuX
 cvI
-ctP
+cAR
 hUj
 cys
 cCB
@@ -93657,7 +93702,7 @@ ctY
 cuY
 cvJ
 cwK
-pjv
+cxC
 cyy
 clH
 jsP
@@ -93682,7 +93727,7 @@ cGw
 clH
 clH
 cGe
-tdK
+abp
 aaa
 aaa
 aaj
@@ -93939,7 +93984,7 @@ clH
 clH
 clH
 cGe
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -94190,13 +94235,13 @@ xjM
 mXX
 peq
 aak
-bqy
+aad
 aai
 aaa
-xGk
+aag
 clH
 cGe
-nsQ
+cEF
 aaa
 aaa
 aaj
@@ -94405,8 +94450,8 @@ bTp
 bUo
 bUo
 bWN
-frE
-bZr
+bVF
+bUv
 bUo
 bUo
 ccT
@@ -94427,7 +94472,7 @@ uPH
 csV
 cva
 cvL
-csV
+xOg
 hJk
 cze
 kON
@@ -94447,13 +94492,13 @@ clH
 aak
 aak
 aak
-bqy
+aad
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
-bqy
+aad
 aaa
 aad
 aaj
@@ -94704,13 +94749,13 @@ clH
 aaa
 aaa
 aai
-bqy
+aad
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
-bqy
+aad
 aaa
 aad
 aaj
@@ -94961,13 +95006,13 @@ clH
 aai
 aai
 aai
-bqy
+aad
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
-bqy
+aad
 aaa
 aad
 aaj
@@ -95218,13 +95263,13 @@ aaa
 aaa
 aaa
 aaa
-bqy
+aad
 aaa
 aaa
-bqy
+aad
 aaa
 aaa
-bqy
+aad
 aaa
 aad
 aaj
@@ -95475,13 +95520,13 @@ aaa
 aaa
 aaa
 aaa
-bqy
+aad
 aaa
 aaa
-bqy
+aad
 aaa
 aaa
-nsQ
+cEF
 aaa
 aad
 aaj
@@ -95738,7 +95783,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aad
 aaj
@@ -95995,7 +96040,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aad
 aaj
@@ -96252,7 +96297,7 @@ aaa
 aag
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -96509,7 +96554,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -96766,7 +96811,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -97023,7 +97068,7 @@ aaa
 aah
 aaa
 aaa
-xGk
+aag
 aaa
 aaa
 aaj
@@ -98051,7 +98096,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -98308,7 +98353,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -98565,7 +98610,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aaa
 aaa
 aaj
@@ -98822,7 +98867,7 @@ aaa
 aag
 aaa
 aaa
-jjk
+ahy
 aaa
 aad
 aaj
@@ -99079,7 +99124,7 @@ aaa
 aae
 aaa
 aaa
-jjk
+ahy
 aad
 aad
 aaj
@@ -101901,8 +101946,8 @@ cFG
 cFL
 cFT
 cFZ
-cGm
-cGC
+cHT
+cHT
 cGL
 cGZ
 cHf

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -22208,24 +22208,6 @@
 	dir = 6
 	},
 /area/bridge)
-"bdU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bdV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bdW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "bdX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22236,31 +22218,6 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bdY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bdZ" = (
-/obj/machinery/ai_status_display,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bea" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"beb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bec" = (
 /obj/machinery/firealarm{
@@ -22547,6 +22504,17 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"beQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "beR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -24052,6 +24020,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bjm" = (
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
@@ -24368,7 +24337,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bki" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bkj" = (
@@ -24378,6 +24349,9 @@
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_y = -21
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -24402,11 +24376,16 @@
 	name = "Station Intercom (AI Private)";
 	pixel_y = -29
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bkm" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bkn" = (
@@ -24962,18 +24941,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"blJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"blK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "blL" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
@@ -24985,18 +24952,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"blO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"blP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -25593,26 +25548,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bnq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bnr" = (
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bns" = (
 /obj/machinery/light,
 /obj/item/banhammer,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bnt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bnu" = (
@@ -26951,6 +26892,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "bqB" = (
@@ -26972,6 +26914,7 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "bqD" = (
@@ -27542,15 +27485,9 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"brY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
 "brZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
@@ -27571,21 +27508,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "bsd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/ai_monitored/nuke_storage)
-"bse" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "bsf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28318,6 +28252,8 @@
 /area/medical/medbay/central)
 "btM" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "btN" = (
@@ -28948,6 +28884,7 @@
 /area/ai_monitored/nuke_storage)
 "bvb" = (
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 6
 	},
@@ -28972,6 +28909,7 @@
 	network = list("SS13")
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 10
 	},
@@ -29061,6 +28999,11 @@
 /area/medical/chemistry)
 "bvn" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/chemistry,
 /obj/item/folder/white,
 /obj/item/device/radio/headset/headset_med,
 /turf/open/floor/plasteel/white,
@@ -29593,23 +29536,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"bwv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
-"bww" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
 "bwx" = (
 /obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "bwy" = (
@@ -29626,25 +29555,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ai_monitored/nuke_storage)
-"bwz" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
-"bwA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
-"bwB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "bwC" = (
 /obj/structure/closet/secure_closet/captains,
@@ -29705,10 +29615,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/chem/centrifuge{
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -29718,8 +29626,7 @@
 /area/medical/chemistry)
 "bwL" = (
 /obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap,
+/obj/machinery/chem/pressure,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwM" = (
@@ -36216,6 +36123,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -36227,6 +36137,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -36535,6 +36448,9 @@
 "bMu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -36888,6 +36804,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -37435,6 +37352,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/storage)
 "bOF" = (
@@ -37464,8 +37384,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -37476,12 +37396,17 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bOJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -37494,6 +37419,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "tox1";
 	name = "Toxins Lockdown Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -37706,9 +37634,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPl" = (
@@ -37716,18 +37641,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
-"bPm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPn" = (
@@ -37738,9 +37651,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPo" = (
@@ -37748,7 +37658,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
 	},
@@ -39751,6 +39663,9 @@
 /area/science/xenobiology)
 "bTW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -40198,8 +40113,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -40675,6 +40590,9 @@
 	},
 /area/science/research)
 "bWl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -41162,6 +41080,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bXq" = (
@@ -41649,6 +41568,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bYG" = (
@@ -41677,6 +41597,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bYI" = (
@@ -43557,6 +43478,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cdt" = (
@@ -43564,6 +43486,7 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cdu" = (
@@ -44200,6 +44123,9 @@
 /area/engine/atmos)
 "cfk" = (
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46333,6 +46259,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ckD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "ckE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 8
@@ -46726,6 +46658,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sign/departments/engineering,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "clA" = (
@@ -47651,6 +47584,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/departments/engineering,
 /turf/open/floor/plating,
 /area/engine/break_room)
 "cod" = (
@@ -48958,10 +48892,7 @@
 	c_tag = "Atmospherics South East";
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/arrival{
 	dir = 6
 	},
@@ -49347,6 +49278,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csx" = (
@@ -49364,6 +49301,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csz" = (
@@ -49372,11 +49312,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49414,7 +49354,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csD" = (
-/obj/machinery/shieldgen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "csF" = (
@@ -49493,6 +49433,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csL" = (
@@ -49855,19 +49801,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ctH" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "ctJ" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -50281,7 +50214,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cuJ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -50289,6 +50221,7 @@
 	c_tag = "Engineering Secure Storage";
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cuK" = (
@@ -50601,7 +50534,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cvy" = (
-/obj/machinery/field/generator,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cvz" = (
@@ -50647,12 +50580,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cvC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cvD" = (
@@ -50765,6 +50693,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics N2 Tank"
+	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "cvQ" = (
@@ -50781,6 +50712,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics O2 Tank"
+	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "cvT" = (
@@ -50796,6 +50730,9 @@
 "cvV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Air Tank"
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -51484,11 +51421,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -51750,6 +51682,7 @@
 /area/engine/engineering)
 "cyo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cyp" = (
@@ -51773,32 +51706,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cyu" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cyv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 1;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
-	pixel_y = -28
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering Center";
 	dir = 1;
@@ -51806,23 +51717,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cyw" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cyx" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cyy" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cyA" = (
@@ -52136,41 +52033,43 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cza" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "czd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cze" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52182,36 +52081,18 @@
 "czf" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/space/nearstation)
 "czg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "czh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"czi" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/airlock_painter,
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -52329,6 +52210,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "czy" = (
@@ -52342,6 +52228,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -52497,89 +52386,99 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czN" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"czP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"czP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "czQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"czR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"czR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "czS" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"czT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Particle Accelerator";
-	network = list("SS13","Singularity")
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"czU" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"czV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"czU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"czV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52596,8 +52495,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/engivend,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czZ" = (
@@ -52680,6 +52579,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cAk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cAl" = (
@@ -52773,164 +52675,107 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cAx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cAy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAz" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAA" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAC" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAD" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cAE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cAF" = (
-/obj/structure/particle_accelerator/end_cap,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cAG" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cAH" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cAI" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cAJ" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAK" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cAL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cAN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52992,6 +52837,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cAV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "cAZ" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -53037,11 +52895,22 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cBi" = (
-/obj/machinery/door/airlock/abandoned{
-	name = "Observatory Access"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "cBj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -53052,10 +52921,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cBk" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cBl" = (
@@ -53107,92 +52987,80 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cBr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = -32
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cBs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 24;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBu" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -24;
-	req_access_txt = "11"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBv" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBw" = (
-/obj/structure/particle_accelerator/fuel_chamber,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Filter"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBx" = (
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = -24;
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBy" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 24;
-	req_access_txt = "11"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cBz" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -24;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53243,9 +53111,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cBJ" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "cBK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -53348,36 +53223,40 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cBV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBW" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBX" = (
-/obj/structure/particle_accelerator/power_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cBY" = (
-/obj/item/screwdriver,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cCa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -53411,19 +53290,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cCh" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/port_engineering)
 "cCi" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/closed/wall/r_wall,
+/area/engine/port_engineering)
 "cCj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "cCk" = (
@@ -53527,73 +53406,60 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cCy" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cCz" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/rad_collector{
-	anchored = 1
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cCA" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/item/tank/internals/plasma{
-	anchored = 0
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCB" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cCC" = (
-/obj/structure/particle_accelerator/particle_emitter/left,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm/engine{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cCD" = (
-/obj/structure/particle_accelerator/particle_emitter/center,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cCE" = (
-/obj/structure/particle_accelerator/particle_emitter/right,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Gas to Chamber"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cCF" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cCG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cCH" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/closet/emcloset{
-	anchored = 1
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cCH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53648,16 +53514,20 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "cCQ" = (
-/obj/structure/table,
-/obj/item/device/taperecorder,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "cCR" = (
-/obj/structure/table,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/port_engineering)
 "cCS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -53767,6 +53637,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDd" = (
@@ -53780,6 +53655,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDe" = (
@@ -53791,6 +53671,9 @@
 	},
 /obj/item/storage/firstaid/fire,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDf" = (
@@ -53814,37 +53697,38 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cDi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cDj" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cDk" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	locked = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
 	},
-/obj/item/wirecutters,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cDl" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cDn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -53859,9 +53743,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDp" = (
@@ -53979,110 +53861,82 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cDE" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cDF" = (
 /obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cDG" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cDH" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space/nearstation)
 "cDJ" = (
-/obj/machinery/power/grounding_rod,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity North-West";
-	network = list("Singularity","SS13")
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cDK" = (
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cDL" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cDM" = (
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cDN" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Cooling Loop"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cDN" = (
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cDO" = (
-/obj/machinery/power/grounding_rod,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity North-East";
-	network = list("Singularity","SS13")
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cDS" = (
 /obj/structure/closet/emcloset,
@@ -54151,76 +54005,64 @@
 	},
 /area/engine/gravity_generator)
 "cEb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cEc" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEd" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEe" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cEf" = (
+/obj/machinery/power/supermatter_shard/crystal/engine,
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cEg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cEg" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cEh" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEi" = (
-/obj/item/wrench,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEj" = (
 /obj/machinery/light/small{
@@ -54303,90 +54145,63 @@
 	name = "floor"
 	},
 /area/engine/gravity_generator)
-"cEs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cEt" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	icon_state = "emitter";
-	state = 2
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space/nearstation)
 "cEu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cEv" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEy" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cEz" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	icon_state = "emitter";
-	state = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cEA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEC" = (
 /obj/structure/sign/warning/securearea,
@@ -54483,56 +54298,56 @@
 	},
 /area/engine/gravity_generator)
 "cEK" = (
-/obj/item/device/multitool,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cEL" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cooling Loop to Gas"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEM" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEN" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Gas to Mix"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEP" = (
 /obj/structure/transit_tube/curved{
@@ -54621,49 +54436,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"cFa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cFb" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cFc" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cFd" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/space/basic,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cFe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cFf" = (
 /obj/structure/transit_tube/curved/flipped,
@@ -54683,22 +54483,29 @@
 /area/engine/gravity_generator)
 "cFj" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cFk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "cFl" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cFm" = (
 /obj/structure/transit_tube/junction/flipped{
 	dir = 1
@@ -54725,47 +54532,23 @@
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"cFr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cFs" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 6
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cFt" = (
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cFu" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cFv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cFw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -54789,24 +54572,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"cFA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cFB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cFC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cFD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	icon_state = "intact";
@@ -54899,23 +54664,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"cFR" = (
-/obj/item/device/radio,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cFS" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cFT" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -55015,35 +54763,16 @@
 "cGe" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/space/nearstation)
 "cGg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cGh" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/obj/structure/girder,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGj" = (
 /obj/structure/window/reinforced{
@@ -55103,58 +54832,25 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
-"cGs" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity South-West";
-	dir = 1;
-	network = list("Singularity","SS13")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cGt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/wrench,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGu" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cGw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGx" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity South-East";
-	dir = 1;
-	network = list("Singularity","SS13")
-	},
-/turf/open/floor/plating/airless,
+/obj/item/crowbar/large,
+/obj/structure/rack,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGy" = (
 /obj/structure/window/reinforced,
@@ -55233,10 +54929,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cGJ" = (
-/obj/machinery/light,
-/turf/open/space/basic,
-/area/engine/engineering)
 "cGK" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -57929,6 +57621,22 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cLV" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "cNs" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -57950,6 +57658,87 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cQC" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Toxins Tank"
+	},
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
+"cQZ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"cUs" = (
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engine/engineering";
+	dir = 1;
+	name = "Engineering APC";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Port Engineering Power Storage";
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"cUz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"cWP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"cXm" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"cXR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"day" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"ddh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "deA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57958,6 +57747,11 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"dfP" = (
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "dlH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57971,12 +57765,67 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"dmH" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"dns" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"dnt" = (
+/obj/structure/table,
+/obj/item/device/flashlight{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "dnH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
+"doB" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/lighter,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"dpb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"drq" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "duc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57985,6 +57834,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"dwL" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"dxg" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"dxK" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity South-West";
+	dir = 4;
+	network = list("Singularity","SS13")
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "dyK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57992,6 +57862,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"dBI" = (
+/obj/machinery/power/grounding_rod,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"dCf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "dCk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -58001,6 +57881,101 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dEi" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dFw" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai_upload)
+"dGM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"dIF" = (
+/obj/structure/reflector/box/anchored{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"dLx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"dMV" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dNC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"dNP" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"dPZ" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics N2O Tank"
+	},
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
+"dSw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dTm" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -58008,12 +57983,51 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"dYn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"dYS" = (
+/obj/structure/reflector/single/anchored{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"eca" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"eeb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"eeO" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity North-East";
+	dir = 8;
+	network = list("Singularity","SS13")
+	},
+/obj/machinery/power/grounding_rod,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "efu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -58035,6 +58049,29 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"eoL" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"eqR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "eqV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -58045,6 +58082,55 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"eyc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"eyl" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"eBA" = (
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 2;
+	network = list("engine");
+	pixel_x = 23
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"eGr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"eHF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
 "eMT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58053,23 +58139,60 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eOD" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"ePF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "eRY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"eSY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"eUC" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Bypass"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
+"eVs" = (
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "eYb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -58078,6 +58201,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"eYB" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
+/area/engine/port_engineering)
 "eYX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -58093,6 +58220,29 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"eZY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"fau" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "faW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58106,10 +58256,36 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fcS" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "ffe" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fho" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"fhA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
+"fim" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "fiw" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58131,6 +58307,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"fnZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"fqS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "frE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58143,6 +58341,53 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"fuh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"fyu" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"fDt" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"fGt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "fHK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -58165,12 +58410,48 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"fUH" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"fUK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"fZx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"fZV" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gdI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gdP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "gfP" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -58183,6 +58464,45 @@
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/hallway/secondary/service)
+"ggR" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"gib" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"giH" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"gmh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"gmI" = (
+/obj/structure/table,
+/obj/item/book/manual/engineering_particle_accelerator,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "goo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -58193,6 +58513,23 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"gqI" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"grx" = (
+/obj/machinery/the_singularitygen/tesla,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "gsF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/floorgrime,
@@ -58203,6 +58540,23 @@
 	},
 /turf/open/floor/plasteel/arrival,
 /area/engine/atmos)
+"gzb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gBw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
@@ -58228,6 +58582,66 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gEC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"gFd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"gFK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"gIn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"gIr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"gSG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gWR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -58236,6 +58650,59 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gXP" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"gZj" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"gZB" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hba" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"hdv" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hfe" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/port/aft)
+"hgw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "hhz" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel/hydrofloor,
@@ -58251,6 +58718,31 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"hka" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hkb" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hmI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -58266,6 +58758,59 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hoK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"hoQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"hsR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"htW" = (
+/obj/machinery/light/small{
+	dir = 1;
+	flickering = 1
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hwl" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/tool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"hwn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "hwV" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
@@ -58274,6 +58819,12 @@
 	dir = 4
 	},
 /area/engine/atmos)
+"hyh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "hyo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58301,20 +58852,63 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"hDK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"hEo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"hEt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
+"hED" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hFg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "hJk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hJr" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"hJw" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hLq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58330,6 +58924,32 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/forge)
+"hNn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Output Release";
+	open = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"hPf" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"hQn" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity South-East";
+	dir = 8;
+	network = list("Singularity","SS13")
+	},
+/obj/machinery/power/grounding_rod,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "hUj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58346,10 +58966,59 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"iby" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"icl" = (
+/obj/item/device/multitool,
+/turf/open/space/basic,
+/area/engine/port_engineering)
+"ieB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Port Engineering";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "ify" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"imZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "iof" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -58358,6 +59027,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ipi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"ipu" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "ipS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58380,6 +59069,37 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"iug" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"ivA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"ivW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"iyD" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "iza" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -58388,6 +59108,19 @@
 	dir = 6
 	},
 /area/engine/atmos)
+"izC" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "izE" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -58396,18 +59129,92 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iAS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"iBi" = (
+/obj/machinery/camera{
+	c_tag = "Particle Accelerator";
+	dir = 8;
+	network = list("SS13","Singularity")
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "iBJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iEz" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"iFp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"iFO" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"iKH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "iLq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iLK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"iTx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	flickering = 1
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "iUv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58418,6 +59225,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iXV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"iZb" = (
+/obj/machinery/power/tesla_coil,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"iZv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "iZN" = (
 /obj/machinery/light{
 	dir = 4
@@ -58428,6 +59272,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jgL" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"jhK" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "jig" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58440,6 +59301,22 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"jjf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jjk" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "jjM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -58451,6 +59328,64 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"jon" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"jrq" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jsa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jsP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jwc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jxj" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jxZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -58481,6 +59416,44 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jAo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jDj" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"jEw" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"jGE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "jGJ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -58490,12 +59463,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"jHG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"jIH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"jND" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "jOR" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jTb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jUQ" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "jYo" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
@@ -58511,6 +59522,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"keK" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"kfK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"klU" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"kmg" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"knd" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "koh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58519,10 +59574,42 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"kpZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kqn" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"krk" = (
+/obj/structure/closet/emcloset,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Port Engineering Foyer";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"kvn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kwC" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -58536,21 +59623,145 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"kON" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"kBb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"kJK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to Loop"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"kON" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"kTC" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity North-West";
+	dir = 4;
+	network = list("Singularity","SS13")
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"kVT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/engine/port_engineering)
+"kWH" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"kYh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"kYE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"kYV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "PortEngineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"kZZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lcD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Storage";
+	req_access_txt = "11"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"leU" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "lfl" = (
 /turf/open/floor/plasteel/caution{
 	dir = 6
 	},
 /area/hallway/primary/aft)
+"lit" = (
+/obj/machinery/power/emitter,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "liA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58560,6 +59771,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ljG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"lnJ" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"lpx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space/nearstation)
 "lrb" = (
 /obj/machinery/light{
 	dir = 8
@@ -58569,6 +59801,29 @@
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/hallway/secondary/service)
+"lsm" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"lum" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"lvb" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lxO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/bodycontainer/morgue{
@@ -58576,6 +59831,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"lyM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lzk" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -58585,6 +59846,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lBs" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"lCQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"lFf" = (
+/obj/structure/table,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/ointment,
+/obj/item/storage/inflatable,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"lFD" = (
+/obj/structure/closet/cardboard,
+/obj/machinery/light/small{
+	dir = 1;
+	flickering = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lIp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58592,12 +59886,53 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"lJf" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lJD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"lKd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"lLq" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"lLt" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "lLW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 2
@@ -58607,6 +59942,79 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"lQA" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"lRe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
+"lSk" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/space)
+"lUc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"lUA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"lVq" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"lYW" = (
+/obj/structure/reflector/single/anchored{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"lZA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"lZN" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "maQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58619,15 +60027,106 @@
 	},
 /turf/open/floor/plating,
 /area/security/vacantoffice)
+"mee" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"meC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"meH" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mga" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"mkS" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"mlU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"mmp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mpy" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"mvb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "mvx" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Waste Tank"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"mzq" = (
+/obj/item/wirecutters,
+/turf/open/space/basic,
+/area/engine/port_engineering)
+"mBf" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "mBg" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -58649,6 +60148,48 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mEa" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 4;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("Singularity");
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"mEv" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"mGZ" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics CO2 Tank"
+	},
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
+"mJX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mKE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "mLO" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -58659,12 +60200,49 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"mNz" = (
+/obj/structure/particle_accelerator/particle_emitter/right{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"mOP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mQv" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"mUC" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "mXB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"mXX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"mYc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mYi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
@@ -58672,6 +60250,15 @@
 	},
 /turf/open/floor/noslip,
 /area/maintenance/forge)
+"mYt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "nav" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -58680,6 +60267,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ncA" = (
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"nfo" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"nfy" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"nhj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "nhZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58692,16 +60309,83 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nkz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "nmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nmD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"nqz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"nsj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"nsr" = (
+/obj/machinery/field/generator,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"nsQ" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "ntM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"nvr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"nyM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "nzH" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -58710,6 +60394,15 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nFo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nGy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58718,6 +60411,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nHy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"nHB" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "nId" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -58725,6 +60431,20 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"nKF" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "nLd" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -58745,6 +60465,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"nNq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nOw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58767,6 +60496,29 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
+"nSR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/science/storage)
+"nTb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"nTN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "nYN" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58787,12 +60539,54 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
+"nZG" = (
+/obj/structure/closet/radiation,
+/obj/machinery/camera{
+	c_tag = "Port Engineering South";
+	dir = 2
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "oaV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"obw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oht" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"oln" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/emitter/anchored,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"olo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "omf" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
@@ -58801,16 +60595,62 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"omM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oov" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
 "otB" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/folder/blue,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"oua" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/camera{
+	c_tag = "Port Engineering Secure Storage";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"ouE" = (
+/obj/item/weldingtool,
+/turf/open/space/basic,
+/area/engine/port_engineering)
 "ouX" = (
 /obj/machinery/droneDispenser,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"ozL" = (
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"oAG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "oAY" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -58831,6 +60671,10 @@
 	dir = 8
 	},
 /area/medical/sleeper)
+"oFj" = (
+/obj/structure/reflector/box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "oFI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58840,6 +60684,16 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/science/mixing)
+"oGE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "oHr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -58856,6 +60710,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"oLV" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engine/port_engineering)
+"oPn" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "oPL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58867,25 +60737,120 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/forge)
+"oQZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"oSu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"oTS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oUf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"oUp" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"oUK" = (
+/turf/closed/wall/r_wall,
+/area/engine/port_engineering)
+"oYI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "oZh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/construction)
+"oZQ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"paC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"pcA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "pcU" = (
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
 /area/hallway/primary/aft)
+"peq" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"pgL" = (
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "pjv" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -58896,6 +60861,17 @@
 /obj/structure/guillotine,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"pkQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "plb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -58904,6 +60880,48 @@
 	dir = 6
 	},
 /area/engine/atmos)
+"pmn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"ppc" = (
+/obj/structure/closet/firecloset,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"pqD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"prV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "pvf" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58911,6 +60929,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pxN" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"pyl" = (
+/obj/structure/reflector/double/anchored{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"pBd" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pCL" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -58918,17 +60960,87 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"pDe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pGR" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"pGX" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "pHm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"pNC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"pPx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"pRd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Output to Waste"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"pSL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"pWN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "pYl" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -58941,12 +61053,90 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"qbk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"qcg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"qeo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "qeU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"qhG" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"qir" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"qmo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"qoi" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 4;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("Singularity");
+	pixel_x = -27
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"qrY" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"qtI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "qwO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58956,6 +61146,68 @@
 	dir = 2
 	},
 /area/hallway/secondary/entry)
+"qwV" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"qyT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"qFn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"qGt" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"qIQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"qKX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/caution/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "qNr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58964,6 +61216,19 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"qOZ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"qSW" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "raY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58982,6 +61247,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rde" = (
+/turf/open/space,
+/area/engine/port_engineering)
+"rdB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"rdO" = (
+/turf/open/space/basic,
+/area/engine/port_engineering)
 "rfM" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -58992,6 +61267,15 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
+"riN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rkg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59003,6 +61287,44 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"rpv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"rue" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"rvj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"rBH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "rCG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -59024,12 +61346,28 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"rEI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "rIm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/science/circuit)
+"rIp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rJR" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -59042,6 +61380,122 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rMv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"rNB" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"rOb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"rOt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"rQg" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"rSk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"rTU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"rVh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"rXs" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"rYX" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"rZX" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"shd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "skx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59065,10 +61519,78 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"smP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "spz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"srQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"ssU" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"stg" = (
+/obj/machinery/computer/station_alert,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"stN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sxo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "PortEngineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "szP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59084,6 +61606,25 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"sBg" = (
+/obj/machinery/computer/shuttle/pod{
+	pixel_y = -32;
+	possible_destinations = "pod_lavaland4";
+	shuttleId = "pod4"
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/space)
+"sBj" = (
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "sDt" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -59093,29 +61634,136 @@
 	dir = 5
 	},
 /area/engine/atmos)
+"sDX" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 25
+	},
+/obj/item/storage/pod{
+	pixel_x = 6;
+	pixel_y = -32
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/blue,
+/area/space)
 "sEo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
+"sFQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sHO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sIg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sJq" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sKc" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"sMk" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "11"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sNr" = (
+/obj/structure/rack,
+/obj/item/device/flashlight/flare,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "sOH" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"sXO" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+"sOM" = (
+/obj/structure/closet/wardrobe/black,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"sPv" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"sPA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sRu" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/emitter/anchored{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sSz" = (
+/obj/structure/particle_accelerator/power_box{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"sTo" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"sXO" = (
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sZz" = (
 /obj/structure/cable{
@@ -59126,24 +61774,206 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"taq" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"tbT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"tcz" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"tcT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "tcZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tdK" = (
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"tes" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "teP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"tjo" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"tjD" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tkN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
+"tkO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"tmE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"tqz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"trP" = (
+/obj/machinery/light/small,
+/obj/machinery/field/generator,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"tta" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"twn" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/port_engineering)
+"twq" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"txC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"tEM" = (
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "tFb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/blue/side{
 	dir = 10
 	},
 /area/engine/atmos)
+"tFA" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tFV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"tJH" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"tJZ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "tNL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59151,27 +61981,78 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tOI" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
+"tSY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "tVk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tWk" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "tWn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tXn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Gas"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"uet" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Aft";
+	dir = 2;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"ufc" = (
+/obj/item/crowbar,
+/turf/open/space/basic,
+/area/engine/port_engineering)
 "uio" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -59181,12 +62062,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"uoq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uoH" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side,
 /area/engine/atmos)
+"uqb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"uqR" = (
+/obj/structure/table,
+/obj/item/book/manual/engineering_singularity_safety,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "urE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -59195,6 +62095,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"uxp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"uyE" = (
+/obj/item/device/radio,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "uIT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59204,6 +62117,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uJG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"uJZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "uKV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59212,6 +62140,49 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"uLQ" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/belt/utility,
+/obj/effect/turf_decal/bot,
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "PortEngineering";
+	name = "Port Engineering External Lockdown";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"uMY" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
+"uOy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"uOE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/storage/belt/utility,
+/obj/structure/rack,
+/obj/item/device/multitool,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "uPH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -59225,6 +62196,22 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"uPT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"uRY" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"uWW" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "uXr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -59240,6 +62227,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"uYC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
 "uZm" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
@@ -59248,12 +62245,37 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/maintenance/department/electrical)
+"vcj" = (
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"vcY" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "vdn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"vdN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "vfA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -59269,6 +62291,50 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vkT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"vna" = (
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/kitchen/knife,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vpg" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"vqC" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
+/area/space)
+"vsf" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"vsC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "vtk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -59277,6 +62343,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vuq" = (
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage 2";
+	name = "Secure Storage";
+	pixel_x = 24;
+	req_access_txt = "11"
+	},
+/obj/machinery/camera{
+	c_tag = "Port Engineering Central";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "vwF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -59297,6 +62382,102 @@
 	name = "floor"
 	},
 /area/engine/gravity_generator)
+"vxM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"vza" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"vCA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"vGx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"vJD" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8;
+	filter_type = "n2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"vLZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"vOl" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"vSN" = (
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_carp{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"vTj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"vUb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vWT" = (
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"vYe" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "wae" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59316,6 +62497,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"waY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"wip" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"wjs" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
+"wjF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"wka" = (
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "wkE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -59330,6 +62549,77 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wmy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"wom" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"wql" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "11"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"wqy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
+"wrg" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/item/kitchen/fork,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"wrm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "wsz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -59357,6 +62647,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"wzO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "wAS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59366,10 +62664,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wAW" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "wBK" = (
 /obj/item/stack/rods,
 /turf/open/space,
 /area/space/nearstation)
+"wHe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "wIF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -59386,11 +62715,121 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"wPw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "Secure Storage 2";
+	name = "secure storage"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"wPy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"wPz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"wPU" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/obj/docking_port/mobile/pod{
+	dir = 4;
+	id = "pod4";
+	name = "escape pod 4";
+	port_direction = 2;
+	preferred_direction = 4;
+	timid = 0
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/space)
+"wUa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/device/geiger_counter,
+/obj/item/device/geiger_counter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"wUI" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"wWR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/storage/tech)
+"wYv" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"xba" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"xdn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "PortEngineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "xfx" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"xgB" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/camera{
+	c_tag = "Port Engineering North";
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "xil" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59398,6 +62837,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xit" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"xjp" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/port_engineering)
+"xjH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
+"xjM" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xkm" = (
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_x = -32
@@ -59419,6 +62882,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xoE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xpF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -59430,12 +62903,61 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"xsT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"xur" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"xBe" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"xBh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "xBF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/arrival{
 	dir = 10
 	},
 /area/engine/atmos)
+"xDw" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space/nearstation)
 "xDY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59443,21 +62965,75 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xFG" = (
+"xGk" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
+"xHg" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"xIc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"xII" = (
+/obj/structure/cable/yellow,
+/obj/machinery/particle_accelerator/control_box{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"xJc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/science/research)
 "xJp" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
+"xJZ" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"xOu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/device/flashlight,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xRG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59476,6 +63052,56 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hallway/secondary/service)
+"xWR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"xYc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"xYs" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
+"xZi" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"xZF" = (
+/obj/structure/table,
+/obj/item/storage/inflatable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 "yah" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59490,9 +63116,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"yee" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/port_engineering)
 "yeg" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
+"yhF" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"yig" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/port_engineering)
+"yjb" = (
+/obj/machinery/power/tesla_coil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/engine/port_engineering)
 
 (1,1,1) = {"
 aaa
@@ -72022,16 +75679,16 @@ aaa
 aaa
 aaa
 aaa
+aae
+aae
+aae
+aae
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
 aaa
 aaa
 aaa
@@ -72278,18 +75935,18 @@ aaa
 aaa
 aaa
 aaa
+aad
+aad
+aad
+aad
+aad
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aad
+aad
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -72527,31 +76184,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
+aaj
 aaa
 aaa
 aaa
@@ -72784,31 +76441,31 @@ aaa
 aaa
 aaa
 aaa
+aaj
+aad
+aad
+aad
 aaa
 aaa
 aaa
 aaa
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aad
+aad
+aaj
 aaa
 aaa
 aaa
@@ -73041,31 +76698,31 @@ aaa
 aaa
 aaa
 aaa
+aaj
 aaa
+aad
+aad
+aad
+hJw
+hJw
+hJw
+hJw
+vqC
+hJw
+hJw
+hJw
+hJw
+hJw
+vqC
+hJw
+hJw
+hJw
+hJw
+aad
+aad
+aad
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -73298,31 +76955,31 @@ aaa
 aaa
 aaa
 aaa
+aaj
 aaa
 aaa
+aad
+hJw
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+hJw
+aad
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -73555,31 +77212,31 @@ aaa
 aaa
 aaa
 aaa
+aaj
 aaa
+oUK
+oUK
+oUK
+oUK
+ncA
+twn
+twn
+twn
+twn
+rdO
+kVT
+rdO
+rdO
+twn
+twn
+twn
+ncA
+oUK
+oUK
+oUK
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -73812,31 +77469,31 @@ aaa
 aaa
 aaa
 aaa
+aaj
 aaa
+oUK
+iFO
+uyE
+kTC
+dBI
+ncA
+ncA
+ncA
+ncA
+dBI
+ncA
+dBI
+ncA
+ncA
+ncA
+ncA
+dBI
+dxK
+ncA
+iFO
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -74069,31 +77726,31 @@ aaX
 aaX
 aaF
 aaX
-aaX
+aak
 aaa
+oUK
+iFO
+ncA
+rdO
+ncA
+rQg
+sPA
+sPA
+sPA
+sPA
+sPA
+sPA
+sPA
+sPA
+sPA
+sJq
+ncA
+twn
+ncA
+iFO
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -74326,31 +77983,31 @@ aaa
 aai
 aaa
 aaa
-aaX
+aak
 aaa
+oUK
+nfo
+oln
+rdO
+ncA
+qhG
+eVs
+oLV
+oLV
+oLV
+oLV
+eVs
+oLV
+oLV
+eVs
+ckD
+ncA
+twn
+sRu
+vLZ
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -74583,33 +78240,33 @@ rfM
 rfM
 rfM
 aai
-aaX
+aak
 aaa
+oUK
+mYt
+ncA
+twn
+pGX
+iZb
+oLV
+rde
+ufc
+rdO
+rdO
+twn
+rdO
+rdO
+oLV
+yjb
+xsT
+twn
+ncA
+mYt
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aac
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -74840,33 +78497,33 @@ oAY
 oAY
 eqV
 aaa
-aaX
+aak
 aaa
+oUK
+tJZ
+vLZ
+twn
+vOl
+eGr
+oLV
+rdO
+twn
+twn
+twn
+twn
+twn
+rdO
+oLV
+dLx
+jIH
+twn
+nfo
+uxp
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -75097,33 +78754,33 @@ nYN
 nYN
 nYN
 aai
-aaX
+aak
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oUK
+oUK
+mYt
+twn
+nTb
+qhG
+eVs
+twn
+twn
+oQZ
+gib
+nhj
+twn
+rdO
+oLV
+wPz
+jIH
+twn
+mYt
+oUK
+oUK
+aad
+aaj
+aad
+aag
 aaa
 aaa
 aaa
@@ -75354,33 +79011,33 @@ aai
 aaa
 aaa
 aaa
-aaF
+aak
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eYB
+oUK
+olo
+twn
+vOl
+eGr
+oLV
+rdO
+twn
+ckD
+oht
+fUK
+twn
+rdO
+oLV
+dLx
+jIH
+twn
+eeb
+oUK
+eYB
+aad
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -75611,33 +79268,33 @@ rfM
 rfM
 rfM
 aai
-aaX
+aak
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oUK
+oUK
+mYt
+twn
+vOl
+iZb
+oLV
+rdO
+twn
+lUc
+grx
+yig
+twn
+twn
+eVs
+ckD
+nTb
+icl
+mYt
+oUK
+oUK
+aad
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -75868,33 +79525,33 @@ oAY
 oAY
 eqV
 aaa
-aaX
+aak
 aaa
+oUK
+nfo
+uxp
+twn
+vOl
+eGr
+oLV
+mzq
+twn
+twn
+twn
+twn
+twn
+rdO
+oLV
+dLx
+jIH
+twn
+tJZ
+vLZ
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -76125,33 +79782,33 @@ nYN
 nYN
 nYN
 aai
-aaX
+aak
 aaa
+oUK
+mYt
+ncA
+rdO
+vOl
+iZb
+oLV
+rdO
+rdO
+twn
+rdO
+rdO
+rdO
+ouE
+oLV
+yjb
+jIH
+twn
+ncA
+mYt
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aFi
 aaa
 aaa
 aaa
@@ -76382,33 +80039,33 @@ aai
 aaa
 aaa
 aaa
-aaX
+aak
 aaa
+oUK
+xHg
+oln
+rdO
+nTb
+qhG
+eVs
+oLV
+oLV
+eVs
+oLV
+oLV
+oLV
+oLV
+eVs
+ckD
+nTb
+twn
+sRu
+hsR
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aFi
 aaa
 aaa
 aaa
@@ -76639,33 +80296,33 @@ cld
 cld
 cld
 aai
-aaX
+aak
 aaa
+oUK
+mYt
+ncA
+rdO
+oZQ
+kmg
+beQ
+beQ
+beQ
+beQ
+fGt
+beQ
+beQ
+beQ
+beQ
+hED
+ljG
+rdO
+ncA
+mYt
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -76896,33 +80553,33 @@ cuE
 cuE
 cyf
 aaa
-aaX
+aak
 aaa
+oUK
+tJZ
+wzO
+eeO
+ncA
+ncA
+dBI
+cQZ
+cQZ
+cQZ
+mkS
+cQZ
+cQZ
+cQZ
+dBI
+ncA
+ncA
+hQn
+uWW
+uxp
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
+aad
+aae
 aaa
 aaa
 aaa
@@ -77153,31 +80810,31 @@ clf
 clf
 clf
 aai
-aaX
+aak
 aaa
+oUK
+oUK
+pWN
+oUK
+cQZ
+cQZ
+cQZ
+cQZ
+rYX
+fUH
+wUI
+mEv
+mEv
+cQZ
+cQZ
+cQZ
+cQZ
+oUK
+pWN
+oUK
+oUK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -77406,35 +81063,35 @@ csl
 aaa
 aaa
 aai
+aaj
+aak
+aaj
+aaj
+aak
 aaa
-aai
-aaa
-aaa
-aaX
+oUK
+gZB
+stN
+oUK
+hka
+hka
+hka
+cQZ
+nTb
+drq
+giH
+mNz
+ncA
+cQZ
+hka
+hka
+hka
+oUK
+stN
+cXm
+oUK
 aad
-aad
-aad
-aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -77664,34 +81321,34 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aaj
-aaj
-aaj
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+nqz
+oUK
+mga
+mga
+mga
+oUK
+iTx
+dxg
+sSz
+ncA
+ncA
+oUK
+mga
+mga
+mga
+oUK
+nqz
+oUK
+oUK
 aad
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaj
 aaa
 aaa
 aaa
@@ -77920,35 +81577,35 @@ csn
 cpR
 aaa
 aai
-aai
-aaa
-aaa
-aaa
-aaa
-aad
+aak
+oUK
+stg
+tes
+mEa
+hJr
+oUK
+xgB
+cUz
+kfK
+hgw
+hgw
+meC
+oUK
+wql
+xII
+pgL
+uRY
+sMk
+oUK
+lZN
+xBh
+hgw
+kfK
+fau
+sNr
+oUK
 aad
 aaj
-aad
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78177,37 +81834,37 @@ cso
 cpR
 aaa
 aaa
-aai
-aai
+aak
+oUK
+ozL
+dNC
+nkz
+xZF
+hPf
+iby
+smP
+cAV
+lLt
+qwV
+leU
+xWR
+gdP
+xsT
+fho
+pGX
+tcT
+xWR
+gIn
+wom
+qyT
+yee
+qmo
+uLQ
+oUK
 aaa
-aaa
-aaa
-aaa
-aad
 aaj
 aad
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78434,37 +82091,37 @@ csp
 cpR
 cpR
 aaa
-aaa
-aai
-aai
-aaa
-aaa
-aaa
+aaj
+oUK
+oUK
+cUs
+uYC
+uqR
+jGE
+uOE
+oUf
+dns
+dfP
+iug
+iEz
+oUK
+ncA
+nTb
+iBi
+nTb
+ncA
+oUK
+lUA
+dwL
+jND
+dnt
+qmo
+lnJ
+xdn
 aaa
 aaj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aae
 aaa
 aaa
 aaa
@@ -78691,37 +82348,37 @@ csq
 ctA
 cpS
 aaa
-aaa
-aaa
-aai
-aai
-aaa
-aaa
+aaj
+oUK
+tjo
+vGx
+ipu
+uJG
+lcD
+ePF
+tmE
+rpv
+pSL
+nKF
+tbT
+eYB
+oUK
+izC
+oUK
+shd
+oUK
+eYB
+nZG
+rMv
+vSN
+nfy
+xur
+lFf
+kYV
 aaa
 aaj
-aah
+aad
 aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78948,37 +82605,37 @@ csr
 ctB
 cpS
 aaa
-aaa
-aaa
-aaa
-aai
-aai
-aaa
+aaj
+oUK
+gmI
+vGx
+wip
+tkO
+jGE
+kBb
+ivW
+fnZ
+vTj
+lKd
+vdN
+imZ
+oYI
+eqR
+qoi
+rTU
+vcY
+oGE
+rOt
+pkQ
+yee
+yee
+wHe
+dNP
+sxo
 aaa
 aaj
-aaa
 aad
-aad
-aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -79206,36 +82863,36 @@ ctC
 cpS
 aak
 aak
-aak
+oUK
+eOD
+lsm
+day
+taq
+mQv
+hwl
+jEw
+ipi
+uJZ
+wmy
+mlU
+wAW
+mlU
+mlU
+mlU
+mlU
+mlU
+vxM
+mlU
+mlU
+mlU
+mlU
+iZv
+gqI
+oUK
+aad
 aaj
-aaj
-aak
-aak
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aae
 aaa
 aaa
 aaa
@@ -79463,35 +83120,35 @@ cpS
 cpS
 bJS
 cwt
-bJS
-aaa
-aaa
-aaa
-aai
-aai
-aaa
-aaa
-aad
-aad
-aad
+oUK
+xjp
+uPT
+qIQ
+xit
+oUK
+gEC
+cLV
+pPx
+vkT
+kYh
+dmH
+xYs
+fyu
+paC
+paC
+vuq
+srQ
+hFg
+cWP
+klU
+paC
+paC
+tFV
+iyD
+oUK
 aad
 aaj
-aae
-aae
-aae
 aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -79720,35 +83377,35 @@ bQG
 cuF
 bJS
 cwu
-bJS
-aaa
-aaa
-aaa
-aaa
-aai
-aai
-aaa
-aaa
-aaa
-aaa
+hfe
+hfe
+qir
+hfe
+hfe
+oUK
+gmh
+prV
+rVh
+lZA
+lZA
+oUK
+oUK
+oUK
+wPw
+wPw
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+tWk
+oUK
+oUK
+oUK
 aad
 aaj
 aad
-aad
-aah
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -79978,33 +83635,33 @@ car
 bJS
 cwv
 bJS
+sOM
+bQG
+cCg
+hfe
+ppc
+hba
+iFp
+qFn
+qeo
+lVq
+oUK
+oht
+ncA
+ncA
+ncA
+lit
+lit
+nsr
+oUK
+aaa
+oUK
+ncA
+nHB
+oUK
 aaa
 aaa
-aai
-aaa
-bJS
-bJS
-ctD
-ctD
-ctD
-aaa
-aad
 aaj
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-aaa
-aah
-aae
-aae
-aae
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -80235,33 +83892,33 @@ bQG
 cvs
 bQG
 bJS
-ctD
-ctD
-ctD
-ctD
-bJS
-ctE
-cCg
+lFD
+wrg
+vna
+hfe
+krk
+ssU
+hwn
 cCQ
-ctD
+vcj
+tEM
+oUK
+htW
+ncA
+ncA
+hdv
+lit
+nsr
+trP
+oUK
 aaa
-aad
+oUK
+gZj
+oUK
+oUK
+aaa
+aaa
 aaj
-amB
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aae
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -80486,39 +84143,39 @@ cnF
 cpd
 cpT
 cri
-bXQ
-bQG
-bQG
-bQG
-bQG
-bQG
-bQG
-bQG
-bQG
-bQG
+fDt
+mOP
+mOP
+mOP
+mOP
+oPn
+mOP
+doB
+mOP
+jhK
 cBi
-bQG
+nyM
 cCh
 cCR
-ctD
+oUK
+oUK
+oUK
+wka
+vYe
+oUp
+oua
+lit
+nsr
+nsr
+oUK
 aaa
 aaa
 aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aad
-aae
 aaa
 aaa
 aaa
+aaa
+aaj
 aaa
 aaa
 aaa
@@ -80749,33 +84406,33 @@ bJS
 bJS
 vgI
 bJS
-ctD
-ctD
-ctD
-ctD
 bJS
+bJS
+bJS
+hfe
+fqS
 cBJ
 cCi
-bQF
-ctD
 aaa
 aaa
 aaa
-aad
-aad
-aad
-aad
-aaa
-aaa
-aaa
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
+oUK
 aaa
 aad
 aaj
-aad
-aaa
-aaa
-aaa
-aaa
+aaj
+aaj
+aaj
+aaj
+aaj
 aaa
 aaa
 aaa
@@ -81000,28 +84657,28 @@ ckf
 ckf
 ckf
 ckf
-csx
+rOb
 bJS
 bQG
 cvs
 bQG
-bJS
-aaa
-aaa
-aai
-aaa
-bJS
-bJS
-bJS
-bJS
-bJS
+ctD
 aaa
 aaa
 aaa
-aad
-aad
-aad
-aad
+jon
+pxN
+wjF
+cCi
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81257,19 +84914,19 @@ clj
 cpe
 hLV
 ckf
-csx
+rOb
 bJS
 bQG
 bQH
 clg
-bJS
+ctD
 aaa
 aaa
-aai
 aaa
-aaa
-aai
-aai
+jon
+pxN
+wjF
+cCi
 aaa
 cDy
 cDy
@@ -81514,7 +85171,7 @@ cnG
 cpf
 hLV
 ckf
-csx
+rOb
 bJS
 cuG
 cuG
@@ -81524,8 +85181,8 @@ cuG
 cuG
 czv
 cAi
-cAi
-cAi
+ieB
+tkN
 cCj
 cCS
 cCS
@@ -81771,7 +85428,7 @@ cli
 cpg
 cpU
 ckf
-csx
+rOb
 bJS
 cuG
 cvt
@@ -81782,7 +85439,7 @@ cyJ
 czw
 cAj
 cBj
-cuG
+uMY
 cCk
 cCT
 cDy
@@ -82028,7 +85685,7 @@ cnH
 cph
 cpV
 crk
-csx
+rOb
 bJS
 cuG
 cvu
@@ -82542,7 +86199,7 @@ cnI
 mYi
 cpX
 crm
-csx
+rOb
 bJS
 cuG
 cvu
@@ -82799,7 +86456,7 @@ cli
 cpj
 cpY
 ckf
-csx
+rOb
 bJS
 cuG
 cvw
@@ -83056,7 +86713,7 @@ cnJ
 cpf
 oPL
 ckf
-csx
+rOb
 bJS
 cuG
 cuG
@@ -83313,7 +86970,7 @@ cnK
 cpk
 cpZ
 ckf
-csx
+rOb
 ctD
 aai
 aaa
@@ -83570,7 +87227,7 @@ ckg
 ckg
 cqa
 ckf
-csx
+rOb
 bJS
 bJS
 bJS
@@ -83842,20 +87499,20 @@ cBP
 cCr
 qeU
 clH
+aai
+aaa
+aaa
+aai
+aaa
+aaa
+aai
 aaa
 aaa
 aaa
+aai
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -84098,21 +87755,21 @@ cBn
 czh
 cCs
 cDb
-cDD
+clH
+aai
+aaa
+aaa
+aai
+aaa
+aaa
+aai
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aad
+aaE
+aaE
+aaE
+aFi
 aaa
 aaa
 aaa
@@ -84356,20 +88013,20 @@ cyp
 cys
 cDc
 cDE
+aai
+fim
+ggR
+lpx
+ggR
+ggR
+lpx
+mUC
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aad
+aaE
+cGm
+aaE
+aFi
 aaa
 aaa
 aaa
@@ -84612,23 +88269,23 @@ cAs
 cBQ
 cCt
 cDd
-cDF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abf
-abf
-abf
-aad
+cDE
 aak
-aad
-aad
-aad
+vsC
+cDI
+xDw
+lpx
+lpx
+xDw
+cEt
+aai
+aai
+aaE
+cGm
+aaE
+aFi
+aFi
+aFi
 aaa
 aaa
 aad
@@ -84869,25 +88526,25 @@ cyp
 cBR
 cys
 cDe
-cDG
-aaa
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-aaa
-aaa
-abf
-aad
+cDC
 aak
-aaj
-aaj
-aaj
-aaj
-aaj
+vsC
+oSu
+xDw
+ggR
+ggR
+xDw
+jDj
+aaa
+aaa
+aaE
+cGm
+aaE
+aFi
+aFi
+aFi
+aFi
+aFi
 aaj
 aad
 aaa
@@ -85113,11 +88770,11 @@ cdI
 cqe
 clH
 csD
-ctH
+csD
 cuJ
 cvy
-cvy
-cvy
+oFj
+fZV
 clH
 cyV
 mDN
@@ -85126,25 +88783,25 @@ tNL
 cBS
 cCu
 cDf
-cDD
-aaa
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-aad
+clH
+aak
+vsC
+cDI
+xDw
+lpx
+lpx
+xDw
+cEt
 aai
+aai
+aaE
+cGm
+aaE
 aaa
 aaa
-aad
-aad
-aad
+aFi
+aFi
+aFi
 aaj
 aaa
 aaa
@@ -85369,11 +89026,11 @@ cnO
 cdI
 cqe
 clH
-csD
+eoL
 ctJ
 cuK
-cvy
-cvy
+ctJ
+ctJ
 cvz
 clH
 cyW
@@ -85384,24 +89041,24 @@ cBT
 cCv
 cDg
 clH
-aaa
-abf
-abf
-abf
-abf
-abf
-abf
-abf
-aaa
-aaa
-abf
-aaa
-abf
+aak
+vsC
+oSu
+xDw
+ggR
+ggR
+xDw
+mUC
 aaa
 aaa
+aaE
+cGm
+aaE
 aaa
 aaa
-aad
+aaa
+aaa
+aFi
 aaj
 aad
 aaa
@@ -85626,11 +89283,11 @@ cnP
 cdI
 cqe
 clH
+eoL
 ctJ
 ctJ
 ctJ
-cvz
-cvz
+ctJ
 cvz
 clH
 cyX
@@ -85641,24 +89298,24 @@ csF
 csF
 clH
 clH
-clH
-clH
-clH
-clH
-clH
-czf
-clH
-clH
-clH
-clH
-clH
-clH
-clH
-aad
-aad
+aak
+vsC
+cDI
+xDw
+lpx
+lpx
+xDw
+cEt
+aai
+aai
+aaE
+cGm
+aaE
+aFi
+aFi
 aaa
 aaa
-aad
+aFi
 aaj
 aad
 aaa
@@ -85897,25 +89554,25 @@ cBp
 csF
 cCw
 clH
-cDH
-cEb
-cEs
-cEb
-cFa
 clH
-clH
-clH
-cDH
-cEb
-cFa
-cGe
-cGe
-clH
-aaa
-abf
+aak
+vsC
+oSu
+xDw
+ggR
+ggR
+xDw
+mUC
 aaa
 aaa
-aad
+aaE
+cGm
+aaE
+aaa
+aaa
+aai
+aaa
+aFi
 aaj
 aad
 aaa
@@ -86150,29 +89807,29 @@ cyn
 cyZ
 czM
 cAx
-xFG
-tOI
+cvC
+cBU
 cCx
-sXO
+cDh
 cDI
-cDL
+xDw
 cEt
-cDL
-cDQ
-cEb
-cFr
-cEb
-cFe
-cDL
+cDI
+xDw
+lpx
+lpx
+xDw
 cEt
-cDL
-cDL
-clH
-cGe
-abf
-abf
-aaa
+aai
+aai
+aaE
+aaE
+aaE
 aad
+aai
+aai
+aai
+aFi
 aaj
 aad
 aaa
@@ -86407,29 +90064,29 @@ cyo
 cza
 czN
 cAy
-cBr
+cCB
 clH
 clH
 clH
 cDJ
-cDL
+iLK
 cEu
 cEK
-cDL
-cDL
-cDL
-cDL
-cDL
-cFR
 cEu
-cDL
-cGs
-clH
-clH
-cGe
+cEu
+pcA
 aaa
 aaa
-aad
+aaa
+aaa
+aai
+aaa
+aaa
+aaa
+aaa
+aai
+aaa
+aFi
 aaj
 aad
 aaa
@@ -86660,28 +90317,28 @@ cuM
 cvB
 cwC
 ctP
-cyp
+cys
 czb
 czO
 cAz
-cys
-cBV
-cCy
+mJX
+mJX
+mJX
+rIp
+cDK
+omM
+cEv
+xoE
+uoq
+meH
+hDK
+pcA
 clH
-cDK
-cDK
-cEv
-cDK
-cDK
-cDM
-cDK
-cDM
-cDK
-cDK
-cEv
-cDK
-cDK
-cDL
+clH
+clH
+clH
+clH
+clH
 clH
 cGe
 aad
@@ -86888,7 +90545,7 @@ bMu
 bNN
 bPk
 bQM
-bKU
+bRY
 bTh
 bJT
 bVt
@@ -86917,28 +90574,28 @@ cuN
 cvC
 cwD
 ctP
-cyp
+cys
 czc
 czP
 cAA
 cBs
-cBW
-cCz
-cCB
+cBs
+cBs
+cBs
 cDL
-cEc
+cBs
+cBs
+cEL
+cBs
+tqz
+yhF
+czc
+lBs
+sXO
 cEw
-cEL
-cEL
-cEL
-cEL
-cEw
-cEL
-cEL
-cEw
-cEw
+sXO
 cGt
-cEv
+clH
 clH
 cGe
 aad
@@ -87117,12 +90774,12 @@ aZb
 baC
 bcb
 bdT
-bdU
-bgM
-bgM
-bgM
-bgM
-blJ
+blM
+blM
+blM
+blM
+blM
+blM
 bfs
 bfs
 bfs
@@ -87141,11 +90798,11 @@ aNa
 bIN
 bJT
 bKS
-bKU
+oAG
 bNO
 bPl
 bQN
-bKU
+bRZ
 bTi
 bJT
 bVt
@@ -87174,28 +90831,28 @@ cuO
 cvD
 cwE
 yco
-cyq
+pNC
 czd
 czQ
-cAA
-cBs
+rSk
+jrq
 cBW
-cCA
-cCB
-cDL
+cBW
+pmn
+jsa
 cEd
 cEx
 cEM
 cFb
-cEM
-cFb
-cEx
-cFb
-cEM
-cEx
-cGf
-cGu
-cEv
+eZY
+sHO
+qOZ
+rdB
+rdB
+qbk
+sXO
+sXO
+clH
 clH
 cGe
 aai
@@ -87373,13 +91030,13 @@ aXq
 aZc
 baD
 bcc
-bdU
-bdW
+blM
+blM
 bgN
 bhO
 bjl
 bkh
-bdV
+blM
 bnp
 boT
 bqy
@@ -87398,11 +91055,11 @@ aNa
 bIO
 bJT
 bKT
-bKU
+oAG
 bNP
-bPm
+bPi
 bQO
-bRY
+bRZ
 bTj
 bJT
 bVu
@@ -87431,28 +91088,28 @@ cuP
 cvE
 cwF
 cxE
-cyr
-cze
+fZx
+dCf
 czR
 cAB
 cBt
-cBW
+vWT
 cCz
-cCB
+jgL
 cDM
 cEe
 cEy
-aak
-aak
-aaj
-aaj
-cEy
-aak
-aak
-cEy
+gXP
+uqb
+mee
+wPy
+dEi
+mYc
+riN
+sPv
 cGg
 cGu
-cEv
+clH
 clH
 czf
 aai
@@ -87630,20 +91287,20 @@ aXr
 aZd
 baC
 bcd
-bdV
+blM
 bfw
 bfx
 bfx
 bgO
 bki
-blK
-bnq
-boU
-boU
-brY
-boU
-boU
-bwv
+blM
+bnr
+boV
+boV
+boV
+boV
+boV
+boV
 aaa
 bzs
 bAS
@@ -87655,9 +91312,9 @@ aNa
 nGy
 bJT
 bKU
+oAG
 bKU
-bKU
-bPm
+bPi
 bQP
 bRZ
 bTk
@@ -87689,27 +91346,27 @@ csF
 csF
 cxF
 cys
-czf
 clH
+xOu
 cAC
+mmp
+xBe
+cCz
 clH
+eBA
+ivA
+ivA
 clH
+obw
+vJD
+qtI
 cCB
-cCB
-cCB
-cEe
-aaj
-avB
-avB
-aFi
-avB
-aad
-avB
-avB
-aaj
-cGh
-cGv
-cEv
+ctJ
+qSW
+eyl
+eyl
+ctJ
+clH
 clH
 cGe
 abf
@@ -87887,12 +91544,12 @@ aXs
 aZe
 baE
 bce
-bdV
+blM
 bfx
 bfx
 bfx
 bfx
-bfx
+gIr
 blL
 bnr
 boV
@@ -87900,7 +91557,7 @@ bqz
 brZ
 btv
 bva
-bww
+boV
 aaa
 bzs
 bAT
@@ -87912,7 +91569,7 @@ aNa
 jyA
 bJT
 bJT
-bJT
+wWR
 bJT
 bPn
 bJT
@@ -87947,26 +91604,26 @@ cwC
 cxG
 cyt
 clH
-ctJ
-cAD
+jAo
+cAB
 cBu
-czS
-czS
+keK
+clH
 cDi
-cCB
-cEe
-aaj
-avB
-aFi
-aFi
-avB
-aad
-aFi
-avB
-aaj
-cGg
-cGu
-cDK
+jxj
+jxj
+dMV
+clH
+jjf
+kvn
+qtI
+clH
+xYc
+sXO
+sXO
+sXO
+sXO
+clH
 clH
 cGe
 abf
@@ -88144,18 +91801,18 @@ aXt
 aZf
 baF
 bcf
-bdW
-bfx
-bgO
-bgO
+bgM
+eHF
+mvb
+mvb
 bjm
 bkj
-blM
-bnr
-boV
+bgM
+hEo
+boU
 bqA
-bsa
-bsa
+wqy
+lRe
 bvb
 bwx
 byb
@@ -88169,7 +91826,7 @@ bHE
 bIQ
 bJU
 bKV
-bMv
+qKX
 bMv
 bPo
 bQQ
@@ -88202,28 +91859,28 @@ cuS
 cvG
 cwC
 cxG
-cyu
+cys
 czg
 czS
-cAE
+cAB
 cBv
-ctJ
+qrY
 cCC
 cDj
-cCB
-cEe
-aaj
-aFi
-aFi
+uOy
+uOy
+uOy
+cDD
+kpZ
 cFj
 cFs
-cFA
-aad
-aad
-cEy
-cGg
-cGu
-cDK
+cCB
+pyl
+sXO
+sXO
+lYW
+sXO
+clH
 clH
 cGe
 abf
@@ -88460,27 +92117,27 @@ cvF
 cwC
 cxG
 cyv
-clH
-czT
-cAF
+cCB
+czS
+cAB
 cBw
 cBX
 cCD
 cDk
 cDN
 cEf
-aaj
-avB
-avB
+cDN
+cCB
+uet
 cFk
-cFt
-cFB
-avB
-avB
-aaj
+cFk
+cCB
+dIF
+sXO
+dIF
 cGh
-cGv
-cGJ
+sXO
+clH
 clH
 cGe
 aai
@@ -88658,20 +92315,20 @@ aXv
 aZg
 baH
 bch
-bdY
-bfx
-bgO
-bgO
-bjm
+bgR
+hoQ
+gFd
+gFd
+dFw
 bkl
-blM
-bnr
-boV
+bgR
+rEI
+boW
 bqC
 bsc
-bsc
+hEt
 bvd
-bwz
+bFj
 byd
 bzv
 bAW
@@ -88716,28 +92373,28 @@ cpm
 cpm
 clH
 cxH
-cyw
+cys
 czg
 czS
-cAG
+cAB
 cBx
 cBY
 cCE
 cDl
-cCB
-cEe
-cEy
-aad
-aad
+tSY
+tSY
+tSY
+wYv
+sIg
 cFl
 cFu
-cFC
-aFi
-aFi
-aaj
-cGg
-cGu
-cDK
+cCB
+sXO
+sXO
+sXO
+dYS
+sXO
+clH
 clH
 cGe
 abf
@@ -88915,12 +92572,12 @@ aXw
 aZd
 baI
 bci
-bdZ
+blL
 bfx
 bfx
 bfx
 bfx
-bfx
+dYn
 blN
 bnr
 boV
@@ -88928,7 +92585,7 @@ bqD
 bsd
 btw
 bve
-bwA
+boV
 aaa
 bzs
 bAX
@@ -88975,26 +92632,26 @@ cwG
 cxG
 cys
 clH
-ctJ
-cAH
+wUa
+cAB
 cBy
-ctJ
-ctJ
-cDl
-cCB
-cEe
-aaj
-avB
-aFi
-aad
-avB
-aFi
-aFi
-avB
-aaj
-cGg
-cGu
-cDK
+clH
+wYv
+lQA
+rZX
+rZX
+hkb
+clH
+jjf
+kvn
+qtI
+clH
+xYc
+sXO
+sXO
+sXO
+sXO
+clH
 clH
 cGe
 aai
@@ -89172,20 +92829,20 @@ aXx
 aZh
 baJ
 bcj
-bea
+blM
 bfz
 bfx
 bfx
 bgO
 bkm
-blO
-bnt
-boW
-boW
-bse
-boW
-boW
-bwB
+blM
+bnr
+boV
+boV
+boV
+boV
+boV
+boV
 aaa
 bzs
 bAY
@@ -89231,27 +92888,27 @@ cpm
 cwH
 cxG
 cys
-czf
 clH
-cAC
+gzb
+nHy
+jwc
+lum
+lLq
 clH
+ivA
+ivA
+ivA
 clH
+nFo
+lvb
+qtI
 cCB
-cCB
-cCB
-cEe
-aaj
-avB
-aFi
-aad
-avB
-aFi
-aFi
-avB
-aaj
-cGh
-cGv
-cEv
+ctJ
+qGt
+rXs
+qGt
+ctJ
+clH
 clH
 cGe
 aai
@@ -89429,13 +93086,13 @@ aXy
 aZi
 baK
 bck
-beb
-bdY
+blM
+blM
 bgQ
 bhQ
 bfz
 bkn
-bea
+blM
 bnp
 boT
 bqy
@@ -89487,28 +93144,28 @@ cuW
 cvH
 cwI
 wAS
-cyx
-czh
-czh
-cAI
-cBz
-cBW
-cCz
+cys
 cCB
-cDM
-cEe
-cEy
-aak
-aaj
-cEy
-aaj
-aaj
-aak
-aak
-cEy
-cGg
+czS
+cAI
+jwc
+xIc
+lLq
+gXP
+tcz
+iKH
+iXV
+jgL
+sFQ
+vpg
+pRd
+dEi
+mYc
+rNB
+rNB
+hoK
 cGu
-cEv
+clH
 clH
 czf
 aai
@@ -89687,12 +93344,12 @@ aZj
 baI
 bcl
 bec
-beb
-bgR
-bgR
-bgR
-bgR
-blP
+blM
+blM
+blM
+blM
+blM
+blM
 bfA
 bfA
 bfA
@@ -89744,28 +93401,28 @@ cuX
 cvI
 ctP
 hUj
-cyp
-cyp
-cyp
-cAJ
-cBs
-cBW
-cCz
+cys
 cCB
-cDL
+tjD
+cAJ
+oTS
+jTb
+jTb
+rvj
+eyc
 cEg
-cEu
+eUC
 cEN
 cFc
-cEN
-cFc
-cEu
-cFc
-cEN
-cEu
-cGi
-cGu
-cEv
+nNq
+xba
+kWH
+dpb
+dpb
+nmD
+sXO
+sXO
+clH
 clH
 cGe
 aai
@@ -90002,30 +93659,30 @@ cvJ
 cwK
 pjv
 cyy
-cyp
-cyp
+clH
+jsP
 cAK
+kJK
 cBs
-cBW
-cCz
-cCB
-cDL
-cEh
-cEw
+cBs
+cBs
+tXn
+cBs
+cBs
 cEO
-cEO
-cEO
-cEO
-cEw
-cEO
-cFS
-cEw
-cEw
+cBs
+twq
+hNn
+cok
+mBf
+sXO
+knd
+sXO
 cGw
-cEv
+clH
 clH
 cGe
-abf
+tdK
 aaa
 aaa
 aaj
@@ -90257,32 +93914,32 @@ cpm
 cpm
 cpm
 cwL
-eSY
-cyp
-czi
+ctP
+cys
+cCB
 czU
 cAL
-cys
+iAS
 cBV
 cCF
-clH
-cDK
-cDK
-cEv
-cDK
+waY
+qcg
+cCF
+cCF
+tFA
 cFd
-cDM
-cDK
-cDM
-cDK
-cDK
-cEv
-cDK
-cDK
-cDL
+gFK
+cXR
+nsj
+clH
+clH
+clH
+clH
+clH
+clH
 clH
 cGe
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -90515,31 +94172,31 @@ cuZ
 cvK
 cwM
 cxL
-cyq
-cyq
-cyq
-cza
+cBB
+pqD
+ddh
+tta
 cBr
-clH
+csF
 clH
 clH
 cDO
-cDL
-cEx
-cDL
-cDL
-cDL
-cDL
-cDL
-cDL
-cDL
-cEx
-cDL
-cGx
-clH
+sXO
+sXO
+sKc
+kYE
+sBj
+xjM
+mXX
+peq
+aak
+bqy
+aai
+aaa
+xGk
 clH
 cGe
-aaa
+nsQ
 aaa
 aaa
 aaj
@@ -90772,32 +94429,32 @@ cva
 cvL
 csV
 hJk
-kON
+cze
 kON
 czV
 efu
-cCt
+dGM
 tOI
-cCG
+cCB
 sXO
 cDP
 cEi
-cEz
-cDL
-cDH
-cEb
-cFv
-cEb
-cFa
-cDL
-cEz
-cDL
-cDL
+cEi
+xJZ
+sXO
+tJH
 clH
-cGe
-abf
-abf
-abf
+aak
+aak
+aak
+bqy
+aaa
+aaa
+jjk
+aaa
+aaa
+bqy
+aaa
 aad
 aaj
 aad
@@ -91033,27 +94690,27 @@ cyA
 czj
 liA
 cAN
+vUb
 cys
-csF
 cCH
-clH
+knd
 cDQ
 cEb
 cEA
-cEb
+cEA
 cFe
+vsf
 clH
-clH
-clH
-cDQ
-cEb
-cFe
-cGe
-cGe
-clH
-aad
-abf
 aaa
+aaa
+aai
+bqy
+aaa
+aaa
+jjk
+aaa
+aaa
+bqy
 aaa
 aad
 aaj
@@ -91290,27 +94947,27 @@ clH
 clH
 czX
 cAO
-cys
-csF
-csF
-csF
+fuh
+pBd
 clH
 clH
 clH
 clH
 clH
+cCB
+cCB
+cCB
 clH
-czf
-clH
-clH
-clH
-clH
-clH
-clH
-clH
-aja
 aai
-aad
+aai
+aai
+bqy
+aaa
+aaa
+jjk
+aaa
+aaa
+bqy
 aaa
 aad
 aaj
@@ -91547,8 +95204,8 @@ bVM
 clH
 czY
 cAP
-cBB
-cCa
+cyq
+gSG
 cCa
 cDn
 cBU
@@ -91558,16 +95215,16 @@ aak
 aaa
 aaa
 aaa
-aad
-aaa
-aaa
-aae
-aaa
-aaa
-aaF
 aaa
 aaa
 aaa
+bqy
+aaa
+aaa
+bqy
+aaa
+aaa
+bqy
 aaa
 aad
 aaj
@@ -91805,7 +95462,7 @@ clH
 czZ
 cAQ
 cyr
-cze
+kZZ
 cCI
 cDo
 clH
@@ -91815,16 +95472,16 @@ aak
 aaa
 aaa
 aaa
-aad
 aaa
 aaa
-aae
-abf
-abf
-aai
+aaa
+bqy
 aaa
 aaa
-aac
+bqy
+aaa
+aaa
+nsQ
 aaa
 aad
 aaj
@@ -92062,7 +95719,7 @@ clH
 cAa
 cAR
 cBC
-clH
+hyh
 cCJ
 cDp
 clH
@@ -92081,7 +95738,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aad
 aaj
@@ -92319,7 +95976,7 @@ clH
 clH
 cAS
 clH
-clH
+hyh
 cCK
 cDq
 cDS
@@ -92338,7 +95995,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aad
 aaj
@@ -92576,7 +96233,7 @@ csF
 cAb
 ctJ
 cBD
-csF
+oov
 cCL
 cyp
 cDT
@@ -92595,7 +96252,7 @@ aaa
 aag
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -92833,7 +96490,7 @@ csF
 csF
 cAU
 csF
-csF
+oov
 cCM
 cDr
 cDU
@@ -92852,7 +96509,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -93087,10 +96744,10 @@ cwT
 cxP
 bVM
 csF
-aaa
-afD
-aaa
-csF
+fcS
+wPU
+fcS
+oov
 cBP
 cBP
 cBP
@@ -93109,7 +96766,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -93344,10 +97001,10 @@ cwS
 cwS
 bVM
 csF
-aaa
-aaa
-aaa
-csF
+jUQ
+sDX
+jUQ
+oov
 aaa
 aaa
 aaa
@@ -93366,7 +97023,7 @@ aaa
 aah
 aaa
 aaa
-aaa
+xGk
 aaa
 aaa
 aaj
@@ -93601,10 +97258,10 @@ bVM
 bVM
 bVM
 clH
-aaa
-aaa
-aaa
-clH
+jUQ
+sBg
+jUQ
+hyh
 aai
 aaa
 aaa
@@ -93858,10 +97515,10 @@ cwV
 cxQ
 bVM
 aaa
-aaa
-aaa
-aaa
-aai
+jUQ
+lSk
+jUQ
+xZi
 aai
 aaa
 aaa
@@ -94095,7 +97752,7 @@ caP
 cbR
 cdd
 cec
-cdd
+lJf
 cbR
 cdd
 ciu
@@ -94118,7 +97775,7 @@ aaa
 aaa
 cAZ
 aaa
-aai
+xZi
 aai
 aaa
 aaa
@@ -94375,7 +98032,7 @@ aaa
 aaa
 aaa
 aaa
-aai
+xZi
 aai
 aaa
 aaa
@@ -94394,7 +98051,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -94609,7 +98266,7 @@ caR
 bWY
 bYu
 bZF
-bYu
+vCA
 bWY
 bYu
 bZF
@@ -94632,7 +98289,7 @@ aaa
 aaa
 aaa
 aaa
-aai
+xZi
 aai
 aaa
 aaa
@@ -94651,7 +98308,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -94866,16 +98523,16 @@ aai
 bUE
 aai
 bZG
-aai
-bUE
-aai
-bZG
-aai
-bUE
-aai
-bZG
-aai
-aai
+wjs
+sTo
+txC
+rue
+txC
+sTo
+txC
+rue
+txC
+fhA
 bTp
 crC
 bTp
@@ -94889,7 +98546,7 @@ abf
 abf
 abf
 abf
-aai
+xZi
 abf
 aaa
 aaa
@@ -94908,7 +98565,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aaa
 aaa
 aaj
@@ -95132,7 +98789,7 @@ bWZ
 bYv
 bWZ
 bVM
-aai
+xZi
 bTp
 crD
 bTp
@@ -95146,7 +98803,7 @@ abf
 abf
 abf
 abf
-aai
+xZi
 abf
 aaa
 aaa
@@ -95165,7 +98822,7 @@ aaa
 aag
 aaa
 aaa
-aaa
+jjk
 aaa
 aad
 aaj
@@ -95389,21 +99046,21 @@ ckE
 clQ
 cnb
 bVM
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
+wjs
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+txC
+xjH
 aai
 aai
 aai
@@ -95422,7 +99079,7 @@ aaa
 aae
 aaa
 aaa
-aaa
+jjk
 aad
 aad
 aaj
@@ -95634,15 +99291,15 @@ mvx
 bXb
 bXb
 bVM
-cbU
+dPZ
 cdg
 cbU
 bVM
-cgr
+cQC
 chu
 cgr
 bVM
-ckF
+mGZ
 clR
 ckF
 bVM
@@ -95679,7 +99336,7 @@ aaa
 aad
 aaa
 aaa
-aaa
+xGk
 aaf
 aaf
 aaf
@@ -103082,15 +106739,15 @@ bRp
 bSG
 bTM
 bUO
-bWb
+lCQ
 bXp
 bYF
-bTM
-bTM
-bZU
+vza
+vza
+dSw
 cds
-bTM
-bTM
+vza
+lyM
 bZU
 chz
 bTM
@@ -103595,16 +107252,16 @@ bKv
 bRq
 bRq
 bTP
-bUS
-bWb
-bTM
+bUT
+pDe
+jHG
 bYH
-bZU
-bTM
-bTM
+eca
+jHG
+jHG
 cdt
-bZU
-bTM
+eca
+nTN
 bTM
 chA
 bZU
@@ -104361,7 +108018,7 @@ bJz
 bKw
 bLI
 bNg
-bOD
+bOF
 bQc
 bQc
 bRq
@@ -104875,7 +108532,7 @@ bJB
 bKw
 bLH
 bNi
-bOF
+nSR
 bQd
 bQd
 bRq
@@ -105650,7 +109307,7 @@ bOI
 bQf
 bRs
 bSK
-bQf
+bRs
 bUW
 bWk
 bXx
@@ -105901,14 +109558,14 @@ bHa
 bIi
 bJD
 bKz
+wrm
 bLL
-bLL
-bLL
+xJc
 bLL
 bLL
 bSL
 bLL
-bLL
+mKE
 bWl
 bXw
 bYK
@@ -106674,7 +110331,7 @@ bJF
 bDc
 bLO
 bNo
-bNo
+rBH
 bNo
 bRu
 bLX
@@ -106931,7 +110588,7 @@ bJG
 bDc
 bLP
 bNo
-bNo
+rBH
 bNo
 bRv
 bLX
@@ -107188,7 +110845,7 @@ bJH
 bDc
 bLQ
 bNo
-bNo
+nvr
 bQh
 bRw
 bLX

--- a/hippiestation/code/game/area/Space_Station_13_areas.dm
+++ b/hippiestation/code/game/area/Space_Station_13_areas.dm
@@ -28,3 +28,7 @@
 /area/maintenance/forge
 	name = "Forge room"
 	icon_state = "red"
+
+/area/engine/port_engineering
+	name = "Port Engineering"
+	icon_state = "green"


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: Box station supermatter + atmos hookup
add: Port Engineering which houses our singulo/tesla
del: Removed old singulo/tesla for the supermatter
balance: AI core door is no longer immune to everything but mechs and very high damage weapons.
adds: more air scrubbers and vents in appropriate locations in science
adds: lcass chem pressure chamber and centrifuge in chemistry

/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I asked and I delivered.

![image](https://user-images.githubusercontent.com/32651551/38402020-5d557ab0-3927-11e8-98ef-ca8bb9baa165.png)

![image](https://user-images.githubusercontent.com/32651551/38402035-776c1e7c-3927-11e8-9929-696de280b90f.png)

![image](https://user-images.githubusercontent.com/32651551/38402041-89f7d28e-3927-11e8-9ad3-7852118f48e3.png)

