### PR TITLE
Made plastic require salt instead of sulphuric acid, and lowered the required temp to make plastic

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -579,7 +579,7 @@
 /datum/chemical_reaction/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
+	required_reagents = list("oil" = 5, "sacid" = 2, "ash" = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -579,7 +579,7 @@
 /datum/chemical_reaction/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	required_reagents = list("oil" = 5, "sacid" = 2, "ash" = 3)
+	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2602,6 +2602,7 @@
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
 #include "hippiestation\code\init.dm"
+#include "hippiestation\code\modules\reagents\chemistry\recipes\others.dm"
 #include "hippiestation\code\__HELPERS\_lists.dm"
 #include "hippiestation\code\__HELPERS\_logging.dm"
 #include "hippiestation\code\__HELPERS\markov.dm"

--- a/hippiestation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/hippiestation/code/modules/reagents/chemistry/recipes/others.dm
@@ -1,0 +1,5 @@
+/datum/chemical_reaction/plastic_polymers
+	name = "plastic polymers"
+	id = "plastic_polymers"
+	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
+	required_temp = 330 //lowered required temp so that we don't get that damn stuff turning to charcoal instead

--- a/hippiestation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/hippiestation/code/modules/reagents/chemistry/recipes/others.dm
@@ -1,5 +1,3 @@
 /datum/chemical_reaction/plastic_polymers
-	name = "plastic polymers"
-	id = "plastic_polymers"
 	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
 	required_temp = 330 //lowered required temp so that we don't get that damn stuff turning to charcoal instead


### PR DESCRIPTION
To keep with the old recipe for making plastic, I've changed the recipe from requiring 2 sulphuric acid to requiring 2 sodium chloride. On top of this I lowered the required temp from 374k to 330k to stop those mishaps with the reagents turning into charcoal instead of plastic. Who even thought that little of a temperature difference for two reactions was a good idea??

:cl:
tweak: Made plastic require salt to create instead of sulphuric acid. Why would you change ye olde glorious recipes, anyway?
tweak: Lowered the required temperature to make plastic from 374k to 330k. This should stop all that work turning into charcoal because you missed the number by a few digits.
/:cl:
