### PR TITLE
makes escape pod emergency safes start unlocked [DNM]

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3067,6 +3067,7 @@
 #include "hippiestation\code\modules\research\techweb\_techweb.dm"
 #include "hippiestation\code\modules\research\techweb\all_nodes.dm"
 #include "hippiestation\code\modules\research\xenobiology\xenobiology.dm"
+#include "hippiestation\code\modules\shuttle\emergency.dm"
 #include "hippiestation\code\modules\spells\spells.dm"
 #include "hippiestation\code\modules\spells\staff_req_check.dm"
 #include "hippiestation\code\modules\spells\spell_types\aimed.dm"

--- a/hippiestation/code/modules/shuttle/emergency.dm
+++ b/hippiestation/code/modules/shuttle/emergency.dm
@@ -1,0 +1,2 @@
+/obj/item/storage/pod/can_interact(mob/user)
+	return TRUE


### PR DESCRIPTION
[Changelogs]: makes emergency safes in escape pods start unlocked

:cl: zamolxius
tweak: makes emergency safes in escape pods start unlocked
/:cl:

[why]: 