### PR TITLE
You can now fill fire extinguishers with any reagent container!

### DIFF
--- a/hippiestation/code/game/objects/items/extinguisher.dm
+++ b/hippiestation/code/game/objects/items/extinguisher.dm
@@ -26,3 +26,22 @@
 		return 1
 	else
 		return 0
+
+/obj/item/extinguisher/attackby(obj/O, mob/user)	//I tried working with what was up above but the code is so abysmally shit this was WAY easier to do
+	if(istype(O, /obj/item/reagent_containers))
+		if(!safety)
+			if(reagents.total_volume == reagents.maximum_volume)
+				to_chat(user, "<span class='warning'>\The [src] is already full!</span>")
+				return
+			var/transferred = O.reagents.trans_to(src, max_water)	//Might as well auto-fill right
+			if(transferred > 0)
+				to_chat(user, "<span class='notice'>\The [src] has been refilled by [transferred] units.</span>")
+				for(var/datum/reagent/water/R in reagents.reagent_list)
+					R.cooling_temperature = cooling_power
+			else
+				to_chat(user, "<span class='warning'>\The [O] is empty!</span>")
+				return
+		else
+			to_chat(user, "<span class='warning'>You need to take off the safety before you can refill the [src]!</span>")
+
+	..()

--- a/hippiestation/code/game/objects/items/extinguisher.dm
+++ b/hippiestation/code/game/objects/items/extinguisher.dm
@@ -1,5 +1,17 @@
-/obj/item/extinguisher
-	container_type = OPENCONTAINER
+/obj/item/extinguisher/attack_self(mob/user)
+	..()
+	if(safety)
+		container_type = AMOUNT_VISIBLE
+	else
+		container_type = OPENCONTAINER
+
+/obj/item/extinguisher/attackby(obj/O, mob/user)
+	if(istype(O, /obj/item/reagent_containers))
+		if(safety)
+			to_chat(user, "<span class='warning'>You need to take off the safety before you can refill the [src]!</span>")
+			return
+	else
+		..()
 
 /obj/item/extinguisher/attack_obj(obj/O, mob/living/user)
 	if(attempt_refill_hippie(O, user))

--- a/hippiestation/code/game/objects/items/extinguisher.dm
+++ b/hippiestation/code/game/objects/items/extinguisher.dm
@@ -1,3 +1,6 @@
+/obj/item/extinguisher
+	container_type = OPENCONTAINER
+
 /obj/item/extinguisher/attack_obj(obj/O, mob/living/user)
 	if(attempt_refill_hippie(O, user))
 		refilling = TRUE
@@ -26,22 +29,3 @@
 		return 1
 	else
 		return 0
-
-/obj/item/extinguisher/attackby(obj/O, mob/user)	//I tried working with what was up above but the code is so abysmally shit this was WAY easier to do
-	if(istype(O, /obj/item/reagent_containers))
-		if(!safety)
-			if(reagents.total_volume == reagents.maximum_volume)
-				to_chat(user, "<span class='warning'>\The [src] is already full!</span>")
-				return
-			var/transferred = O.reagents.trans_to(src, max_water)	//Might as well auto-fill right
-			if(transferred > 0)
-				to_chat(user, "<span class='notice'>\The [src] has been refilled by [transferred] units.</span>")
-				for(var/datum/reagent/water/R in reagents.reagent_list)
-					R.cooling_temperature = cooling_power
-			else
-				to_chat(user, "<span class='warning'>\The [O] is empty!</span>")
-				return
-		else
-			to_chat(user, "<span class='warning'>You need to take off the safety before you can refill the [src]!</span>")
-
-	..()


### PR DESCRIPTION
So I looked at fire extinguishers and saw that you can refill it with water tanks. Now I thought this was pretty dumb actually, considering you can *only* do it with water tanks. I tried working with that code to include reagent containers in itself but the code was so shitty I had to make a new interaction entirely. Regardless, you can now fill fire extinguishers with ANY beaker or other item that holds reagents. This should create some interesting scenarios. For example I already had a crazy flamethrower by putting clf3 into the extinguisher.

:cl:
add: You can now refill fire extinguishers with any reagent container!
/:cl: