### PR TITLE
Fixes Runtime null.failures in garbage.dm

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -179,7 +179,8 @@ SUBSYSTEM_DEF(garbage)
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
 				testing("GC: -- \ref[src] | [type] was unable to be GC'd --")
-				I.failures++
+				if(I)
+					I.failures++
 			if (GC_QUEUE_HARDDELETE)
 				HardDelete(D)
 				if (MC_TICK_CHECK)
@@ -232,9 +233,9 @@ SUBSYSTEM_DEF(garbage)
 	tick = (TICK_USAGE-tick+((world.time-ticktime)/world.tick_lag*100))
 
 	var/datum/qdel_item/I = items[type]
-
-	I.hard_deletes++
-	I.hard_delete_time += TICK_DELTA_TO_MS(tick)
+	if(I)
+		I.hard_deletes++
+		I.hard_delete_time += TICK_DELTA_TO_MS(tick)
 
 
 	if (tick > highest_del_tickusage)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: fixes garbage collection runtime
server: fixes garbage.dm runtime at line 32
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Runtime fixes are good.

Edit: For better explanation, this code here checks to ensure that items[type] is not a null value, thus preventing a runtime in garbage.dm, a common occurence that plagues dream daemon and does not fix itself until reboot.