### PR TITLE
Added a new chem to fix liver damage, and made balance changes to alcohol and livers

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -111,6 +111,8 @@ GAS ANALYZER
 	add_fingerprint(user)
 
 
+/*	Disabled for our Hippie version of the medical scanner, otherwise this one overrides our version
+
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
 	if(isliving(user) && (user.incapacitated() || user.eye_blind))
@@ -240,7 +242,7 @@ GAS ANALYZER
 		var/mob/living/carbon/human/H = M
 		var/ldamage = H.return_liver_damage()
 		if(ldamage > 10)
-			to_chat(user, "\t<span class='alert'>[ldamage > 45 ? "severe" : "minor"] liver damage detected.</span>")
+			to_chat(user, "\t<span class='alert'>[ldamage > 45 ? "Severe" : "Minor"] liver damage detected.</span>")	//Fixed a typo, severe and minor weren't capitalised
 
 	// Body part damage report
 	if(iscarbon(M) && mode == 1)
@@ -300,6 +302,8 @@ GAS ANALYZER
 		if(cyberimp_detect)
 			to_chat(user, "<span class='notice'>Detected cybernetic modifications:</span>")
 			to_chat(user, "<span class='notice'>[cyberimp_detect]</span>")
+
+*/
 
 /proc/chemscan(mob/living/user, mob/living/M)
 	if(istype(M))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -242,7 +242,7 @@ GAS ANALYZER
 		var/mob/living/carbon/human/H = M
 		var/ldamage = H.return_liver_damage()
 		if(ldamage > 10)
-			to_chat(user, "\t<span class='alert'>[ldamage > 45 ? "Severe" : "Minor"] liver damage detected.</span>")	//Fixed a typo, severe and minor weren't capitalised
+			to_chat(user, "\t<span class='alert'>[ldamage > 45 ? "severe" : "minor"] liver damage detected.</span>")
 
 	// Body part damage report
 	if(iscarbon(M) && mode == 1)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -111,7 +111,7 @@ GAS ANALYZER
 	add_fingerprint(user)
 
 
-/*	Disabled for our Hippie version of the medical scanner, otherwise this one overrides our version
+/*	Hippie start, overriding medical scanner to change descriptions & fix a typo
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
@@ -303,7 +303,7 @@ GAS ANALYZER
 			to_chat(user, "<span class='notice'>Detected cybernetic modifications:</span>")
 			to_chat(user, "<span class='notice'>[cyberimp_detect]</span>")
 
-*/
+*/	//Hippie end
 
 /proc/chemscan(mob/living/user, mob/living/M)
 	if(istype(M))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -372,6 +372,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 												"So like, you know how we separate our codebase from the master copy that runs on our consumer boxes? What if we merged the two and undid the separation between codebase and server?",
 												"Dude, radical idea: H.O.N.K mechs but with no bananium required.",
 												"Best idea ever: Disposal pipes instead of hallways."))
+/* Hippie start, handling drunkenness somewhere else so we can change it
 /mob/living/carbon/human/handle_status_effects()
 	..()
 
@@ -435,6 +436,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 		if(drunkenness >= 101)
 			adjustToxLoss(4) //Let's be honest you shouldn't be alive by now
+*/	//Hippie end
 
 #undef THERMAL_PROTECTION_HEAD
 #undef THERMAL_PROTECTION_CHEST

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3050,6 +3050,7 @@
 #include "hippiestation\code\modules\surgery\organs\butts.dm"
 #include "hippiestation\code\modules\surgery\organs\ears.dm"
 #include "hippiestation\code\modules\surgery\organs\eyes.dm"
+#include "hippiestation\code\modules\surgery\organs\liver.dm"
 #include "hippiestation\code\modules\surgery\organs\tails.dm"
 #include "hippiestation\code\modules\surgery\organs\tongue.dm"
 #include "hippiestation\code\modules\techweb\all_nodes.dm"

--- a/hippiestation/code/game/objects/items/devices/scanners.dm
+++ b/hippiestation/code/game/objects/items/devices/scanners.dm
@@ -32,3 +32,193 @@
 	if (T.cores > 1)
 		to_chat(user, "Anomalious slime core amount detected")
 	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")
+
+// Used by the PDA medical scanner too
+proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
+	if(isliving(user) && (user.incapacitated() || user.eye_blind))
+		return
+	//Damage specifics
+	var/oxy_loss = M.getOxyLoss()
+	var/tox_loss = M.getToxLoss()
+	var/fire_loss = M.getFireLoss()
+	var/brute_loss = M.getBruteLoss()
+	var/mob_status = (M.stat == DEAD ? "<span class='alert'><b>Deceased</b></span>" : "<b>[round(M.health/M.maxHealth,0.01)*100] % healthy</b>")
+
+	if(M.has_trait(TRAIT_FAKEDEATH) && !advanced)
+		mob_status = "<span class='alert'><b>Deceased</b></span>"
+		oxy_loss = max(rand(1, 40), oxy_loss, (300 - (tox_loss + fire_loss + brute_loss))) // Random oxygen loss
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.undergoing_cardiac_arrest() && H.stat != DEAD)
+			to_chat(user, "<span class='danger'>Subject suffering from heart attack: apply defibrillator immediately!</span>")
+		if(H.undergoing_liver_failure() && H.stat != DEAD)
+			to_chat(user, "<span class='danger'>Subject suffering from liver failure: apply iecure to repair the liver or perform a liver transplant immediately!</span>")	//Changed liver failure line to include iecure in it
+
+	to_chat(user, "<span class='info'>Analyzing results for [M]:\n\tOverall status: [mob_status]</span>")
+
+	// Damage descriptions
+	if(brute_loss > 10)
+		to_chat(user, "\t<span class='alert'>[brute_loss > 50 ? "Severe" : "Minor"] tissue damage detected.</span>")
+	if(fire_loss > 10)
+		to_chat(user, "\t<span class='alert'>[fire_loss > 50 ? "Severe" : "Minor"] burn damage detected.</span>")
+	if(oxy_loss > 10)
+		to_chat(user, "\t<span class='info'><span class='alert'>[oxy_loss > 50 ? "Severe" : "Minor"] oxygen deprivation detected.</span>")
+	if(tox_loss > 10)
+		to_chat(user, "\t<span class='alert'>[tox_loss > 50 ? "Severe" : "Minor"] amount of toxin damage detected.</span>")
+	if(M.getStaminaLoss())
+		to_chat(user, "\t<span class='alert'>Subject appears to be suffering from fatigue.</span>")
+		if(advanced)
+			to_chat(user, "\t<span class='info'>Fatigue Level: [M.getStaminaLoss()]%.</span>")
+	if (M.getCloneLoss())
+		to_chat(user, "\t<span class='alert'>Subject appears to have [M.getCloneLoss() > 30 ? "severe" : "minor"] cellular damage.</span>")
+		if(advanced)
+			to_chat(user, "\t<span class='info'>Cellular Damage Level: [M.getCloneLoss()].</span>")
+	if (M.getBrainLoss() >= 200 || !M.getorgan(/obj/item/organ/brain))
+		to_chat(user, "\t<span class='alert'>Subject brain function is non-existent.</span>")
+	else if (M.getBrainLoss() >= 120)
+		to_chat(user, "\t<span class='alert'>Severe brain damage detected. Subject likely to have mental traumas.</span>")
+	else if (M.getBrainLoss() >= 45)
+		to_chat(user, "\t<span class='alert'>Brain damage detected.</span>")
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(LAZYLEN(C.get_traumas()))
+			var/list/trauma_text = list()
+			for(var/datum/brain_trauma/B in C.get_traumas())
+				var/trauma_desc = ""
+				switch(B.resilience)
+					if(TRAUMA_RESILIENCE_SURGERY)
+						trauma_desc += "severe "
+					if(TRAUMA_RESILIENCE_LOBOTOMY)
+						trauma_desc += "deep-rooted "
+					if(TRAUMA_RESILIENCE_MAGIC, TRAUMA_RESILIENCE_ABSOLUTE)
+						trauma_desc += "permanent "
+				trauma_desc += B.scan_desc
+				trauma_text += trauma_desc
+			to_chat(user, "\t<span class='alert'>Cerebral traumas detected: subjects appears to be suffering from [english_list(trauma_text)].</span>")
+		if(C.roundstart_quirks.len)
+			to_chat(user, "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span>")
+	if(advanced)
+		to_chat(user, "\t<span class='info'>Brain Activity Level: [(200 - M.getBrainLoss())/2]%.</span>")
+	if (M.radiation)
+		to_chat(user, "\t<span class='alert'>Subject is irradiated.</span>")
+		if(advanced)
+			to_chat(user, "\t<span class='info'>Radiation Level: [M.radiation]%.</span>")
+
+	if(advanced && M.hallucinating())
+		to_chat(user, "\t<span class='info'>Subject is hallucinating.</span>")
+
+	//Eyes and ears
+	if(advanced)
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			var/obj/item/organ/ears/ears = C.getorganslot(ORGAN_SLOT_EARS)
+			to_chat(user, "\t<span class='info'><b>==EAR STATUS==</b></span>")
+			if(istype(ears))
+				var/healthy = TRUE
+				if(C.has_trait(TRAIT_DEAF, GENETIC_MUTATION))
+					healthy = FALSE
+					to_chat(user, "\t<span class='alert'>Subject is genetically deaf.</span>")
+				else if(C.has_trait(TRAIT_DEAF))
+					healthy = FALSE
+					to_chat(user, "\t<span class='alert'>Subject is deaf.</span>")
+				else
+					if(ears.ear_damage)
+						to_chat(user, "\t<span class='alert'>Subject has [ears.ear_damage > UNHEALING_EAR_DAMAGE? "permanent ": "temporary "]hearing damage.</span>")
+						healthy = FALSE
+					if(ears.deaf)
+						to_chat(user, "\t<span class='alert'>Subject is [ears.ear_damage > UNHEALING_EAR_DAMAGE ? "permanently ": "temporarily "] deaf.</span>")
+						healthy = FALSE
+				if(healthy)
+					to_chat(user, "\t<span class='info'>Healthy.</span>")
+			else
+				to_chat(user, "\t<span class='alert'>Subject does not have ears.</span>")
+			var/obj/item/organ/eyes/eyes = C.getorganslot(ORGAN_SLOT_EYES)
+			to_chat(user, "\t<span class='info'><b>==EYE STATUS==</b></span>")
+			if(istype(eyes))
+				var/healthy = TRUE
+				if(C.has_trait(TRAIT_BLIND))
+					to_chat(user, "\t<span class='alert'>Subject is blind.</span>")
+					healthy = FALSE
+				if(C.has_trait(TRAIT_NEARSIGHT))
+					to_chat(user, "\t<span class='alert'>Subject is nearsighted.</span>")
+					healthy = FALSE
+				if(eyes.eye_damage > 30)
+					to_chat(user, "\t<span class='alert'>Subject has severe eye damage.</span>")
+					healthy = FALSE
+				else if(eyes.eye_damage > 20)
+					to_chat(user, "\t<span class='alert'>Subject has significant eye damage.</span>")
+					healthy = FALSE
+				else if(eyes.eye_damage)
+					to_chat(user, "\t<span class='alert'>Subject has minor eye damage.</span>")
+					healthy = FALSE
+				if(healthy)
+					to_chat(user, "\t<span class='info'>Healthy.</span>")
+			else
+				to_chat(user, "\t<span class='alert'>Subject does not have eyes.</span>")
+
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/ldamage = H.return_liver_damage()
+		if(ldamage > 10)
+			to_chat(user, "\t<span class='alert'>[ldamage > 45 ? "Severe" : "Minor"] liver damage detected.</span>")	//Fixed a typo, severe and minor weren't capitalised
+
+	// Body part damage report
+	if(iscarbon(M) && mode == 1)
+		var/mob/living/carbon/C = M
+		var/list/damaged = C.get_damaged_bodyparts(1,1)
+		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
+			to_chat(user, "<span class='info'>\tDamage: <span class='info'><font color='red'>Brute</font></span>-<font color='#FF8000'>Burn</font>-<font color='green'>Toxin</font>-<font color='blue'>Suffocation</font>\n\t\tSpecifics: <font color='red'>[brute_loss]</font>-<font color='#FF8000'>[fire_loss]</font>-<font color='green'>[tox_loss]</font>-<font color='blue'>[oxy_loss]</font></span>")
+			for(var/obj/item/bodypart/org in damaged)
+				to_chat(user, "\t\t<span class='info'>[capitalize(org.name)]: [(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]-[(org.burn_dam > 0) ? "<font color='#FF8000'>[org.burn_dam]</font>" : "<font color='#FF8000'>0</font>"]")
+
+	// Species and body temperature
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		to_chat(user, "<span class='info'>Species: [H.dna.species.name]</span>")
+	to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
+
+	// Time of death
+	if(M.tod && (M.stat == DEAD || ((M.has_trait(TRAIT_FAKEDEATH)) && !advanced)))
+		to_chat(user, "<span class='info'>Time of Death:</span> [M.tod]")
+		var/tdelta = round(world.time - M.timeofdeath)
+		if(tdelta < (DEFIB_TIME_LIMIT * 10))
+			to_chat(user, "<span class='danger'>Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!</span>")
+
+	for(var/thing in M.diseases)
+		var/datum/disease/D = thing
+		if(!(D.visibility_flags & HIDDEN_SCANNER))
+			to_chat(user, "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>")
+
+	// Blood Level
+	if(M.has_dna())
+		var/mob/living/carbon/C = M
+		var/blood_id = C.get_blood_id()
+		if(blood_id)
+			if(ishuman(C))
+				var/mob/living/carbon/human/H = C
+				if(H.bleed_rate)
+					to_chat(user, "<span class='danger'>Subject is bleeding!</span>")
+			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
+			var/blood_type = C.dna.blood_type
+			if(blood_id != "blood")//special blood substance
+				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
+				if(R)
+					blood_type = R.name
+				else
+					blood_type = blood_id
+			if(C.blood_volume <= BLOOD_VOLUME_SAFE && C.blood_volume > BLOOD_VOLUME_OKAY)
+				to_chat(user, "<span class='danger'>LOW blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
+			else if(C.blood_volume <= BLOOD_VOLUME_OKAY)
+				to_chat(user, "<span class='danger'>CRITICAL blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
+			else
+				to_chat(user, "<span class='info'>Blood level [blood_percent] %, [C.blood_volume] cl, type: [blood_type]</span>")
+
+		var/cyberimp_detect
+		for(var/obj/item/organ/cyberimp/CI in C.internal_organs)
+			if(CI.status == ORGAN_ROBOTIC && !CI.syndicate_implant)
+				cyberimp_detect += "[C.name] is modified with a [CI.name].<br>"
+		if(cyberimp_detect)
+			to_chat(user, "<span class='notice'>Detected cybernetic modifications:</span>")
+			to_chat(user, "<span class='notice'>[cyberimp_detect]</span>")

--- a/hippiestation/code/modules/mob/living/carbon/human/life.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/life.dm
@@ -12,3 +12,67 @@
 			if(mind && hud_used.combo_object && hud_used.combo_object.cooldown < world.time)
 				hud_used.combo_object.update_icon()
 				mind.martial_art.streak = ""
+
+/mob/living/carbon/human/handle_status_effects()
+	..()
+
+
+	if(drunkenness)
+		drunkenness = max(drunkenness - (drunkenness * 0.04), 0)
+		if(drunkenness >= 6)
+			if(prob(25))
+				slurring += 2
+			jitteriness = max(jitteriness - 3, 0)
+
+		if(drunkenness >= 11 && slurring < 5)
+			slurring += 1.2
+		if(mind && (mind.assigned_role == "Scientist" || mind.assigned_role == "Research Director"))
+			if(SSresearch.science_tech)
+				if(drunkenness >= 12.9 && drunkenness <= 13.8)
+					drunkenness = round(drunkenness, 0.01)
+					var/ballmer_percent = 0
+					if(drunkenness == 13.35) // why run math if I dont have to
+						ballmer_percent = 1
+					else
+						ballmer_percent = (-abs(drunkenness - 13.35) / 0.9) + 1
+					if(prob(5))
+						say(pick(GLOB.ballmer_good_msg))
+					SSresearch.science_tech.research_points += (BALLMER_POINTS * ballmer_percent)
+				if(drunkenness > 26) // by this point you're into windows ME territory
+					if(prob(5))
+						SSresearch.science_tech.research_points -= BALLMER_POINTS
+						say(pick(GLOB.ballmer_windows_me_msg))
+		if(drunkenness >= 41)
+			if(prob(25))
+				confused += 2
+			Dizzy(10)
+
+		if(drunkenness >= 51)
+			if(prob(5))
+				confused += 10
+				vomit()
+			Dizzy(25)
+
+		if(drunkenness >= 61)
+			if(prob(50))
+				blur_eyes(5)
+
+		if(drunkenness >= 71)
+			blur_eyes(5)
+
+		if(drunkenness >= 81)
+			adjustToxLoss(0.2)
+			if(prob(5) && !stat)
+				to_chat(src, "<span class='warning'>Maybe you should lie down for a bit...</span>")
+
+		if(drunkenness >= 91)
+			adjustBrainLoss(0.4, 60)
+			if(prob(20) && !stat)
+				if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(z)) //QoL mainly
+					to_chat(src, "<span class='warning'>You're so tired... but you can't miss that shuttle...</span>")
+				else
+					to_chat(src, "<span class='warning'>Just a quick nap...</span>")
+					Sleeping(100)	//Reduced from 900 to 100, waiting around for a minute and a half isn't fun
+
+		if(drunkenness >= 101)
+			adjustToxLoss(4) //Let's be honest you shouldn't be alive by now

--- a/hippiestation/code/modules/mob/living/carbon/life.dm
+++ b/hippiestation/code/modules/mob/living/carbon/life.dm
@@ -8,3 +8,11 @@
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/BT = T
 		BT.on_life()
+
+/mob/living/carbon/liver_failure()
+	reagents.metabolize(src, can_overdose=FALSE, liverless = TRUE)
+	if(has_trait(TRAIT_STABLEHEART))
+		return
+	adjustToxLoss(rand(1,8), TRUE,  TRUE)	//Made liver damage change from a range of 1-8 per tick, otherwise liver failure = instant death
+	if(prob(30))
+		to_chat(src, "<span class='notice'>You feel confused and nauseous...</span>")//actual symptoms of liver failure

--- a/hippiestation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1,3 +1,16 @@
+/datum/reagent/consumable/ethanol/on_mob_life(mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
+			var/booze_power = boozepwr
+			if(H.has_trait(TRAIT_ALCOHOL_TOLERANCE)) //we're an accomplished drinker
+				booze_power *= 0.7
+			H.drunkenness = max((H.drunkenness + (sqrt(volume) * booze_power * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
+			var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
+			H.applyLiverDamage((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * L.alcohol_tolerance, 0))/50)	//Reduced the division number to 50 from 150, because otherwise alcohol is never, ever dangerous
+	return ..() || .
+
+
 /datum/reagent/consumable/ethanol/impalco
 	name = "Impure Superhol"
 	id = "impalco"
@@ -44,64 +57,64 @@
 /datum/reagent/consumable/ethanol/isoproyl/on_mob_life(mob/living/M)
 	M.adjustToxLoss(1)
 	..()
-	
+
 /datum/reagent/consumable/ethanol/ale
 	nutriment_factor = 1 * REAGENTS_METABOLISM
-	
+
 /datum/reagent/consumable/ethanol/beer/on_mob_life(mob/living/M)
 	M.jitteriness = max(0,M.jitteriness-5)
 	..()
 	. = 1
-	
+
 /datum/reagent/consumable/ethanol/whiskey/on_mob_life(mob/living/M)
 	if(ishuman(M) && M.job in list("Detective"))
 		M.adjustBruteLoss(-0.5, 0)
 		. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/M)
 	M.radiation = max(M.radiation-4,0)
 	M.set_drugginess(50)
 	return ..()
-	
+
 /datum/reagent/consumable/ethanol/gin/on_mob_life(mob/living/M)
 	M.hallucination = max(0, M.hallucination - 4)
 	. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/vermouth/on_mob_life(mob/living/M)
 	M.metabolism_efficiency = 1.30
 	. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/wine/on_mob_life(mob/living/M)
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL)
 			C.blood_volume += 0.5
 	..()
-	
+
 /datum/reagent/consumable/ethanol/grappa/on_mob_life(mob/living/M)
 	M.metabolism_efficiency = 1.30
 	..()
-	
+
 /datum/reagent/consumable/ethanol/cognac/on_mob_life(mob/living/M)
 	if(ishuman(M) && M.job in list("Mime"))
 		M.heal_bodypart_damage(0.5,0.5, 0)
 		. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/hooch/on_mob_life(mob/living/M)
 	if(prob(10))
 		M.emote("scream")
 	..()
-	
+
 /datum/reagent/consumable/ethanol/whiskey_cola/on_mob_life(mob/living/M)
 	if(ishuman(M) && M.job in list("Detective"))
 		M.adjustFireLoss(-0.5, 0)
 		. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/white_russian/on_mob_life(mob/living/M)
 	var/light_amount = 0
 	if(isturf(M.loc))
@@ -112,7 +125,7 @@
 			M.adjustOxyLoss(-1)
 			M.adjustStaminaLoss(-1*REM, 0)
 		..()
-		
+
 /datum/reagent/consumable/ethanol/booger/on_mob_life(mob/living/M)
 	if(prob(30))
 		M.emote("sneeze")
@@ -135,7 +148,7 @@
 	if(prob(20))
 		M.say(pick("YEE HAW!!","YEEE HAAW!!","YEEEE HAAAW!!","YEEEEE HAAAAW!!","YEEEEEE HAAAAAW!!","YEEEEEEE HAAAAAAW!!","YEEEEEEEE HAAAAAAAW!!"))
 	..()
-	
+
 /datum/reagent/consumable/ethanol/black_russian/on_mob_life(mob/living/M)
 	var/light_amount = 0
 	if(isturf(M.loc))
@@ -146,23 +159,23 @@
 			M.adjustOxyLoss(-1)
 			M.adjustStaminaLoss(-1*REM, 0)
 		..()
-		
+
 /datum/reagent/consumable/ethanol/manhattan/on_mob_life(mob/living/M)
 	if(prob(20)) //may cause involuntary brawls
 		M.say(pick("FUCKIN' SHIT!!","JESUS CHRIST!!","AAASSSSSS!!","FUCKER!!","SHITBIRD!!","FUCK YOURSELF!!","GET OFF THE FUCKIN' ROAD!!","EAT SHIT!!","EAT A DICK, PAL!!","GET FUCKED!!","TRY ME, COCKSUCKER!!","JUMP UP YOUR OWN ASS!!","BADA BING!!","YOU TALKIN' TO ME?!!","FUCK OUTTA HERE!!","EY, I'M WALKIN' HERE!!"))
 	..()
-	
+
 /datum/reagent/consumable/ethanol/whiskeysoda/on_mob_life(mob/living/M)
 	if(ishuman(M) && M.job in list("Detective"))
 		M.adjustToxLoss(-0.5, 0)
 		. = 1
 	..()
-	
+
 /datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/M)
 	M.stuttering = 0
 	M.slurring = 0
 	..()
-	
+
 /datum/reagent/consumable/ethanol/singulo/on_mob_life(mob/living/M)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
@@ -174,27 +187,27 @@
 	if(prob(10))
 		M.reagents.add_reagent("honey",2)
 	..()
-	
+
 /datum/reagent/consumable/ethanol/grog/on_mob_life(mob/living/M)
 	if (M.bodytemperature < 330)
 		M.bodytemperature = min(330, M.bodytemperature + (20 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	return ..()
-	
+
 /datum/reagent/consumable/ethanol/aloe/on_mob_life(mob/living/M)
 	M.adjustFireLoss(-1*REM, 0)
 	..()
 	. = 1
-	
+
 /datum/reagent/consumable/ethanol/acid_spit/on_mob_life(mob/living/M)
 	M.nutrition = max(M.nutrition - 1.5, 0)
 	M.overeatduration = 0
 	return ..()
-	
+
 /datum/reagent/consumable/ethanol/irishcarbomb/on_mob_life(mob/living/M) //sorry, irish
 	if(prob(5))
 		playsound(get_turf(M), 'sound/effects/explosionfar.ogg', 100, 1)
 	return ..()
-	
+
 /datum/reagent/consumable/ethanol/driestmartini/reaction_turf(turf/open/T, reac_volume)
 	if (istype(T))
 		T.MakeDry(ALL, TRUE, reac_volume * 5 SECONDS)

--- a/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -224,3 +224,19 @@ datum/reagent/medicine/virogone/on_mob_life(mob/living/M)//cures viruses very ef
 
 /datum/reagent/medicine/salglu_solution
 	overdose_threshold = 0 //seriously fuck whoever thought this was a good idea.
+
+/datum/reagent/medicine/iecure
+	name = "Iecure"
+	id = "iecure"
+	description = "A powerful chemical that heals liver damage, purges alcohol and heals toxin damage when the user is suffering from liver failure"
+	color = "#957555"	//rgb: 149, 117, 85
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/iecure/on_mob_life(mob/living/M)
+	var/mob/living/carbon/human/H = M
+	H.applyLiverDamage(-10)
+	H.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 5)	//Fixing liver damage is useless if they still have a shitton of alcohol in them
+	if(H.undergoing_liver_failure())	//Only heal their toxin damage if their liver is dying, the rest should need charcoal or something
+		H.adjustToxLoss(-16)	//Liver failure applies 8 toxin damage per tick, ouch
+
+	..()	//It turns out this is needed to actually metabolize the chemical... you learn something new every day :)

--- a/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -231,12 +231,13 @@ datum/reagent/medicine/virogone/on_mob_life(mob/living/M)//cures viruses very ef
 	description = "A powerful chemical that heals liver damage, purges alcohol and heals toxin damage when the user is suffering from liver failure"
 	color = "#957555"	//rgb: 149, 117, 85
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	self_consuming = TRUE
 
 /datum/reagent/medicine/iecure/on_mob_life(mob/living/M)
 	var/mob/living/carbon/human/H = M
-	H.applyLiverDamage(-10)
+	H.applyLiverDamage(rand(-3, -10))
 	H.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 5)	//Fixing liver damage is useless if they still have a shitton of alcohol in them
 	if(H.undergoing_liver_failure())	//Only heal their toxin damage if their liver is dying, the rest should need charcoal or something
-		H.adjustToxLoss(-16)	//Liver failure applies 8 toxin damage per tick, ouch
+		H.adjustToxLoss(-10)	//Liver failure applies 8 toxin damage per tick, ouch
 
 	..()	//It turns out this is needed to actually metabolize the chemical... you learn something new every day :)

--- a/hippiestation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/hippiestation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -50,3 +50,9 @@
 	id = "kelotane"
 	results = list("kelotane" = 3)
 	required_reagents = list("carbon" = 1, "silicon" = 1)
+
+/datum/chemical_reaction/iecure
+	name = "Iecure"
+	id = "iecure"
+	results = list("iecure" = 3)
+	required_reagents = list("charcoal" = 1, "hydrogen" = 1, "ethanol" = 1)	//Added ethanol for some dumb irony

--- a/hippiestation/code/modules/surgery/organs/liver.dm
+++ b/hippiestation/code/modules/surgery/organs/liver.dm
@@ -1,8 +1,11 @@
+/obj/item/organ/liver
+	var/mute_message = FALSE	//Used to mute the flavour text when near liver failure, so that after being healed it doesn't display for a little while
+
 /obj/item/organ/liver/on_life()
 	var/mob/living/carbon/C = owner
 
 	if(istype(C))
-		if(!failing || C.reagents.has_reagent("iecure"))	//can't process reagents with a failing liver - however process everything if we have the one that heals the liver
+		if(!failing)
 			//slowly heal liver damage
 			damage = max(0, damage - 0.1)
 
@@ -21,12 +24,22 @@
 			//metabolize reagents
 			C.reagents.metabolize(C, can_overdose=TRUE)
 
-		if(damage > 10 && prob(damage/3) && !C.reagents.has_reagent("iecure"))	//the higher the damage the higher the probability
-			to_chat(C, "<span class='notice'>You feel [pick("nauseous", "a dull pain in your lower body", "confused")].</span>")	//no liver damage message if they have the liver fixing chemical
+		else
+			mute_message = TRUE
 
-	if(damage > maxHealth)//cap liver damage
-		damage = maxHealth
+		if(damage > 10 && prob(damage/3) && !mute_message)	//the higher the damage the higher the probability
+			to_chat(C, "<span class='notice'>You feel [pick("nauseous", "a dull pain in your lower body", "confused")].</span>")	//no liver damage message if the liver is failing already
+
+	if(damage > 2*maxHealth)//cap liver damage to 2x of max health
+		damage = 2*maxHealth
 
 	if(damage < maxHealth && failing)	//if their liver is healed, stop killing them!!
 		failing = FALSE
 		to_chat(C, "<span class='notice'>You feel [pick("the pain in your lower body fading", "awake and alert again")].</span>")
+		addtimer(CALLBACK(src, .proc/toggle_mute_message), 300)	//Shouldn't display liver damage messages for a little while even if they're still on the verge of failure
+
+/obj/item/organ/liver/proc/toggle_mute_message()
+	if(mute_message)
+		mute_message = FALSE
+	else
+		mute_message = TRUE

--- a/hippiestation/code/modules/surgery/organs/liver.dm
+++ b/hippiestation/code/modules/surgery/organs/liver.dm
@@ -1,0 +1,32 @@
+/obj/item/organ/liver/on_life()
+	var/mob/living/carbon/C = owner
+
+	if(istype(C))
+		if(!failing || C.reagents.has_reagent("iecure"))	//can't process reagents with a failing liver - however process everything if we have the one that heals the liver
+			//slowly heal liver damage
+			damage = max(0, damage - 0.1)
+
+			if(filterToxins && !owner.has_trait(TRAIT_TOXINLOVER))
+				//handle liver toxin filtration
+				var/static/list/toxinstypecache = typecacheof(/datum/reagent/toxin)
+				for(var/I in C.reagents.reagent_list)
+					var/datum/reagent/pickedreagent = I
+					if(is_type_in_typecache(pickedreagent, toxinstypecache))
+						var/thisamount = C.reagents.get_reagent_amount(initial(pickedreagent.id))
+						if (thisamount <= toxTolerance && thisamount)
+							C.reagents.remove_reagent(initial(pickedreagent.id), 1)
+						else
+							damage += (thisamount*toxLethality)
+
+			//metabolize reagents
+			C.reagents.metabolize(C, can_overdose=TRUE)
+
+		if(damage > 10 && prob(damage/3) && !C.reagents.has_reagent("iecure"))	//the higher the damage the higher the probability
+			to_chat(C, "<span class='notice'>You feel [pick("nauseous", "a dull pain in your lower body", "confused")].</span>")	//no liver damage message if they have the liver fixing chemical
+
+	if(damage > maxHealth)//cap liver damage
+		damage = maxHealth
+
+	if(damage < maxHealth && failing)	//if their liver is healed, stop killing them!!
+		failing = FALSE
+		to_chat(C, "<span class='notice'>You feel [pick("the pain in your lower body fading", "awake and alert again")].</span>")


### PR DESCRIPTION
I have added a new chemical called iecure, it rapidly heals liver damage, purges alcohol from the system and heals toxin damage when the liver is failing (it never restores you to full health because it stops healing toxin damage once the liver is functional again). It has a similar recipe to oculine and the... other one that heals ear damage (Inacusiate?). I also modularised some things to make some balance changes to livers and alcohol, here are some changes I made:

- Reduced alcohol's sleeping time from 90 seconds to 10 seconds (whew lad this one was not fun)
- Reduced the amount of alcohol required to get liver failure
- Made the damage from liver failure vary more (it was fixed at 8 toxloss, now it does a random value between 1 and 8 toxloss to give the player more time to react)

:cl:
add: Added a new chemical that fixes liver damage and stops liver failure. Just make sure you're really quick on getting it!
balance: Reduced alcohol's sleeping time from 90 seconds to 10 seconds
balance: Reduced the amount of alcohol required to suffer from liver damage and get liver failure
balance: Changed the amount of damage liver failure gives so there's more time to fix the liver before imminent death
fix: Corrected a typo in the liver damage description in health scanners
/:cl: