### PR TITLE
Fixes a ton of performance sucking runtimes 

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -32,8 +32,7 @@ SUBSYSTEM_DEF(lighting)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 	var/i = 0
-	//Hippie code
-	for (i = 1, i <= GLOB.lighting_update_lights.len, i++)
+	for (i in 1 to GLOB.lighting_update_lights.len)
 		var/datum/light_source/L = GLOB.lighting_update_lights[i]
 
 		L.update_corners()
@@ -45,13 +44,13 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_lights.Cut(1, i)
+		GLOB.lighting_update_lights.Cut(1, i+1)
 		i = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i = 1, i <= GLOB.lighting_update_corners.len, i++)
+	for (i in 1 to GLOB.lighting_update_corners.len)
 		var/datum/lighting_corner/C = GLOB.lighting_update_corners[i]
 
 		C.update_objects()
@@ -61,14 +60,14 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_corners.Cut(1, i)
+		GLOB.lighting_update_corners.Cut(1, i+1)
 		i = 0
 
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i = 1, i <= GLOB.lighting_update_objects.len, i++)
+	for (i in 1 to GLOB.lighting_update_objects.len)
 		var/atom/movable/lighting_object/O = GLOB.lighting_update_objects[i]
 
 		if (QDELETED(O))
@@ -81,8 +80,8 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_objects.Cut(1, i)
-	//Hippie code end
+		GLOB.lighting_update_objects.Cut(1, i+1)
+
 
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(lighting)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 	var/i = 0
-	for (i in 1 to GLOB.lighting_update_lights.len)
+	for (i = 1, i <= GLOB.lighting_update_lights.len, i++)
 		var/datum/light_source/L = GLOB.lighting_update_lights[i]
 
 		L.update_corners()
@@ -44,13 +44,13 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_lights.Cut(1, i+1)
+		GLOB.lighting_update_lights.Cut(1, i)
 		i = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i in 1 to GLOB.lighting_update_corners.len)
+	for (i = 1, i <= GLOB.lighting_update_corners.len, i++)
 		var/datum/lighting_corner/C = GLOB.lighting_update_corners[i]
 
 		C.update_objects()
@@ -60,14 +60,14 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_corners.Cut(1, i+1)
+		GLOB.lighting_update_corners.Cut(1, i)
 		i = 0
 
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i in 1 to GLOB.lighting_update_objects.len)
+	for (i = 1, i <= GLOB.lighting_update_objects.len, i++)
 		var/atom/movable/lighting_object/O = GLOB.lighting_update_objects[i]
 
 		if (QDELETED(O))
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(lighting)
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		GLOB.lighting_update_objects.Cut(1, i+1)
+		GLOB.lighting_update_objects.Cut(1, i)
 
 
 /datum/controller/subsystem/lighting/Recover()

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -32,6 +32,7 @@ SUBSYSTEM_DEF(lighting)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 	var/i = 0
+	//Hippie code
 	for (i = 1, i <= GLOB.lighting_update_lights.len, i++)
 		var/datum/light_source/L = GLOB.lighting_update_lights[i]
 
@@ -81,7 +82,7 @@ SUBSYSTEM_DEF(lighting)
 			break
 	if (i)
 		GLOB.lighting_update_objects.Cut(1, i)
-
+	//Hippie code end
 
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -30,7 +30,7 @@
 	icon_state = beam_icon_state
 	beam_type = btype
 	if(time < INFINITY)
-		QDEL_IN(src, time)
+		QDEL_IN(src, time) //Hippie code
 
 /datum/beam/proc/Start()
 	Draw()
@@ -83,8 +83,8 @@
 
 /datum/beam/Destroy()
 	Reset()
-	if(!isnull(timing_id))
-		deltimer(timing_id)
+	if(!isnull(timing_id)) //Hippie code
+		deltimer(timing_id) // End
 	target = null
 	origin = null
 	return ..()

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -30,7 +30,7 @@
 	icon_state = beam_icon_state
 	beam_type = btype
 	if(time < INFINITY)
-		addtimer(CALLBACK(src,.proc/End), time)
+		QDEL_IN(src, time)
 
 /datum/beam/proc/Start()
 	Draw()
@@ -83,6 +83,8 @@
 
 /datum/beam/Destroy()
 	Reset()
+	if(!isnull(timing_id))
+		deltimer(timing_id)
 	target = null
 	origin = null
 	return ..()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -78,6 +78,9 @@
 	var/datum/action/turret_toggle/toggle_action
 	var/mob/remote_controller
 
+	var/lastdamage_time //Hippie code to override timer
+	var/reset_time = 60 //Hippie code
+
 /obj/machinery/porta_turret/Initialize()
 	. = ..()
 	if(!base)
@@ -324,15 +327,12 @@
 
 /obj/machinery/porta_turret/take_damage(damage, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	. = ..()
-	if(.) //damage received
+	if(. && src && !QDELETED(src)) //damage received
 		if(prob(30))
 			spark_system.start()
 		if(on && !attacked && !(obj_flags & EMAGGED))
 			attacked = TRUE
-			addtimer(CALLBACK(src, .proc/reset_attacked), 60)
-
-/obj/machinery/porta_turret/proc/reset_attacked()
-	attacked = FALSE
+			lastdamage_time = world.time + reset_time
 
 /obj/machinery/porta_turret/deconstruct(disassembled = TRUE)
 	qdel(src)
@@ -412,6 +412,11 @@
 		tryToShootAt(targets)
 	else if(!always_up)
 		popDown() // no valid targets, close the cover
+
+	//Hippie code reset the attack timer after 6 seconds
+	if(attacked && world.time > lastdamage_time)
+		attacked = FALSE
+
 
 /obj/machinery/porta_turret/proc/tryToShootAt(list/atom/movable/targets)
 	while(targets.len > 0)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -327,12 +327,12 @@
 
 /obj/machinery/porta_turret/take_damage(damage, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	. = ..()
-	if(. && src && !QDELETED(src)) //damage received
+	if(. && src && !QDELETED(src)) //damage received. Hippie code
 		if(prob(30))
 			spark_system.start()
 		if(on && !attacked && !(obj_flags & EMAGGED))
 			attacked = TRUE
-			lastdamage_time = world.time + reset_time
+			lastdamage_time = world.time + reset_time //Hippie code
 
 /obj/machinery/porta_turret/deconstruct(disassembled = TRUE)
 	qdel(src)

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -29,6 +29,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/autocleanup = FALSE //will delete itself after use
 
 /datum/effect_system/Destroy()
+	total_effects--
 	holder = null
 	location = null
 	return ..()
@@ -66,7 +67,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
+	if(autocleanup && total_effects <= 0)
+		QDEL_IN(src, 20)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -29,7 +29,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/autocleanup = FALSE //will delete itself after use
 
 /datum/effect_system/Destroy()
-	total_effects--
+	total_effects-- //Hippie code
 	holder = null
 	location = null
 	return ..()
@@ -67,8 +67,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	if(autocleanup && total_effects <= 0)
-		QDEL_IN(src, 20)
+	if(autocleanup && total_effects <= 0) //Hippie
+		QDEL_IN(src, 20) //Code
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -207,8 +207,9 @@
 		return // the device has to be on
 	if(!M || !message)
 		return
-	if(wires.is_cut(WIRE_TX))  // Permacell and otherwise tampered-with radios
-		return
+	if(wires)
+		if(wires.is_cut(WIRE_TX))  // Permacell and otherwise tampered-with radios
+			return
 	if(!M.IsVocal())
 		return
 
@@ -272,14 +273,16 @@
 
 /obj/item/radio/proc/backup_transmission(datum/signal/subspace/vocal/signal)
 	var/turf/T = get_turf(src)
-	if (signal.data["done"] && (T.z in signal.levels))
-		return
+	//hippie code check
+	if(T)
+		if(signal.data["done"] && (T.z in signal.levels))
+			return
 
-	// Okay, the signal was never processed, send a mundane broadcast.
-	signal.data["compression"] = 0
-	signal.transmission_method = TRANSMISSION_RADIO
-	signal.levels = list(T.z)
-	signal.broadcast()
+		// Okay, the signal was never processed, send a mundane broadcast.
+		signal.data["compression"] = 0
+		signal.transmission_method = TRANSMISSION_RADIO
+		signal.levels = list(T.z)
+		signal.broadcast()
 
 /obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -207,7 +207,7 @@
 		return // the device has to be on
 	if(!M || !message)
 		return
-	if(wires)
+	if(wires) //Hippie code because certain things attempt to talk after deletion, aka supermatter
 		if(wires.is_cut(WIRE_TX))  // Permacell and otherwise tampered-with radios
 			return
 	if(!M.IsVocal())

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -54,7 +54,7 @@
 	else if(isobj(AM))
 		var/obj/O = AM
 		tforce = O.throwforce
-	if(src && !QDELETED(src))
+	if(src && !QDELETED(src)) //Hippie code. Do we still exist?
 		take_damage(tforce, BRUTE, "melee", 1, get_dir(src, AM))
 
 /obj/ex_act(severity, target)
@@ -70,17 +70,17 @@
 			obj_integrity = 0
 			qdel(src)
 		if(2)
-			if(src && !QDELETED(src))
+			if(src && !QDELETED(src))//Hippie code. Do we still exist?
 				take_damage(rand(100, 250), BRUTE, "bomb", 0)
 		if(3)
-			if(src && !QDELETED(src))
+			if(src && !QDELETED(src))//Hippie code. Do we still exist?
 				take_damage(rand(10, 90), BRUTE, "bomb", 0)
 
 /obj/bullet_act(obj/item/projectile/P)
 	. = ..()
 	playsound(src, P.hitsound, 50, 1)
 	visible_message("<span class='danger'>[src] is hit by \a [P]!</span>", null, null, COMBAT_MESSAGE_RANGE)
-	if(src && !QDELETED(src))
+	if(src && !QDELETED(src)) //Hippie code. Do we still exist?
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 /obj/proc/hulk_damage()
@@ -109,7 +109,7 @@
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if(src && !QDELETED(src))
+	if(src && !QDELETED(src))//Hippie code. Do we still exist?
 		return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -54,7 +54,8 @@
 	else if(isobj(AM))
 		var/obj/O = AM
 		tforce = O.throwforce
-	take_damage(tforce, BRUTE, "melee", 1, get_dir(src, AM))
+	if(src && !QDELETED(src))
+		take_damage(tforce, BRUTE, "melee", 1, get_dir(src, AM))
 
 /obj/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)
@@ -69,15 +70,18 @@
 			obj_integrity = 0
 			qdel(src)
 		if(2)
-			take_damage(rand(100, 250), BRUTE, "bomb", 0)
+			if(src && !QDELETED(src))
+				take_damage(rand(100, 250), BRUTE, "bomb", 0)
 		if(3)
-			take_damage(rand(10, 90), BRUTE, "bomb", 0)
+			if(src && !QDELETED(src))
+				take_damage(rand(10, 90), BRUTE, "bomb", 0)
 
 /obj/bullet_act(obj/item/projectile/P)
 	. = ..()
 	playsound(src, P.hitsound, 50, 1)
 	visible_message("<span class='danger'>[src] is hit by \a [P]!</span>", null, null, COMBAT_MESSAGE_RANGE)
-	take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
+	if(src && !QDELETED(src))
+		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 /obj/proc/hulk_damage()
 	return 150 //the damage hulks do on punches to this object, is affected by melee armor
@@ -105,7 +109,8 @@
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
+	if(src && !QDELETED(src))
+		return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(attack_generic(user, 60, BRUTE, "melee", 0))

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -35,7 +35,8 @@
 
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.
-		air_contents.react(src)
+		if(air_contents)
+			air_contents.react(src)
 	else
 		update_icon()
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -35,7 +35,7 @@
 
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port) // Pipe network handles reactions if connected.
-		if(air_contents)
+		if(air_contents)//Hippie code. Do we exist?
 			air_contents.react(src)
 	else
 		update_icon()

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -40,7 +40,7 @@
 
 /obj/machinery/portable_atmospherics/pump/process_atmos()
 	..()
-	if(!on)
+	if(!on && pump)
 		pump.airs[1] = null
 		pump.airs[2] = null
 		return

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -40,7 +40,7 @@
 
 /obj/machinery/portable_atmospherics/pump/process_atmos()
 	..()
-	if(!on && pump)
+	if(!on && pump)//Hippie code. Do we still exist?
 		pump.airs[1] = null
 		pump.airs[2] = null
 		return

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -328,7 +328,7 @@
 	for(var/d in dead_barricades)
 		var/obj/effect/ctf/dead_barricade/D = d
 		D.respawn()
-	//hippie code
+	//hippie code. Start when ctf starts
 	for(var/obj/machinery/power/emitter/energycannon/C in GLOB.machines)
 		if(!C.active)
 			C.active = TRUE
@@ -362,7 +362,7 @@
 	team_members.Cut()
 	spawned_mobs.Cut()
 	recently_dead_ckeys.Cut()
-	//hippie code
+	//hippie code. Stop when ctf ends so we don't lag the game.
 	for(var/obj/machinery/power/emitter/energycannon/C in GLOB.machines)
 		if(C.active)
 			C.active = FALSE

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -328,6 +328,11 @@
 	for(var/d in dead_barricades)
 		var/obj/effect/ctf/dead_barricade/D = d
 		D.respawn()
+	//hippie code
+	for(var/obj/machinery/power/emitter/energycannon/C in GLOB.machines)
+		if(!C.active)
+			C.active = TRUE
+	//end hippie code
 
 	dead_barricades.Cut()
 
@@ -357,6 +362,11 @@
 	team_members.Cut()
 	spawned_mobs.Cut()
 	recently_dead_ckeys.Cut()
+	//hippie code
+	for(var/obj/machinery/power/emitter/energycannon/C in GLOB.machines)
+		if(C.active)
+			C.active = FALSE
+	//end hippie code
 
 /obj/machinery/capture_the_flag/proc/instagib_mode()
 	for(var/obj/machinery/capture_the_flag/CTF in GLOB.machines)

--- a/code/modules/awaymissions/mission_code/challenge.dm
+++ b/code/modules/awaymissions/mission_code/challenge.dm
@@ -28,7 +28,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 
-	active = 1
+	active = 0
 	locked = TRUE
 	state = 2
 

--- a/code/modules/awaymissions/mission_code/challenge.dm
+++ b/code/modules/awaymissions/mission_code/challenge.dm
@@ -28,7 +28,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 
-	active = 0
+	active = 0 //Hippie code. Start disabled to reduce lag.
 	locked = TRUE
 	state = 2
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -802,4 +802,5 @@
 			torn_items += leg_clothes
 
 	for(var/obj/item/I in torn_items)
-		I.take_damage(damage_amount, damage_type, damage_flag, 0)
+		if(I && !QDELETED(I))
+			I.take_damage(damage_amount, damage_type, damage_flag, 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -55,7 +55,7 @@
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
-	if(dna)
+	if(dna)//Do we have dna?
 		dna.species.spec_life(src) // for mutantraces
 
 	if(stat != DEAD)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -55,7 +55,8 @@
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
-	dna.species.spec_life(src) // for mutantraces
+	if(dna)
+		dna.species.spec_life(src) // for mutantraces
 
 	if(stat != DEAD)
 		return 1

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -188,7 +188,7 @@
 
 
 	//attempt to dismember bodyparts
-	if(severity <= 2)
+	if(severity && severity <= 2)
 		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -188,7 +188,7 @@
 
 
 	//attempt to dismember bodyparts
-	if(severity && severity <= 2)
+	if(severity && severity <= 2)//Hippie code. Make sure we got a severity.
 		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -265,7 +265,7 @@
 	//Alright, we've done our loop, now lets see if was anything interesting in range
 	if(closest_atom)
 		//common stuff
-		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=5, maxdistance = INFINITY)
+		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=6, maxdistance = INFINITY)
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES))
 			LAZYSET(shocked_targets, closest_atom, TRUE)
 		var/zapdir = get_dir(source, closest_atom)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -265,7 +265,7 @@
 	//Alright, we've done our loop, now lets see if was anything interesting in range
 	if(closest_atom)
 		//common stuff
-		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=6, maxdistance = INFINITY)
+		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", time=6, maxdistance = INFINITY) //Hippie code
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES))
 			LAZYSET(shocked_targets, closest_atom, TRUE)
 		var/zapdir = get_dir(source, closest_atom)

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -84,11 +84,12 @@
 					return TRUE
 
 			var/obj/effect/decal/cleanable/chempile/C = new /obj/effect/decal/cleanable/chempile(T)//otherwise makes a new one
-			if(touch_msg)
-				C.add_fingerprint(touch_mob)
-			C.reagents.add_reagent("[src.id]", volume)
-			var/mixcolor = mix_color_from_reagents(C.reagents.reagent_list)
-			C.add_atom_colour(mixcolor, FIXED_COLOUR_PRIORITY)
+			if(C.reagents)
+				if(touch_msg)
+					C.add_fingerprint(touch_mob)
+				C.reagents.add_reagent("[src.id]", volume)
+				var/mixcolor = mix_color_from_reagents(C.reagents.reagent_list)
+				C.add_atom_colour(mixcolor, FIXED_COLOUR_PRIORITY)
 
 		if(src.reagent_state == SOLID) //SOLID
 			if(atom && istype(atom, /obj/effect/particle_effect))


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Fixed a runtime involving calling the deletion of datum/beam.
fix: Fixed a runtime involving a timer callback to reset the attacked stated of porta_turret
fix: Fixed a runtime involving the effect system involving a deletion timer callback.
fix: Fixed a runtime associated with not checking if a radio had wires. (Supermatter is a good example)
fix: A runtime involving null turf location for radios.
fix: A runtime involving objects taking damage after deletion (Tesla would do this and cause huge lag)
fix: A runtime associated with air_contects being null in portable_atmospherics
fix: A runtime associated with pump being null.
fix: More of an optimization, but CTF emitters start disabled and activate when CTF stars and turns off post game.
fix: Fix a runtime involved with clothing taking damage after deletion. (Explosions mainly)
fix: Ensures humans have dna being call spec_life(src)
fix: monkey_defense ex_act has a severity check to ensure it's not 0.
code: Change tesla's beam time from 5 to 6 as an attempt to ensure the beam callback timer was running it's length (3 ticks)
fix: Made sure Chempiles had configured reagents before calling code.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I think this is ready to go.
