### PR TITLE
Fixed null.client runtime in vote.dm

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -329,6 +329,7 @@ SUBSYSTEM_DEF(vote)
 /datum/action/vote/IsAvailable()
 	return 1
 
+/*	Hippie version is being used instead
 /datum/action/vote/proc/remove_from_client()
 	if(owner.client)
 		owner.client.player_details.player_actions -= src
@@ -338,3 +339,4 @@ SUBSYSTEM_DEF(vote)
 			P.player_actions -= src
 	else
 		return
+*/	Hippie end

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -339,4 +339,4 @@ SUBSYSTEM_DEF(vote)
 			P.player_actions -= src
 	else
 		return
-*/	Hippie end
+*/	//Hippie end

--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -244,7 +244,3 @@
 			var/datum/player_details/P = GLOB.player_details[owner.ckey]
 			if(P)
 				P.player_actions -= src
-		else
-			return
-	else
-		return

--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -235,3 +235,16 @@
 
 
 	return .
+
+/datum/action/vote/proc/remove_from_client()
+	if(owner)	//Fixes null.client runtimes
+		if(owner.client)
+			owner.client.player_details.player_actions -= src
+		else if(owner.ckey)
+			var/datum/player_details/P = GLOB.player_details[owner.ckey]
+			if(P)
+				P.player_actions -= src
+		else
+			return
+	else
+		return


### PR DESCRIPTION
Turns out doing votes in the lobby screen can cause null.client errors - I have added a check to fix this

:cl:
fix: Fixed a null client error if a vote is started in the lobby screen
/:cl: