### PR TITLE
Fixes some very performance hogging runtimes in atmos processing

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -263,7 +263,7 @@
 
 /turf/open/rad_act(pulse_strength)
 	. = ..()
-	if (air.gases[/datum/gas/carbon_dioxide] && air.gases[/datum/gas/oxygen])
+	if(air && air.gases[/datum/gas/carbon_dioxide] && air.gases[/datum/gas/oxygen])//hippie code
 		pulse_strength = min(pulse_strength,air.gases[/datum/gas/carbon_dioxide][MOLES]*1000,air.gases[/datum/gas/oxygen][MOLES]*2000) //Ensures matter is conserved properly
 		air.gases[/datum/gas/carbon_dioxide][MOLES]=max(air.gases[/datum/gas/carbon_dioxide][MOLES]-(pulse_strength/1000),0)
 		air.gases[/datum/gas/oxygen][MOLES]=max(air.gases[/datum/gas/oxygen][MOLES]-(pulse_strength/2000),0)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -54,7 +54,8 @@
 /turf/open/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
 	if(!giver)
 		return FALSE
-	air.merge(giver)
+	if(air)//hippie code
+		air.merge(giver)
 	update_visuals()
 	return TRUE
 
@@ -88,7 +89,8 @@
 	temperature_archived = temperature
 
 /turf/open/archive()
-	air.archive()
+	if(air)//hippie code
+		air.archive()
 	archived_cycle = SSair.times_fired
 	temperature_archived = temperature
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -385,30 +385,32 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//thermal energy of the system (self and sharer) is unchanged
 
 /datum/gas_mixture/compare(datum/gas_mixture/sample)
-	var/list/sample_gases = sample.gases //accessing datum vars is slower than proc vars
-	var/list/cached_gases = gases
+	if(sample)//Hippie code fix
+		var/list/sample_gases = sample.gases //accessing datum vars is slower than proc vars
+		var/list/cached_gases = gases
 
-	for(var/id in cached_gases | sample_gases) // compare gases from either mixture
-		var/gas_moles = cached_gases[id]
-		gas_moles = gas_moles ? gas_moles[MOLES] : 0
-		var/sample_moles = sample_gases[id]
-		sample_moles = sample_moles ? sample_moles[MOLES] : 0
-		var/delta = abs(gas_moles - sample_moles)
-		if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && \
-			delta > gas_moles * MINIMUM_AIR_RATIO_TO_MOVE)
-			return id
+		for(var/id in cached_gases | sample_gases) // compare gases from either mixture
+			var/gas_moles = cached_gases[id]
+			gas_moles = gas_moles ? gas_moles[MOLES] : 0
+			var/sample_moles = sample_gases[id]
+			sample_moles = sample_moles ? sample_moles[MOLES] : 0
+			var/delta = abs(gas_moles - sample_moles)
+			if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && \
+				delta > gas_moles * MINIMUM_AIR_RATIO_TO_MOVE)
+				return id
 
-	var/our_moles
-	TOTAL_MOLES(cached_gases, our_moles)
-	if(our_moles > MINIMUM_MOLES_DELTA_TO_MOVE)
-		var/temp = temperature
-		var/sample_temp = sample.temperature
+		var/our_moles
+		TOTAL_MOLES(cached_gases, our_moles)
+		if(our_moles > MINIMUM_MOLES_DELTA_TO_MOVE)
+			var/temp = temperature
+			var/sample_temp = sample.temperature
 
-		var/temperature_delta = abs(temp - sample_temp)
-		if(temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
-			return "temp"
+			var/temperature_delta = abs(temp - sample_temp)
+			if(temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
+				return "temp"
 
-	return ""
+		return ""
+	//hippie code ned
 
 /datum/gas_mixture/react(datum/holder)
 	. = NO_REACTION


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Fixes atmos runtimes
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Almost every round where lots of atmos processing occurs, such as explosions or plasma fires, runtimes spam endlessly which is a big performance chugger and can prevent atmos from working properly. Eventually too much atmos processing can cause other subsystems to wait too long or fail.