### PR TITLE
Fixes crafting recipe for watcher projector

### DIFF
--- a/hippiestation/code/modules/crafting/recipies.dm
+++ b/hippiestation/code/modules/crafting/recipies.dm
@@ -94,7 +94,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/bonesword
+/datum/crafting_recipe/watcherproj
 	name = "Watcher Projector"
 	result = /obj/item/gun/energy/watcherprojector
 	reqs = list(/obj/item/stack/sheet/bone = 3,


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Watcher projector is now long under bonesword
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
