### PR TITLE
Fixes morgue door air alarm and table blocking it

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -25398,6 +25398,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bnV" = (
@@ -27881,14 +27886,6 @@
 	dir = 6
 	},
 /area/security/checkpoint/medical)
-"btS" = (
-/obj/structure/table,
-/obj/item/paper/guides/jobs/medical/morgue{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "btT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29257,19 +29254,6 @@
 "bwS" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bwT" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64732,6 +64716,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"sKz" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "sKD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -104612,7 +104603,7 @@ bmf
 bmf
 bmf
 bvo
-bnJ
+sKz
 oaV
 bBs
 bCE
@@ -105894,9 +105885,9 @@ bnP
 bpi
 bpi
 bpi
-btS
+bnQ
 wXv
-bwT
+bLy
 bys
 bzQ
 bnJ


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
tweak: Fixes the table blocking the entrance of the morgue and moved the air air alarm inside it.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
