### PR TITLE
Fixed sounds from emotes playing despite the emote not being able to run

### DIFF
--- a/hippiestation/code/modules/mob/living/emote.dm
+++ b/hippiestation/code/modules/mob/living/emote.dm
@@ -2,6 +2,9 @@
 	var/nextsoundemote = 1
 
 /datum/emote/living/scream/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(user.nextsoundemote >= world.time || user.stat != CONSCIOUS)
 		return
 	var/sound
@@ -48,9 +51,11 @@
 		message = "acts out a scream."
 	else
 		message = "makes a very loud noise."
-	. = ..()
 
 /datum/emote/living/burp/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(ishuman(user))
 		if(user.nextsoundemote >= world.time)
 			return
@@ -63,9 +68,10 @@
 			burp_noise = pick(user.burp_sounds)
 			playsound(user, burp_noise, 50, 1, -1)
 
-	. = ..()
-
 /datum/emote/living/cough/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(ishuman(user))
 		if(user.nextsoundemote >= world.time)
 			return
@@ -75,7 +81,6 @@
 			coughsound = pick('hippiestation/sound/voice/cough_f1.ogg', 'hippiestation/sound/voice/cough_f2.ogg', 'hippiestation/sound/voice/cough_f3.ogg')
 		playsound(user.loc, coughsound, 50, 1, 5)
 		user.adjustOxyLoss(5)
-	. = ..()
 
 /datum/emote/living/snap
 	key = "snap"
@@ -84,12 +89,14 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/snap/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(ishuman(user))
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
 		playsound(user, 'hippiestation/sound/voice/snap.ogg', 50, 1, -1)
-	. = ..()
 
 /datum/emote/living/snap2
 	key = "snap2"
@@ -98,12 +105,14 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/snap2/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(ishuman(user))
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
 		playsound(user, 'hippiestation/sound/voice/snap2.ogg', 50, 1, -1)
-	. = ..()
 
 /datum/emote/living/snap3
 	key = "snap3"
@@ -112,9 +121,11 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/snap3/run_emote(mob/living/user, params)
+	. = ..()
+	if (!.)
+		return FALSE
 	if(ishuman(user))
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
 		playsound(user, 'hippiestation/sound/voice/snap3.ogg', 50, 1, -1)
-	. = ..()


### PR DESCRIPTION
When we added some sounds to emotes like scream, cough, etc. we aren't checking if the emote can run properly, so I've added that in

:cl: JohnGinnane
fix: Dead people can no longer cough
/:cl:

I noticed that our medhud doesn't show the flu virus, but /tg/'s did so I'm not sure if that's another bug or not

Fixes https://github.com/HippieStation/HippieStation/issues/7464