### PR TITLE
Fixes chem microdosage glitchiness

### DIFF
--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -46,9 +46,11 @@ GLOBAL_LIST_EMPTY(chempiles)
 		for(var/obj/item/I in M.get_equipped_items())
 			if(I.body_parts_covered & FEET)
 				protection = I.permeability_coefficient
-		if(reagents < 1)	//This should stop those weird as hell microdosages
+		if(reagents.total_volume < 1)	//This should stop those weird as hell microdosages
 			reagents.trans_to(M, 2, protection)
 			CHECK_TICK
+		else
+			return
 
 /obj/effect/decal/cleanable/chempile/fire_act(exposed_temperature, exposed_volume)
 	if(reagents && reagents.chem_temp)

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -46,11 +46,12 @@ GLOBAL_LIST_EMPTY(chempiles)
 		for(var/obj/item/I in M.get_equipped_items())
 			if(I.body_parts_covered & FEET)
 				protection = I.permeability_coefficient
-		if(reagents)
-			for(var/datum/reagent/R in src.reagents.reagent_list)
-				if(reagents.get_reagent_amount(R) > 1)
-					reagents.trans_to(M, 2, protection)
-					CHECK_TICK
+		if(reagents && reagents.total_volume >= 1)	//No transfer if there's less than 1u total
+			reagents.trans_to(M, 2, protection)
+			CHECK_TICK
+			for(var/datum/reagent/R in reagents)
+				if(R.volume < 0.2)
+					reagents.remove_reagent(R)	//Should remove most stray cases of microdosages that may get through without compromising chempiles with lots of mixes in them
 
 /obj/effect/decal/cleanable/chempile/fire_act(exposed_temperature, exposed_volume)
 	if(reagents && reagents.chem_temp)

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -46,9 +46,11 @@ GLOBAL_LIST_EMPTY(chempiles)
 		for(var/obj/item/I in M.get_equipped_items())
 			if(I.body_parts_covered & FEET)
 				protection = I.permeability_coefficient
-		if(reagents.total_volume > 3)	//This should help stop those weird as hell microdosages - mostly a temp fix
-			reagents.trans_to(M, 2, protection)
-			CHECK_TICK
+		if(reagents)
+			for(var/datum/reagent/R in src.reagents.reagent_list)
+				if(reagents.get_reagent_amount(R) > 1)
+					reagents.trans_to(M, 2, protection)
+					CHECK_TICK
 
 /obj/effect/decal/cleanable/chempile/fire_act(exposed_temperature, exposed_volume)
 	if(reagents && reagents.chem_temp)

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(chempiles)
 		for(var/obj/item/I in M.get_equipped_items())
 			if(I.body_parts_covered & FEET)
 				protection = I.permeability_coefficient
-		if(reagents)
+		if(reagents < 1)	//This should stop those weird as hell microdosages
 			reagents.trans_to(M, 2, protection)
 			CHECK_TICK
 

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -46,11 +46,9 @@ GLOBAL_LIST_EMPTY(chempiles)
 		for(var/obj/item/I in M.get_equipped_items())
 			if(I.body_parts_covered & FEET)
 				protection = I.permeability_coefficient
-		if(reagents.total_volume < 1)	//This should stop those weird as hell microdosages
+		if(reagents.total_volume > 3)	//This should help stop those weird as hell microdosages - mostly a temp fix
 			reagents.trans_to(M, 2, protection)
 			CHECK_TICK
-		else
-			return
 
 /obj/effect/decal/cleanable/chempile/fire_act(exposed_temperature, exposed_volume)
 	if(reagents && reagents.chem_temp)


### PR DESCRIPTION
Ok this should stop chempiles if they have 1u of reagents or less, and will remove most microdosages that people can get, as a 2nd safety measure. This should stop most instances of microdosages, although there may still be the occasional odd case of it. However this should fix the majority of cases anyway.
:cl:
fix: Fixed those weird microdosages with chemistry. No more being unconscious forever.
/:cl:
