### PR TITLE
fixes issue #7185

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_item.dm
+++ b/hippiestation/code/modules/uplink/uplink_item.dm
@@ -330,3 +330,6 @@
 	item = /obj/item/storage/box/syndie_kit/armstrong
 	cost = 14
 	surplus = 20 // someone who respects the eldritch god Nar-Sie a little (((too much))) complained
+
+/datum/uplink_item/device_tools/brainwash_disk
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer")


### PR DESCRIPTION
[Changelogs]: # 


:cl: zamolxius
tweak: CMOs can now buy brain washing disks
/:cl:

[why]: 