### PR TITLE
Nanosuit upgrades

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -1,13 +1,13 @@
-//Crytek Nanosuit
+//Crytek Nanosuit made by YoYoBatty
 /obj/item/clothing/under/syndicate/combat/nano
 	name = "nanosuit lining"
 	desc = "Foreign body resistant lining built below the nanosuit. Provides internal protection. Property of CryNet Systems."
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 	armor = list("melee" = 20, "bullet" = 10, "laser" = 0,"energy" = 5, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 80, "acid" = 50)
 
-/obj/item/clothing/under/syndicate/combat/nano/ComponentInitialize()
+/obj/item/clothing/suit/space/hardsuit/nano/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
 
 /obj/item/clothing/under/syndicate/combat/nano/equipped(mob/user, slot)
 	.=..()
@@ -23,10 +23,6 @@
 	desc = "Operator mask. Property of CryNet Systems." //More accurate
 	icon_state = "syndicate"
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
-
-/obj/item/clothing/mask/gas/nano_gas/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
 
 /obj/item/clothing/mask/gas/nano_mask/equipped(mob/user, slot)
 	.=..()
@@ -53,11 +49,6 @@
 	var/jumpdistance = 2 //-1 from to see the actual distance, e.g 3 goes over 2 tiles
 	var/jumpspeed = 1
 	actions_types = list(/datum/action/item_action/nanojump)
-
-/obj/item/clothing/shoes/combat/nano/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
-
 
 /obj/item/clothing/shoes/combat/coldres/nanojump/ui_action_click(mob/user, action)
 	if(!isliving(user))
@@ -111,12 +102,6 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 
-/obj/item/clothing/gloves/combat/nano/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
-
-/obj/item/device/radio/headset/syndicate/alt/nano
-
 /obj/item/clothing/gloves/combat/nano/equipped(mob/user, slot)
 	.=..()
 	if(slot == SLOT_GLOVES)
@@ -135,20 +120,16 @@
 	keyslot = new /obj/item/encryptionkey/binary
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 
-/obj/item/device/radio/headset/syndicate/alt/nano/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
-
-/obj/item/device/radio/headset/syndicate/alt/nano/equipped(mob/user, slot)
+/obj/item/radio/headset/syndicate/alt/nano/equipped(mob/user, slot)
 	.=..()
 	if(slot == SLOT_EARS)
 		flags_1 |= NODROP_1
 
-/obj/item/device/radio/headset/syndicate/alt/nano/dropped(mob/user)
+/obj/item/radio/headset/syndicate/alt/nano/dropped(mob/user)
 	..()
 	qdel(src)
 
-/obj/item/device/radio/headset/syndicate/alt/nano/emp_act()
+/obj/item/radio/headset/syndicate/alt/nano/emp_act()
 	return
 
 /obj/item/clothing/glasses/nano_goggles
@@ -163,10 +144,6 @@
 	actions_types = list(/datum/action/item_action/nanogoggles/toggle)
 	vision_correction = 1 //We must let our wearer have good eyesight
 	var/on = 0
-
-/obj/item/clothing/glasses/nano_goggles/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
 
 /datum/client_colour/glass_colour/nightvision
 	colour = "#45723f"
@@ -224,8 +201,8 @@
 	item_state = "nanosuit"
 	name = "nanosuit"
 	desc = "Some sort of alien future suit. It looks very robust. Property of CryNet Systems."
-	var/armor_mode = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 65, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 45, "bomb" = 70, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
+	var/armor_mode = list("melee" = 70, "bullet" = 60, "laser" = 60, "energy" = 65, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 40, "energy" = 45, "bomb" = 70, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 	allowed = list(/obj/item/tank/internals)
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
@@ -257,13 +234,14 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
 
 /obj/item/clothing/suit/space/hardsuit/nano/emp_act(severity)
 	..()
 	cell.use(round(cell.charge / severity))
-	if(prob(5/severity*1.5) && !shutdown)
-		emp_assault()
+	if(mode != "armor" && cell.charge > 0)
+		if(prob(5/severity*1.5) && !shutdown)
+			emp_assault()
 	update_icon()
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/emp_assault()
@@ -553,13 +531,19 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF //No longer shall our kind be foiled by lone chemists with spray bottles!
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 45, "bomb" = 70, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 40, "energy" = 45, "bomb" = 70, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
-	var/list/datahuds = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_BASIC)
+	var/list/datahuds = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)
 	var/zoom_range = 12
 	var/zoom = FALSE
+	var/obj/machinery/doppler_array/integrated/bomb_radar
+	scan_reagents = 1
 	actions_types = list(/datum/action/item_action/nanosuit/zoom)
+
+/obj/item/clothing/head/helmet/space/hardsuit/nano/Initialize()
+	. = ..()
+	bomb_radar = new /obj/machinery/doppler_array/integrated(src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/nano/ui_action_click()
 	return FALSE
@@ -610,7 +594,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/nano/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
 
 /obj/item/clothing/suit/space/hardsuit/nano/equipped(mob/user, slot)
 	if(ishuman(user))
@@ -633,7 +617,7 @@
 	uniform = /obj/item/clothing/under/syndicate/combat/nano
 	glasses = /obj/item/clothing/glasses/nano_goggles
 	mask = /obj/item/clothing/mask/gas/nano_mask
-	ears = /obj/item/device/radio/headset/syndicate/alt/nano
+	ears = /obj/item/radio/headset/syndicate/alt/nano
 	shoes = /obj/item/clothing/shoes/combat/coldres/nanojump
 	gloves = /obj/item/clothing/gloves/combat/nano
 	implants = list(/obj/item/implant/explosive/disintegrate)
@@ -667,16 +651,17 @@ obj/item/clothing/suit/space/hardsuit/nano/dropped()
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
-	if(. && mob_has_gravity()) //floating is easy
+	if(.) //floating is easy
 		if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
 			var/obj/item/clothing/suit/space/hardsuit/nano/NS = wear_suit
-			if(stat != DEAD && m_intent == MOVE_INTENT_RUN)
-				if(NS.cell.charge > 0)
-					if(NS.mode == "speed" || NS.mode == "cloak")
-						NS.cell.use(NS.move_use)
-				else
-					if(NS.mode != "armor")//no more infinite loops
-						NS.toggle_mode("armor", TRUE)
+			if(mob_has_gravity())
+				if(stat != DEAD && m_intent == MOVE_INTENT_RUN)
+					if(NS.cell.charge > 0)
+						if(NS.mode == "speed" || NS.mode == "cloak")
+							NS.cell.use(NS.move_use)
+					else
+						if(NS.mode != "armor")//no more infinite loops
+							NS.toggle_mode("armor", TRUE)
 
 /datum/martial_art/nano
 	name = "Strength Mode"
@@ -758,7 +743,7 @@ obj/item/clothing/suit/space/hardsuit/nano/dropped()
 
 
 /obj/proc/nano_damage() //the damage nanosuits do on punches to this object, is affected by melee armor
-	return 22 //just enough to damage an airlock
+	return 25 //just enough to damage an airlock
 
 /atom/proc/attack_nano(mob/living/carbon/human/user, does_attack_animation = 0)
 	SendSignal(COMSIG_ATOM_HULK_ATTACK, user)
@@ -899,6 +884,7 @@ obj/item/clothing/suit/space/hardsuit/nano/dropped()
 	name = "self-filling miniature oxygen tank"
 	desc = "A magical tank that uses bluespace technology to replenish it's oxygen supply."
 	volume = 2
+	icon_state = "emergency_tst"
 
 /obj/item/tank/internals/emergency_oxygen/recharge/New()
 	..()


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: Bomb radar + reagent scanner to nanosuit
add: Can now attack mob/living/carbon with nano damage (strength unarmed attack)
add: Shooting an empty gun in cloak no longer cancels cloak
add: Shooting a suppressed gun in cloak temporarily pauses and unpauses cloak.
tweak: Changed radiation insulation on nanosuit suit and head to medium
balance: Increased nano damage to 25 from 22
balance: Increased melee protection in armour mode to 70 from 60 and default armour to 50 from 40
fix: Headset is now under obj/item/radio rather than obj/item/device/radio
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
