### PR TITLE
Fixes mime and clown apcs

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -14271,7 +14271,7 @@
 	d2 = 2
 	},
 /obj/machinery/power/apc{
-	areastring = "area/hippie/mime";
+	areastring = "/area/hippie/mime";
 	dir = 8;
 	name = "Mime's Office APC";
 	pixel_x = -24;
@@ -15026,7 +15026,7 @@
 	d2 = 2
 	},
 /obj/machinery/power/apc{
-	areastring = "area/hippie/clown";
+	areastring = "/area/hippie/clown";
 	dir = 8;
 	name = "Clown's Office APC";
 	pixel_x = -24
@@ -58362,6 +58362,7 @@
 /area/space/nearstation)
 "erS" = (
 /obj/structure/table/wood,
+/obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
 "esQ" = (
@@ -64203,6 +64204,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"rMi" = (
+/obj/structure/table/wood,
+/obj/item/toy/eightball,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "rMv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -66701,12 +66707,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xui" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
-	},
-/area/hallway/secondary/entry)
 "xur" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74984,7 +74984,7 @@ aad
 aad
 aad
 aCH
-xui
+mQC
 wAJ
 yhM
 mQC
@@ -76780,7 +76780,7 @@ iAp
 aRf
 aRf
 wkC
-dda
+rMi
 bkV
 aRf
 aAd


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Mime and clown apc had a bad areastring 
add: Eight ball to arrivals recreation area + deck of cards
del: Random fuel tank outside aux base
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
