### PR TITLE
Fixes nanosuit implant causing runtimes.

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -610,15 +610,6 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/recharge
 	internals_slot = SLOT_S_STORE
 
-
-obj/item/clothing/suit/space/hardsuit/nano/dropped()
-	toggle_mode("none", TRUE)
-	if(U)
-		if(help_verb)
-			U.verbs -= help_verb
-		U = null
-	..()
-
 /mob/living/carbon/human/Stat()
 	..()
 	//NANOSUITCODE
@@ -935,6 +926,8 @@ obj/item/clothing/suit/space/hardsuit/nano/dropped()
 /obj/item/implant/explosive/disintegrate/activate(cause)
 	if(!cause || !imp_in || active)
 		return FALSE
+	if(!src.loc) //Do we have a host?
+		return FALSE
 	if(cause == "action_button" && !popup)
 		popup = TRUE
 		var/response = alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to vapourize!", "[name] Confirmation", "Yes", "No")
@@ -947,7 +940,7 @@ obj/item/clothing/suit/space/hardsuit/nano/dropped()
 	var/area/A = get_area(dustturf)
 	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [A.name] [ADMIN_JMP(dustturf)], with cause of [cause].")
 	playsound(loc, 'sound/effects/fuse.ogg', 30, 0)
-	imp_in.dust()
+	imp_in.dust(TRUE,TRUE)
 	qdel(src)
 
 /obj/item/tank/internals/emergency_oxygen/recharge


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
tweak: Nanosuit will drop what the user is wearing on death, but does not include the suit and its equipment.
fix: Fixes that bugger runtime when the nanosuit user dies. 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
