### PR TITLE
Talking in soft crit makes you whisper automatically

### DIFF
--- a/hippiestation/code/modules/mob/living/say.dm
+++ b/hippiestation/code/modules/mob/living/say.dm
@@ -12,3 +12,10 @@
 		return FALSE
 
 	return TRUE
+
+/mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE)
+	// If we're in soft crit and tried to talk, automatically make us whisper
+	if (stat == SOFT_CRIT && get_message_mode(message) != MODE_WHISPER)
+		message = "#" + message
+
+	. = ..()


### PR DESCRIPTION
Only after looking at the code did I learn you can whisper by saying "#hello world", rather than using the whisper verb. In any case, this is done for you automatically if you're in soft crit and didn't whisper

:cl: JohnGinnane
tweak: Talking in soft crit makes you whisper automatically
/:cl:

Fixes https://github.com/HippieStation/HippieStation/issues/7497