### PR TITLE
Replaces server restart with force shuttle call

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -130,7 +130,12 @@ SUBSYSTEM_DEF(vote)
 				active_admins = 1
 				break
 		if(!active_admins)
-			SSticker.Reboot("Restart vote successful.", "restart vote")
+			// Hippie Start - Call shuttle instead of restarting the server
+			//SSticker.Reboot("Restart vote successful.", "restart vote")
+			SSshuttle.emergencyNoRecall = TRUE
+			SSshuttle.emergency.request()
+			log_admin("The emergency shuttle has been force-called due to vote restart.")
+			// Hippie End
 		else
 			to_chat(world, "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
 			message_admins("A restart vote has passed, but there are active admins on with +server, so it has been canceled. If you wish, you may restart the server.")


### PR DESCRIPTION
:cl: JohnGinnane
admin: Changed the "vote restart" functionality to force call the shuttle (cannot be recalled), rather then restarting within 30 seconds
/:cl:

People upset at getting killed call the vote, sometimes just to spite the tators. Sometimes they're right and sometimes they're wrong, but with this it means the tator has a define time frame to complete his objectives rather than just outright restarting the whole game after 30 seconds

Fixes https://github.com/HippieStation/HippieStation/issues/7515