### PR TITLE
Made removing the employee retrieval implant not gib you

### DIFF
--- a/hippiestation/code/game/objects/items/implants/implant_teleporter.dm
+++ b/hippiestation/code/game/objects/items/implants/implant_teleporter.dm
@@ -91,8 +91,7 @@
 
 /obj/item/implant/teleporter/removed(mob/living/source, silent = 0, special = 0)
 	..()
-	say("Implant tampering detected.")
-	source.gib()
+	say("Implant tampering detected. Your contract has been terminated!")
 
 /obj/item/implant/teleporter/ghost_role
 	name = "employee retrieval implant"


### PR DESCRIPTION
If someone goes through the effort to find all the items in the hotel that are required to do ghetto surgery and successfully manages to remove the implant, they shouldn't be instagibbed. That's an instant fuck you and that's stupid. Nobody even likes the space hotel anyway. This should make the ghost role at least potentially useful.

:cl:
balance: Removing the employee retrieval implant no longer instagibs you.
/:cl:
