### PR TITLE
Added tool_behaviour to holotool

### DIFF
--- a/hippiestation/code/game/objects/items/holotool.dm
+++ b/hippiestation/code/game/objects/items/holotool.dm
@@ -46,6 +46,7 @@
 		if(!chosen)
 			return
 		current_tool = chosen
+		tool_behaviour = current_tool.tool_behaviour
 		playsound(loc, 'sound/items/rped.ogg', get_clamped_volume(), 1, -1)
 		update_icons()
 	else


### PR DESCRIPTION
:cl: JohnGinnane
fix: Fixed holotool missing the appropriate tool_behaviour. Should now work with the intended tool (e.g. multitool)
/:cl:

/tg/ added tool_behaviour a little while ago, and this wasn't added

There's also a strange thing where the icon only updates every second time you change the holotool. I tried to refactor the code to fix it but it kept happening and I have no idea why so I decided to abandon that and keep this simple

Fixes https://github.com/HippieStation/HippieStation/issues/3220