### PR TITLE
Standardizes cam networks, minor tweaks/fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -714,7 +714,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abV" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/hos,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abW" = (
@@ -1737,10 +1737,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1776,10 +1773,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aen" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3525,7 +3519,8 @@
 "ail" = (
 /obj/machinery/camera{
 	c_tag = "Brig Interrogation";
-	dir = 8
+	dir = 8;
+	network = list("interrogation")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -4003,10 +3998,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajv" = (
@@ -4062,6 +4054,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -7926,11 +7921,8 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
+/obj/machinery/computer/security/telescreen/prison{
 	dir = 1;
-	name = "Prison Monitor";
-	network = list("prison");
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -9141,12 +9133,9 @@
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
 /obj/item/assault_pod/mining,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for the Auxillary Mining Base.";
+/obj/machinery/computer/security/telescreen/auxbase{
 	dir = 8;
-	name = "Auxillary Base Monitor";
-	network = list("auxbase");
-	pixel_x = 28
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -12611,7 +12600,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
-	network = list("minisat")
+	network = list("vault")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/corner{
@@ -17727,9 +17716,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUd" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
+/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel/brown{
 	dir = 6
 	},
@@ -20822,7 +20809,8 @@
 /obj/structure/table,
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/camera/motion{
-	dir = 4
+	dir = 4;
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20840,7 +20828,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/motion{
-	dir = 8
+	dir = 8;
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -23910,6 +23899,7 @@
 "bkb" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -24436,6 +24426,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/cell_charger,
@@ -25529,10 +25520,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnR" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -26829,6 +26817,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27513,6 +27502,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -28841,7 +28831,8 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("ss13","rd")
+	network = list("ss13", "medbay");
+	
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28875,6 +28866,7 @@
 "bvB" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -29232,7 +29224,8 @@
 "bww" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Surgery Observation"
+	c_tag = "Surgery Observation";
+	network = list("ss13", "medbay")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -29317,6 +29310,7 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -29335,6 +29329,7 @@
 "bwL" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
+	network = list("ss13", "medbay");
 	dir = 4
 	},
 /obj/structure/table,
@@ -29587,13 +29582,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxj" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd","minisat");
-	pixel_y = 2
-	},
 /obj/structure/table,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxk" = (
@@ -30239,8 +30229,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	network = list("mine","auxbase")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -30583,13 +30572,8 @@
 /area/security/checkpoint/science)
 "bzD" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen/circuitry,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -30907,6 +30891,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31125,10 +31110,6 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bAS" = (
-/obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
-	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
 	dir = 4
@@ -31140,6 +31121,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32;
 	supply_display = 1
+	},
+/obj/machinery/computer/security/qm{
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 10
@@ -31940,6 +31924,7 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /turf/open/floor/plasteel/white,
@@ -32022,6 +32007,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
+	network = list("ss13", "medbay");
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32314,6 +32300,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/iv_drip,
@@ -32555,6 +32542,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -32767,13 +32755,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bEK" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 4
 	},
+/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bEL" = (
@@ -33136,6 +33122,10 @@
 "bFE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
@@ -33849,16 +33839,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHv" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -34102,6 +34088,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
+	network = list("ss13", "medbay");
 	dir = 1;
 	pixel_x = 22
 	},
@@ -34423,7 +34410,8 @@
 	pixel_y = 29
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Break Room"
+	c_tag = "Virology Break Room";
+	network = list("ss13", "medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -34572,7 +34560,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bJa" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -35615,20 +35602,12 @@
 	},
 /area/science/test_area)
 "bLr" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
-	dir = 8;
-	invuln = 1;
-	light = null;
-	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
-	use_power = 0
-	},
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	luminosity = 2;
@@ -36477,7 +36456,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNF" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -36730,6 +36708,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37874,14 +37853,10 @@
 /area/science/misc_lab)
 "bQY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 2;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 28
-	},
 /obj/item/integrated_circuit_printer,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bQZ" = (
@@ -37991,13 +37966,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -38417,7 +38388,8 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Telecomms Monitoring";
-	dir = 8
+	dir = 8;
+	network = list("tcomms")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -38686,7 +38658,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Module"
+	c_tag = "Virology Module";
+	network = list("ss13", "medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41990,7 +41963,8 @@
 "cbl" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
-	dir = 4
+	dir = 4;
+	network = list("tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42332,14 +42306,11 @@
 /area/science/circuit)
 "cbZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 1;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = -28
-	},
 /obj/item/integrated_circuit_printer,
+/obj/machinery/computer/security/telescreen/circuitry{
+	dir = 1;
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cca" = (
@@ -45330,11 +45301,8 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
-	name = "Research Monitor";
-	network = list("rd");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault,
@@ -48086,15 +48054,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "csq" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 1;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_y = -29
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/turbine{
+	dir = 1;
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
@@ -49451,7 +49416,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Core Hallway";
 	dir = 4;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -49829,7 +49794,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
 	dir = 1;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -50725,7 +50690,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
 	dir = 2;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -52678,16 +52643,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cMC" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -19219,9 +19219,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/qm)
 "aUs" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
@@ -19229,6 +19226,9 @@
 	c_tag = "Cargo - Quartermaster's Quarters";
 	dir = 8;
 	name = "cargo camera"
+	},
+/obj/machinery/computer/security/qm{
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -28839,14 +28839,11 @@
 	},
 /area/security/execution/transfer)
 "bpg" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = 26
 	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/red,
 /area/security/execution/transfer)
 "bph" = (
@@ -30114,11 +30111,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "brC" = (
-/obj/machinery/computer/security{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/computer/security/hos{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
@@ -32397,7 +32394,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber - Fore";
 	name = "motion-sensitive ai camera";
-	network = list("ai")
+	network = list("aichamber")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -32851,7 +32848,8 @@
 "bxe" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 4
+	dir = 4;
+	network = list("vault")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40845,7 +40843,7 @@
 	c_tag = "Telecomms - Monitoring";
 	dir = 2;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -41329,7 +41327,7 @@
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
 	name = "motion-sensitive ai camera";
-	network = list("ai")
+	network = list("aichamber")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
@@ -45718,12 +45716,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the AI's satellite.";
-	dir = 4;
-	name = "Research Monitor";
-	network = list("minisat");
-	pixel_y = 2
+/obj/machinery/computer/security/telescreen/minisat{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -45764,12 +45758,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_x = -30
 	},
 /mob/living/simple_animal/parrot/Poly,
@@ -49043,6 +49033,10 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen/vault{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ccD" = (
@@ -49053,7 +49047,7 @@
 	c_tag = "Telecomms - Chamber Port";
 	dir = 4;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -49497,7 +49491,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI - Upload";
 	name = "motion-sensitive ai camera";
-	network = list("minisat")
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -50940,7 +50934,7 @@
 	c_tag = "Telecomms - Chamber Starboard";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -52596,7 +52590,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Bridge - Captain's Emergency Escape";
 	dir = 4;
-	name = "command camera"
+	name = "motion-sensitive command camera"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54722,7 +54716,7 @@
 	c_tag = "Telecomms - Cooling Room";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -67889,6 +67883,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -71807,6 +71802,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -71946,6 +71942,7 @@
 "cYc" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Break Room";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -72623,6 +72620,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Fore Port";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -72704,6 +72702,7 @@
 /obj/item/stack/medical/ointment,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -75472,9 +75471,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
+	network = list("ss13", "medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
@@ -76303,6 +76302,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Center";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -77695,6 +77695,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -77793,6 +77794,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81245,6 +81247,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81304,6 +81307,7 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81770,6 +81774,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -83166,6 +83171,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Lab";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -83797,6 +83803,7 @@
 /obj/item/storage/box/disks,
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Desk";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -84104,6 +84111,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -84698,6 +84706,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Port";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -84756,6 +84765,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -85976,8 +85986,9 @@
 /obj/structure/table/glass,
 /obj/item/clipboard,
 /obj/item/toy/figure/cmo,
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 4;
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -86024,6 +86035,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Starboard";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -88049,15 +88061,11 @@
 /area/science/test_area)
 "dGY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the testing site.";
-	dir = 4;
-	layer = 4;
-	name = "Testing Site Telescreen";
-	network = list("toxins")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -89057,6 +89065,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -89168,6 +89177,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -90365,17 +90375,8 @@
 /obj/item/target,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
-	dir = 4;
-	invuln = 1;
-	light = null;
-	name = "hardened testing camera";
-	network = list("toxins");
-	start_active = 1;
-	use_power = 0
+/obj/machinery/camera/preset/toxins{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
@@ -92468,6 +92469,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Containment Lock";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -92980,6 +92982,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -94686,6 +94689,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
+	network = list("ss13", "medbay");
 	name = "virology camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -94705,6 +94709,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -96408,6 +96413,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -551,7 +551,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abS" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/hos,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1856,10 +1856,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1904,10 +1901,7 @@
 	},
 /area/security/prison)
 "aes" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4323,10 +4317,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajE" = (
@@ -9399,11 +9390,8 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
+/obj/machinery/computer/security/telescreen/prison{
 	dir = 1;
-	name = "Prison Monitor";
-	network = list("prison");
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -19941,9 +19929,7 @@
 	},
 /area/bridge)
 "aZm" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
+/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel/brown{
 	dir = 6
 	},
@@ -28442,10 +28428,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buX" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -32520,12 +32503,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bEE" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd","minisat");
-	pixel_y = 2
-	},
+/obj/machinery/computer/security/telescreen/rd,
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -33200,8 +33178,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	network = list("mine","auxbase")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -33551,12 +33528,7 @@
 /area/security/checkpoint/science/research)
 "bGY" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 2
-	},
+/obj/machinery/computer/security/telescreen/rd,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -34207,8 +34179,7 @@
 /area/maintenance/starboard)
 "bIt" = (
 /obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -35913,9 +35884,7 @@
 /turf/closed/wall,
 /area/science/mixing)
 "bMd" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
+/obj/machinery/computer/security/mining,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 4
@@ -37095,12 +37064,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bOV" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4;
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41218,13 +41183,7 @@
 /area/science/misc_lab)
 "bYQ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 2;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 28
-	},
+/obj/machinery/computer/security/telescreen/rd,
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -44901,12 +44860,8 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -46047,12 +46002,9 @@
 /area/science/misc_lab)
 "ckZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
+/obj/machinery/computer/security/telescreen/circuitry{
 	dir = 1;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = -28
+	pixel_y = -30
 	},
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white,
@@ -49559,12 +49511,8 @@
 	},
 /area/engine/engineering)
 "ctU" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -49974,12 +49922,8 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 4;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/vault,
@@ -50430,11 +50374,8 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
 "cvZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
+/obj/machinery/computer/security/telescreen/turbine{
 	dir = 1;
-	name = "turbine vent monitor";
-	network = list("turbine");
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -58715,11 +58656,8 @@
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
 /obj/item/assault_pod/mining,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for the Auxillary Mining Base.";
+/obj/machinery/computer/security/telescreen/auxbase{
 	dir = 1;
-	name = "Auxillary Base Monitor";
-	network = list("auxbase");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -62022,12 +61960,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 4;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
@@ -63768,12 +63702,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 4;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("Singularity");
 	pixel_x = -27
 	},
 /obj/machinery/holopad,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -76159,18 +76159,10 @@
 /obj/item/stock_parts/cell/super,
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/reinforced,
-<<<<<<< HEAD
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 32
-=======
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_x = 30
->>>>>>> ca8d9f06a0... there we go (#38730)
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -466,7 +466,6 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "abv" = (
@@ -1519,7 +1518,6 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "adG" = (
@@ -20206,9 +20204,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/camera_advanced/base_construction{
-	dir = 4
-	},
+/obj/machinery/computer/camera_advanced/base_construction,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
@@ -20711,9 +20707,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aSJ" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 4
-	},
+/obj/machinery/computer/shuttle/mining,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
@@ -35262,7 +35256,6 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/machinery/jukebox,
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "bwO" = (
@@ -41732,7 +41725,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLe" = (
-/obj/machinery/vending/autodrobe/all_access,
+/obj/machinery/vending/autodrobe{
+	req_access_txt = "0"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLf" = (
@@ -53014,7 +53009,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "cjp" = (
-/obj/machinery/vending/boozeomat/all_access,
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cjq" = (
@@ -72648,9 +72643,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dek" = (
@@ -72800,11 +72792,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "deC" = (
 /obj/effect/turf_decal/bot{
@@ -73020,11 +73008,8 @@
 	dir = 4;
 	network = list("engine")
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfp" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -73085,11 +73070,8 @@
 /area/engine/engineering)
 "dfD" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dft" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73950,10 +73932,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
 "dib" = (
@@ -74553,8 +74531,6 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "djx" = (
@@ -74860,7 +74836,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dss" = (
@@ -74904,7 +74879,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dtR" = (
@@ -74980,7 +74954,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dwc" = (
@@ -74993,17 +74966,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault,
-/area/chapel/main)
-"dDI" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dDJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -75025,17 +74989,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dwj" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75629,8 +75593,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -75727,7 +75691,7 @@
 /area/bridge/showroom/corporate)
 "dDg" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -75767,12 +75731,11 @@
 /area/maintenance/starboard/aft)
 "dDr" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"uRM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -75783,8 +75746,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/area/science/research)
-"uTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -75798,10 +75759,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"vyx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -76367,10 +76325,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"lGS" = (
-/obj/docking_port/stationary/public_mining_dock,
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "lMz" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -76982,10 +76936,6 @@
 "wOE" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"wOY" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/space)
 "wPk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82407,7 +82357,6 @@ aaa
 aaa
 aaa
 aaa
-aac
 aaa
 aaa
 aaa
@@ -82922,8 +82871,6 @@ aaa
 aaa
 aaa
 aaa
-"}
-(24,1,1) = {"
 aaa
 aaa
 aaa
@@ -83062,7 +83009,6 @@ aaa
 aaa
 aaa
 aaa
-aac
 aaa
 aaa
 aaa
@@ -83143,6 +83089,85 @@ aaa
 aaa
 aaa
 aac
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83263,8 +83288,6 @@ aaa
 aaa
 aaa
 aaa
-"}
-(25,1,1) = {"
 aaa
 aaa
 aaa
@@ -83522,8 +83545,6 @@ aaa
 aaa
 aaa
 aaa
-"}
-(26,1,1) = {"
 aaa
 aaa
 aaa
@@ -83625,7 +83646,6 @@ aaa
 aaa
 aaa
 aaa
-aac
 aaa
 aaa
 aaa
@@ -83782,8 +83802,6 @@ aaa
 aaa
 aaa
 aaa
-"}
-(27,1,1) = {"
 aaa
 aaa
 aaa
@@ -83875,12 +83893,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
@@ -84064,21 +84076,6 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -84495,21 +84492,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 "}
 (30,1,1) = {"
 aaa
@@ -84608,21 +84590,6 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -85039,21 +85006,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 "}
 (32,1,1) = {"
 aaa
@@ -85152,21 +85104,6 @@ aaf
 aaa
 aaa
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -86462,7 +86399,7 @@ aaa
 aaa
 aaa
 aaa
-wOY
+aaa
 aSH
 aUb
 aVt
@@ -86976,7 +86913,7 @@ aaa
 aaa
 aaa
 aaa
-wOY
+aaa
 aSI
 aRA
 aVv
@@ -89030,7 +88967,7 @@ obX
 aDa
 aDa
 aDa
-lGS
+aDa
 cWM
 cXR
 cYG
@@ -102098,7 +102035,7 @@ aaa
 aaa
 aaa
 aaa
-wOY
+aaa
 abL
 acf
 acy
@@ -102612,7 +102549,7 @@ aaa
 aaa
 aaa
 aaa
-wOY
+aaa
 abN
 ach
 aax
@@ -114696,9 +114633,9 @@ aaa
 aaf
 aaa
 acP
-wOY
+aaa
 adF
-wOY
+aaa
 acP
 afB
 agz
@@ -120395,9 +120332,9 @@ dgp
 cXI
 cYj
 atm
-wOY
+aaa
 adF
-wOY
+aaa
 bhT
 bpv
 brL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1910,7 +1910,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aev" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/hos,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aew" = (
@@ -3554,13 +3554,6 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching certain areas.";
-	dir = 1;
-	name = "Head of Security's Monitor";
-	network = list("prison","minisat","tcomm");
-	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/hos)
@@ -7852,10 +7845,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqY" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqZ" = (
@@ -8778,12 +8768,8 @@
 /area/security/main)
 "asN" = (
 /obj/structure/chair,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching proceedings in the interrogation room.";
+/obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
-	layer = 4;
-	name = "interrogation monitor";
-	network = list("interrogation");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
@@ -9867,6 +9853,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -10533,7 +10523,7 @@
 /area/security/brig)
 "awz" = (
 /obj/machinery/camera{
-	c_tag = "Interrogation";
+	c_tag = "Interrogation room";
 	dir = 8;
 	network = list("interrogation")
 	},
@@ -13115,6 +13105,7 @@
 "aCg" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
+	network = list("vault");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -14211,8 +14202,7 @@
 /area/quartermaster/warehouse)
 "aEv" = (
 /obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -17486,7 +17476,7 @@
 /obj/structure/table,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Fore";
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -19642,12 +19632,11 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQq" = (
-/obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
-	},
 /obj/machinery/light_switch{
 	pixel_x = -23
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -19747,7 +19736,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Port";
 	dir = 1;
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -19770,7 +19759,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Starboard";
 	dir = 1;
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20268,7 +20257,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aRK" = (
-/obj/machinery/computer/cargo{
+/obj/machinery/computer/security/qm{
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -21603,16 +21592,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching areas on the MiniSat.";
-	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
-	pixel_x = 29
-	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Foyer";
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -21935,7 +21917,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
 	dir = 2;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 2;
@@ -22183,8 +22165,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	network = list("mine","auxbase")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -23419,7 +23400,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
 	dir = 4;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -24131,7 +24112,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
 	dir = 2;
-	network = list("rd")
+	network = list("aicore")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -25035,10 +25016,8 @@
 	pixel_y = 10
 	},
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 4;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25096,7 +25075,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -26192,10 +26171,8 @@
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -28117,7 +28094,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -30032,15 +30009,12 @@
 	},
 /obj/item/storage/secure/briefcase,
 /obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_y = 30
-	},
 /obj/item/folder/blue,
 /obj/item/storage/secure/briefcase,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bmq" = (
@@ -32209,10 +32183,8 @@
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -33007,10 +32979,8 @@
 /obj/machinery/porta_turret/ai{
 	dir = 2
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33032,10 +33002,8 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
@@ -33797,10 +33765,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -35515,7 +35481,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "Telecomms Camera Monitor";
-	network = list("tcomm");
+	network = list("tcomms");
 	pixel_x = 26
 	},
 /obj/machinery/computer/telecomms/monitor{
@@ -36811,10 +36777,8 @@
 /area/crew_quarters/heads/captain/private)
 "bAe" = (
 /obj/machinery/light,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /obj/structure/bed/dogbed/renault,
@@ -38522,7 +38486,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -38553,7 +38517,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -40872,7 +40836,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -42287,7 +42251,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Port";
 	dir = 4;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42325,7 +42289,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Starboard";
 	dir = 8;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -43131,7 +43095,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
@@ -57858,13 +57822,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "csZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 2
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -62083,7 +62042,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cBO" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62873,21 +62831,12 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cDy" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top.";
-	dir = 8;
-	invuln = 1;
-	light = null;
-	luminosity = 3;
-	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
-	use_power = 0
-	},
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 8
 	},
 /turf/open/floor/plating/airless{
 	luminosity = 2
@@ -63868,7 +63817,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cFw" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -76211,11 +76159,18 @@
 /obj/item/stock_parts/cell/super,
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/reinforced,
+<<<<<<< HEAD
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
 	network = list("rd");
 	pixel_y = 32
+=======
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_x = 30
+>>>>>>> ca8d9f06a0... there we go (#38730)
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -76517,6 +76472,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+<<<<<<< HEAD
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
@@ -76525,6 +76481,13 @@
 	},
 /obj/item/stock_parts/cell/super,
 /obj/item/stack/sheet/metal/fifty,
+=======
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
+	},
+>>>>>>> ca8d9f06a0... there we go (#38730)
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ohj" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1910,7 +1910,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aev" = (
-/obj/machinery/computer/security/hos,
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aew" = (
@@ -3554,6 +3554,13 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching certain areas.";
+	dir = 1;
+	name = "Head of Security's Monitor";
+	network = list("prison","minisat","tcomm");
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/hos)
@@ -7845,7 +7852,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqY" = (
-/obj/machinery/computer/security/labor,
+/obj/machinery/computer/security{
+	name = "Labor Camp Monitoring";
+	network = list("labor")
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqZ" = (
@@ -8768,8 +8778,12 @@
 /area/security/main)
 "asN" = (
 /obj/structure/chair,
-/obj/machinery/computer/security/telescreen/interrogation{
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching proceedings in the interrogation room.";
 	dir = 1;
+	layer = 4;
+	name = "interrogation monitor";
+	network = list("interrogation");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
@@ -9853,10 +9867,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 8;
-	pixel_x = 30
-	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -10523,7 +10533,7 @@
 /area/security/brig)
 "awz" = (
 /obj/machinery/camera{
-	c_tag = "Interrogation room";
+	c_tag = "Interrogation";
 	dir = 8;
 	network = list("interrogation")
 	},
@@ -13105,7 +13115,6 @@
 "aCg" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	network = list("vault");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -14202,7 +14211,8 @@
 /area/quartermaster/warehouse)
 "aEv" = (
 /obj/machinery/computer/security/mining{
-	dir = 4
+	dir = 4;
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -17476,7 +17486,7 @@
 /obj/structure/table,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Fore";
-	network = list("aiupload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -19632,11 +19642,12 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQq" = (
+/obj/machinery/computer/security/mining{
+	dir = 4;
+	network = list("mine","auxbase")
+	},
 /obj/machinery/light_switch{
 	pixel_x = -23
-	},
-/obj/machinery/computer/cargo{
-	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -19736,7 +19747,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Port";
 	dir = 1;
-	network = list("aiupload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -19759,7 +19770,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Starboard";
 	dir = 1;
-	network = list("aiupload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20257,7 +20268,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aRK" = (
-/obj/machinery/computer/security/qm{
+/obj/machinery/computer/cargo{
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -21592,9 +21603,16 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching areas on the MiniSat.";
+	dir = 8;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
+	pixel_x = 29
+	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Foyer";
-	network = list("aiupload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -21917,7 +21935,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
 	dir = 2;
-	network = list("aicore")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 2;
@@ -22165,7 +22183,8 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8
+	dir = 8;
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -23400,7 +23419,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
 	dir = 4;
-	network = list("aicore")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -24112,7 +24131,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
 	dir = 2;
-	network = list("aicore")
+	network = list("rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -25016,8 +25035,10 @@
 	pixel_y = 10
 	},
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 4;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25075,7 +25096,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
-	network = list("aicore")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -26171,8 +26192,10 @@
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/machinery/computer/security/telescreen/ce{
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -28094,7 +28117,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
-	network = list("aicore")
+	network = list("rd")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -30009,12 +30032,15 @@
 	},
 /obj/item/storage/secure/briefcase,
 /obj/structure/table/wood,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_y = 30
+	},
 /obj/item/folder/blue,
 /obj/item/storage/secure/briefcase,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/computer/security/telescreen/vault{
-	pixel_y = 30
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bmq" = (
@@ -32183,8 +32209,10 @@
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -32979,8 +33007,10 @@
 /obj/machinery/porta_turret/ai{
 	dir = 2
 	},
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 8;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33002,8 +33032,10 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
@@ -33765,8 +33797,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -35481,7 +35515,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "Telecomms Camera Monitor";
-	network = list("tcomms");
+	network = list("tcomm");
 	pixel_x = 26
 	},
 /obj/machinery/computer/telecomms/monitor{
@@ -36777,8 +36811,10 @@
 /area/crew_quarters/heads/captain/private)
 "bAe" = (
 /obj/machinery/light,
-/obj/machinery/computer/security/telescreen/minisat{
+/obj/machinery/computer/security/telescreen{
 	dir = 1;
+	name = "MiniSat Monitor";
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /obj/structure/bed/dogbed/renault,
@@ -38486,7 +38522,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
 	dir = 2;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -38517,7 +38553,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
 	dir = 2;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -40836,7 +40872,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -42251,7 +42287,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Port";
 	dir = 4;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42289,7 +42325,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Starboard";
 	dir = 8;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -43095,7 +43131,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft";
 	dir = 1;
-	network = list("ss13","tcomms")
+	network = list("ss13","tcomm")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
@@ -45998,6 +46034,9 @@
 	sortType = 20
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -57822,8 +57861,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "csZ" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	name = "Research Monitor";
+	network = list("rd");
+	pixel_y = 2
+	},
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -62042,6 +62086,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cBO" = (
+/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62831,12 +62876,21 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cDy" = (
+/obj/machinery/camera{
+	active_power_usage = 0;
+	c_tag = "Bomb Test Site";
+	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top.";
+	dir = 8;
+	invuln = 1;
+	light = null;
+	luminosity = 3;
+	name = "Hardened Bomb-Test Camera";
+	network = list("toxins");
+	use_power = 0
+	},
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/camera/preset/toxins{
-	dir = 8
 	},
 /turf/open/floor/plating/airless{
 	luminosity = 2
@@ -63817,6 +63871,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cFw" = (
+/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -76159,10 +76214,11 @@
 /obj/item/stock_parts/cell/super,
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_x = 30
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of your own office.";
+	name = "Research Monitor";
+	network = list("rd");
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -76464,7 +76520,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-<<<<<<< HEAD
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
@@ -76473,13 +76528,6 @@
 	},
 /obj/item/stock_parts/cell/super,
 /obj/item/stack/sheet/metal/fifty,
-=======
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_y = 30
-	},
->>>>>>> ca8d9f06a0... there we go (#38730)
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ohj" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2249,9 +2249,7 @@
 	c_tag = "Brig Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
+/obj/machinery/computer/security/telescreen/prison{
 	network = list("prison");
 	pixel_y = 30
 	},
@@ -4378,7 +4376,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "amz" = (
-/obj/machinery/computer/security{
+/obj/machinery/computer/security/hos{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -5072,10 +5070,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aok" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aol" = (
@@ -5936,6 +5931,10 @@
 	},
 /area/security/brig)
 "aqA" = (
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -6269,7 +6268,8 @@
 "arz" = (
 /obj/machinery/camera{
 	c_tag = "Brig Interrogation";
-	dir = 8
+	dir = 8;
+	network = list("interrogation")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7310,6 +7310,7 @@
 "aud" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
+	network = list("vault");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -10280,6 +10281,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBA" = (
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
+	},
 /obj/machinery/computer/security/mining,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -10783,7 +10787,8 @@
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Port";
-	dir = 4
+	dir = 4;
+	network = list("aiupload")
 	},
 /obj/item/aiModule/reset,
 /obj/machinery/flasher{
@@ -10830,7 +10835,8 @@
 /obj/item/aiModule/supplied/freeform,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Starboard";
-	dir = 8
+	dir = 8;
+	network = list("aiupload")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11261,7 +11267,8 @@
 /obj/machinery/holopad,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Center";
-	dir = 1
+	dir = 1;
+	network = list("aiupload")
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -16561,6 +16568,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/auxbase{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aRH" = (
@@ -21317,13 +21328,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdM" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	department = "Mining";
 	departmentType = 0;
 	pixel_x = 32
+	},
+/obj/machinery/computer/security/mining{
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
@@ -22046,13 +22057,11 @@
 	},
 /area/quartermaster/qm)
 "bfD" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
+/obj/machinery/computer/security/qm,
 /turf/open/floor/plasteel/brown{
 	dir = 6
 	},
@@ -23836,6 +23845,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Foyer";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -24222,12 +24232,8 @@
 	dir = 1
 	},
 /obj/item/integrated_electronics/debugger,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the other eggheads from the comfort of the circuitry lab.";
-	dir = 2;
-	name = "RnD Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -24252,12 +24258,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the other eggheads from the comfort of the circuitry lab.";
-	dir = 2;
-	name = "RnD Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -24404,6 +24406,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Post";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
@@ -25231,6 +25234,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/camera{
 	c_tag = "Medbay Entrance";
+	network = list("ss13","medbay");
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -26121,7 +26125,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Fore";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -26733,6 +26737,7 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/machinery/airalarm/unlocked{
@@ -27758,6 +27763,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay Port Hallway";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -29667,7 +29673,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Aft";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light/small{
@@ -30318,19 +30324,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching surgery.";
-	dir = 8;
-	layer = 4;
-	name = "Surgery Telescreen";
-	network = list("surgery");
-	pixel_x = 30
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -30689,7 +30691,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics";
 	dir = 1;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
@@ -30745,6 +30747,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32005,13 +32008,11 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd","minisat");
-	pixel_y = -32
-	},
 /obj/structure/table/glass,
+/obj/machinery/computer/security/telescreen/rd{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/crew_quarters/heads/hor)
 "bEV" = (
@@ -33213,6 +33214,7 @@
 "bHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33271,6 +33273,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Equipment Room";
+	network = list("ss13","medbay");
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -33337,6 +33340,7 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38256,6 +38260,9 @@
 	c_tag = "Chief Engineer's Office";
 	dir = 2
 	},
+/obj/machinery/computer/security/telescreen/ce{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -41892,7 +41899,7 @@
 	dir = 2;
 	layer = 4;
 	name = "Telecomms Telescreen";
-	network = list("tcomm");
+	network = list("tcomms");
 	pixel_y = 28
 	},
 /obj/structure/disposalpipe/segment{
@@ -43106,16 +43113,7 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "cjV" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Testing Asteroid Fore";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top.";
-	invuln = 1;
-	luminosity = 3;
-	name = "Hardened Bomb-Test Camera";
-	network = list("ss13","rd","toxins");
-	use_power = 0
-	},
+/obj/machinery/camera/preset/toxins,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cjZ" = (
@@ -43867,7 +43865,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port";
 	dir = 8;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -43929,7 +43927,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard";
 	dir = 4;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44105,7 +44103,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Server Room";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -44136,7 +44134,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port Aft";
 	dir = 2;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44145,7 +44143,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard Aft";
 	dir = 2;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -49224,7 +49222,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
 	dir = 1;
-	network = list("SS13","tcomm");
+	network = list("tcomms");
 	start_active = 1
 	},
 /obj/structure/cable/yellow{
@@ -50943,7 +50941,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52239,7 +52237,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Access";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -54458,7 +54456,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
 	dir = 8;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /obj/machinery/light{
 	dir = 4

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -78,7 +78,8 @@
 /area/shuttle/auxillary_base)
 "X" = (
 /obj/machinery/camera{
-	dir = 1
+	dir = 1;
+	network = list("auxbase")
 	},
 /obj/structure/mining_shuttle_beacon,
 /turf/open/floor/plating,

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -41,6 +41,16 @@
 
 	var/internal_light = TRUE //Whether it can light up when an AI views it
 
+/obj/machinery/camera/preset/toxins //Bomb test site in space
+	name = "Hardened Bomb-Test Camera"
+	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top."
+	c_tag = "Bomb Testing Site"
+	network = list("rd","toxins")
+	use_power = NO_POWER_USE //Test site is an unpowered area
+	invuln = TRUE
+	light_range = 10
+	start_active = TRUE
+
 /obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
 	for(var/i in network)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -65,6 +65,7 @@
 	for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
 		if (status)
 			aiPlayer.triggerAlarm("Motion", get_area(src), list(src), src)
+			visible_message("<span class='warning'>A red light flashes on the [src]!</span>")
 	detectTime = -1
 	return TRUE
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -2,7 +2,7 @@
 
 // EMP
 /obj/machinery/camera/emp_proof
-	start_active = 1
+	start_active = TRUE
 
 /obj/machinery/camera/emp_proof/Initialize()
 	. = ..()
@@ -11,7 +11,7 @@
 // X-RAY
 
 /obj/machinery/camera/xray
-	start_active = 1
+	start_active = TRUE
 	icon_state = "xraycam" // Thanks to Krutchen for the icons.
 
 /obj/machinery/camera/xray/Initialize()
@@ -20,7 +20,7 @@
 
 // MOTION
 /obj/machinery/camera/motion
-	start_active = 1
+	start_active = TRUE
 	name = "motion-sensitive security camera"
 
 /obj/machinery/camera/motion/Initialize()
@@ -29,7 +29,7 @@
 
 // ALL UPGRADES
 /obj/machinery/camera/all
-	start_active = 1
+	start_active = TRUE
 
 /obj/machinery/camera/all/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -152,6 +152,50 @@
 			D["[C.c_tag][(C.status ? null : " (Deactivated)")]"] = C
 	return D
 
+// SECURITY MONITORS
+
+/obj/machinery/computer/security/wooden_tv
+	name = "security camera monitor"
+	desc = "An old TV hooked into the station's camera network."
+	icon_state = "television"
+	icon_keyboard = null
+	icon_screen = "detective_tv"
+	clockwork = TRUE //it'd look weird
+
+/obj/machinery/computer/security/mining
+	name = "outpost camera console"
+	desc = "Used to access the various cameras on the outpost."
+	icon_screen = "mining"
+	icon_keyboard = "mining_key"
+	network = list("mine", "auxbase")
+	circuit = /obj/item/circuitboard/computer/mining
+
+/obj/machinery/computer/security/research
+	name = "research camera console"
+	desc = "Used to access the various cameras in science."
+	network = list("rd")
+	circuit = /obj/item/circuitboard/computer/research
+
+/obj/machinery/computer/security/hos
+	name = "Head of Security's camera console"
+	desc = "A custom security console with added access to the labor camp network."
+	network = list("ss13", "labor")
+	circuit = null
+
+/obj/machinery/computer/security/labor
+	name = "labor camp monitoring"
+	desc = "Used to access the various cameras on the labor camp."
+	network = list("labor")
+	circuit = null
+
+/obj/machinery/computer/security/qm
+	name = "Quartermaster's camera console"
+	desc = "A console with access to the mining, auxillary base and vault camera networks."
+	network = list("mine", "auxbase", "vault")
+	circuit = null
+
+// TELESCREENS
+
 /obj/machinery/computer/security/telescreen
 	name = "\improper Telescreen"
 	desc = "Used for watching an empty arena."
@@ -161,7 +205,6 @@
 	density = FALSE
 	circuit = null
 	clockwork = TRUE //it'd look very weird
-
 	light_power = 0
 
 /obj/machinery/computer/security/telescreen/update_icon()
@@ -176,28 +219,68 @@
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment"
 	network = list("thunder")
-	density = FALSE
-	circuit = null
 
-/obj/machinery/computer/security/wooden_tv
-	name = "security camera monitor"
-	desc = "An old TV hooked into the stations camera network."
-	icon_state = "television"
-	icon_keyboard = null
-	icon_screen = "detective_tv"
-	clockwork = TRUE //it'd look weird
+/obj/machinery/computer/security/telescreen/rd
+	name = "Research Director's telescreen"
+	desc = "Used for watching the AI and the RD's goons from the safety of his office."
+	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test")
 
-
-/obj/machinery/computer/security/mining
-	name = "outpost camera console"
-	desc = "Used to access the various cameras on the outpost."
-	icon_screen = "mining"
-	icon_keyboard = "mining_key"
-	network = list("mine")
-	circuit = /obj/item/circuitboard/computer/mining
-
-/obj/machinery/computer/security/research
-	name = "research camera console"
-	desc = "Used to access the various cameras in science."
+/obj/machinery/computer/security/telescreen/circuitry
+	name = "circuitry telescreen"
+	desc = "Used for watching the other eggheads from the safety of the circuitry lab."
 	network = list("rd")
-	circuit = /obj/item/circuitboard/computer/research
+
+/obj/machinery/computer/security/telescreen/ce
+	name = "Chief Engineer's telescreen"
+	desc = "Used for watching the engine, telecommunications and the minisat."
+	network = list("engine", "singularity", "tcomms", "minisat")
+
+/obj/machinery/computer/security/telescreen/cmo
+	name = "Chief Medical Officer's telescreen"
+	desc = "A telescreen with access to the medbay's camera network."
+	network = list("medbay")
+
+/obj/machinery/computer/security/telescreen/vault
+	name = "Vault monitor"
+	desc = "A telescreen that connects to the vault's camera network."
+	network = list("vault")
+
+/obj/machinery/computer/security/telescreen/toxins
+	name = "Bomb test site monitor"
+	desc = "A telescreen that connects to the bomb test site's camera."
+	network = list("toxin")
+
+/obj/machinery/computer/security/telescreen/engine
+	name = "engine monitor"
+	desc = "A telescreen that connects to the engine's camera network."
+	network = list("engine")
+
+/obj/machinery/computer/security/telescreen/turbine
+	name = "turbine monitor"
+	desc = "A telescreen that connects to the turbine's camera."
+	network = list("turbine")
+
+/obj/machinery/computer/security/telescreen/interrogation
+	name = "interrogation room monitor"
+	desc = "A telescreen that connects to the interrogation room's camera."
+	network = list("interrogation")
+
+/obj/machinery/computer/security/telescreen/prison
+	name = "prison monitor"
+	desc = "A telescreen that connects to the permabrig's camera network."
+	network = list("prison")
+
+/obj/machinery/computer/security/telescreen/auxbase
+	name = "auxillary base monitor"
+	desc = "A telescreen that connects to the auxillary base's camera."
+	network = list("auxbase")
+
+/obj/machinery/computer/security/telescreen/minisat
+	name = "minisat monitor"
+	desc = "A telescreen that connects to the minisat's camera network."
+	network = list("minisat")
+
+/obj/machinery/computer/security/telescreen/aiupload
+	name = "AI upload monitor"
+	desc = "A telescreen that connects to the AI upload's camera network."
+	network = list("aiupload")


### PR DESCRIPTION
🆑 Denton
tweak: Camera networks, monitor screens and telescreens have been standardized.
tweak: Motion-sensitive cameras now show a message when they trigger the alarm.
fix: The Box/Meta auxillary base camera now works.
fix: Bomb test site cameras now emit light, as intended.
fix: Meta: Replaced the RD telescreen in the CE office with the correct one.
/🆑

Cam networks/telescreens were all over the place - the last time someone updated them was when Genetics was still a part of RnD.

I figured that it makes sense if department heads can access their relevant camnets:

RD: AI core, AI upload, the minisat and RnD
CE: The engine, telecomms and minisat
HoS: Security cameras and gulag
HoP/QM: the vault/vault+auxbase+mining
CMO: medbay
Other than that I fixed bomb site+aux base cams and made motion sensitive cams show a warning when they trigger the alarm.