### PR TITLE
Potential fix for door timers fucking up

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1071,7 +1071,7 @@
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 
 	if(autoclose)
-		autoclose_in(normalspeed ? 150 : 15)
+		autoclosedoor_in(normalspeed ? 150 : 15)
 
 	if(!density)
 		return TRUE
@@ -1104,7 +1104,7 @@
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
-				autoclose_in(60)
+				autoclosedoor_in(60)
 				return
 
 	if(forced < 2)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -263,7 +263,7 @@
 	air_update_turf(1)
 	update_freelook_sight()
 	if(autoclose)
-		spawn(autoclose)
+		spawn(autoclosedoor())
 			close()
 	return 1
 
@@ -276,7 +276,7 @@
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
 				if(autoclose)
-					autoclose_in(60)
+					autoclosedoor_in(60)
 				return
 
 	operating = TRUE
@@ -324,12 +324,12 @@
 	for(var/obj/mecha/M in get_turf(src))
 		M.take_damage(DOOR_CRUSH_DAMAGE)
 
-/obj/machinery/door/proc/autoclose()
+/obj/machinery/door/proc/autoclosedoor()
 	if(!QDELETED(src) && !density && !operating && !locked && !welded && autoclose)
 		close()
 
-/obj/machinery/door/proc/autoclose_in(wait)
-	addtimer(CALLBACK(src, .proc/autoclose), wait, TIMER_UNIQUE | TIMER_NO_HASH_WAIT | TIMER_OVERRIDE)
+/obj/machinery/door/proc/autoclosedoor_in(wait)
+	addtimer(CALLBACK(src, .proc/autoclosedoor), wait, TIMER_UNIQUE | TIMER_NO_HASH_WAIT | TIMER_OVERRIDE)
 
 /obj/machinery/door/proc/requiresID()
 	return 1


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Airlock timers were attempting to call a variable instead of a proc with the same name smh
code: Editted proc autoclose() to autoclosedoor()
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
