### PR TITLE
Displays lobby theme name when playing.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -20,6 +20,7 @@ SUBSYSTEM_DEF(ticker)
 	var/event = 0
 
 	var/login_music							//music played in pregame lobby
+	var/login_music_name					// hippie - song name displayed when title theme plays
 	var/round_end_sound						//music/jingle played when the world reboots
 	var/round_end_sound_sent = TRUE			//If all clients have loaded it
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -20,7 +20,6 @@ SUBSYSTEM_DEF(ticker)
 	var/event = 0
 
 	var/login_music							//music played in pregame lobby
-	var/login_music_name					// hippie - song name displayed when title theme plays
 	var/round_end_sound						//music/jingle played when the world reboots
 	var/round_end_sound_sent = TRUE			//If all clients have loaded it
 

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2649,6 +2649,7 @@
 #include "hippiestation\code\datums\traits\neutral.dm"
 #include "hippiestation\code\datums\wires\wires.dm"
 #include "hippiestation\code\game\atoms.dm"
+#include "hippiestation\code\game\sound.dm"
 #include "hippiestation\code\game\area\areas.dm"
 #include "hippiestation\code\game\area\Space_Station_13_areas.dm"
 #include "hippiestation\code\game\gamemodes\objective_items.dm"

--- a/hippiestation/code/controllers/subsystem/ticker.dm
+++ b/hippiestation/code/controllers/subsystem/ticker.dm
@@ -1,3 +1,7 @@
+/datum/controller/subsystem/ticker/Initialize(timeofday)
+	..()
+	login_music_name = pop(splittext(login_music, "/")) // title name will be last element of the list
+
 /datum/controller/subsystem/ticker/Shutdown()
 	if(!round_end_sound)
 		round_end_sound = pick(\

--- a/hippiestation/code/controllers/subsystem/ticker.dm
+++ b/hippiestation/code/controllers/subsystem/ticker.dm
@@ -3,7 +3,8 @@
 
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	..()
-	login_music_name = pop(splittext(login_music, "/")) // title name will be last element of the list
+	//login_music_name = pop(splittext(login_music, "/")) // title name will be last element of the list
+	login_music_name = "https://github.com/HippieStation/HippieStation/tree/master/" + login_music
 
 /datum/controller/subsystem/ticker/Shutdown()
 	if(!round_end_sound)

--- a/hippiestation/code/controllers/subsystem/ticker.dm
+++ b/hippiestation/code/controllers/subsystem/ticker.dm
@@ -1,3 +1,6 @@
+/datum/controller/subsystem/ticker
+	var/login_music_name					// hippie - song name displayed when title theme plays
+
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	..()
 	login_music_name = pop(splittext(login_music, "/")) // title name will be last element of the list

--- a/hippiestation/code/game/sound.dm
+++ b/hippiestation/code/game/sound.dm
@@ -1,0 +1,4 @@
+/client/playtitlemusic(vol = 85)
+	..()
+	if(prefs && (prefs.toggles & SOUND_LOBBY))
+		to_chat(src, "<i>Now playing:</i> <b>[SSticker.login_music_name]</b>.")


### PR DESCRIPTION
:cl: McBawbaggings
tweak: The game now displays the current lobby theme when playing.
/:cl:
![image](https://user-images.githubusercontent.com/15840795/38446614-ec938004-39f0-11e8-8be7-7592a8ff98d7.png)

Idea suggested by JohnGinnane: https://hippiestation.com/threads/post-lobby-and-round-end-music-when-it-plays.8575/