### PR TITLE
makes escape pod storage safes start unlocked

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -510,18 +510,18 @@
 
 /obj/item/storage/pod
 	name = "emergency space suits"
-	desc = "A wall mounted safe containing space suits. Will only open in emergencies."
+	desc = "A wall mounted safe containing space suits. Originally opens only during emergencies; budget cuts caused by various shenanigans have lead to streamlining efforts in Nanotrasen's ruling body."
 	anchored = TRUE
 	density = FALSE
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "safe"
-	var/unlocked = FALSE
+	var/unlocked = TRUE
 
 /obj/item/storage/pod/PopulateContents()
-	new /obj/item/clothing/head/helmet/space/orange(src)
-	new /obj/item/clothing/head/helmet/space/orange(src)
-	new /obj/item/clothing/suit/space/orange(src)
-	new /obj/item/clothing/suit/space/orange(src)
+	new /obj/item/clothing/head/helmet/space/fragile(src)
+	new /obj/item/clothing/head/helmet/space/fragile(src)
+	new /obj/item/clothing/suit/space/fragile(src)
+	new /obj/item/clothing/suit/space/fragile(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/tank/internals/oxygen/red(src)
@@ -546,7 +546,7 @@
 
 /obj/item/storage/pod/can_interact(mob/user)
 	if(!..())
-		return FALSE
+		return TRUE
 	if(GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_DELTA || unlocked)
 		return TRUE
 	to_chat(user, "The storage unit will only unlock during a Red or Delta security alert.")


### PR DESCRIPTION
[Changelogs]: escape pods start unlocked. complements the other related PR but may be mutually exclusive because the other one adds a lot of fragile spacesuits among the station and this may be just too much. Feed back appreciated

:cl: zamolxius
add: unlocks space pod safes and replaces the standard orange suits in there with fragile ones
tweak: unlocks escape pod safes and replaces the standard orange suits in there with fragile ones
balance: unlocks escape pod safes and replaces the standard orange suits in there with fragile ones
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
