### PR TITLE
Fixes alien surgery disks requiring alien tech node

### DIFF
--- a/hippiestation/code/modules/research/techweb/all_nodes.dm
+++ b/hippiestation/code/modules/research/techweb/all_nodes.dm
@@ -6,3 +6,6 @@
 	design_ids = list("bluebutt")
 	research_cost = 2500
 	export_price = 10000
+
+/datum/techweb_node/alien_surgery
+	prereq_ids = list("exp_surgery")	//Fuck the idiot who made it require a node that doesn't exist


### PR DESCRIPTION
The alien surgery disk node required another node called alien tech, which has been removed for months now. So you could never unlock alien surgery disks as it would want you to get a node that doesn't exist.

:cl:
fix: Fixed the alien surgery disk research node requiring a node that doesn't exist. Slow clap to whoever managed to forget that the alien tech node has been removed for months.
/:cl: