### PR TITLE
Fixes telescreens and cameras id tags

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -5297,7 +5297,7 @@
 /area/solar/starboard/fore)
 "alK" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 2
+	cyclelinkeddir = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -6026,7 +6026,7 @@
 /area/maintenance/starboard/fore)
 "anH" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 1
+	cyclelinkeddir = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -18670,7 +18670,7 @@
 /area/hallway/secondary/exit)
 "aVa" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
+	cyclelinkeddir = 0;
 	name = "Security Escape Airlock";
 	req_access_txt = "2"
 	},
@@ -18688,7 +18688,7 @@
 /area/hallway/secondary/exit)
 "aVd" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
+	cyclelinkeddir = 0;
 	name = "Security Escape Airlock";
 	req_access_txt = "2"
 	},
@@ -19689,7 +19689,7 @@
 /area/hallway/secondary/exit)
 "aYq" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
+	cyclelinkeddir = 0;
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -19699,7 +19699,7 @@
 /area/hallway/secondary/exit)
 "aYs" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
+	cyclelinkeddir = 0;
 	name = "Escape Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -23873,7 +23873,7 @@
 /area/hallway/secondary/exit)
 "bjI" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
+	cyclelinkeddir = 0;
 	name = "Cargo Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -23888,7 +23888,7 @@
 /area/hallway/secondary/exit)
 "bjK" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
+	cyclelinkeddir = 0;
 	name = "Cargo Escape Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -26154,7 +26154,8 @@
 "bpE" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2
+	dir = 2;
+	network = list("ss13","rd")
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -30663,7 +30664,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division North";
-	dir = 2
+	dir = 2;
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31708,7 +31710,8 @@
 "bCS" = (
 /obj/machinery/camera{
 	c_tag = "Research Division West";
-	dir = 2
+	dir = 2;
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33546,7 +33549,9 @@
 /area/security/checkpoint/science/research)
 "bGY" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen/rd,
+/obj/machinery/computer/security/telescreen/rd{
+	name = "Research Division security telescreen"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -34736,7 +34741,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/science/research";
 	dir = 2;
-	name = "Science Security APC";
+	name = "Research Security APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -38724,7 +38729,8 @@
 "bSL" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
@@ -42163,7 +42169,9 @@
 	name = "Chemical Lab";
 	req_access_txt = "47"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
 "cbi" = (
@@ -44882,6 +44890,7 @@
 	},
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
+	network = list("engine","singularity");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -44891,7 +44900,7 @@
 "ciq" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/atmos";
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 8;
 	name = "Atmospherics APC";
 	pixel_x = -24
@@ -49537,6 +49546,7 @@
 "ctU" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
+	network = list("engine","singularity");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55897,7 +55907,6 @@
 	name = "MiniSat Chamber Hallway";
 	req_one_access_txt = "65"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cJf" = (
@@ -56389,9 +56398,7 @@
 	name = "AI Chamber";
 	req_access_txt = "65"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cKm" = (
@@ -56532,6 +56539,9 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "AI Core";
 	req_access_txt = "65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -57310,6 +57320,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"cTD" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 0;
+	name = "Escape Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "cUs" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/engine/port_engineering";
@@ -59522,7 +59542,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway - Aft 2";
 	dir = 8;
-	network = list("ss13","engine")
+	network = list("ss13")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -61992,6 +62012,7 @@
 	},
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 4;
+	network = list("Singularity");
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
@@ -62093,6 +62114,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching output from station security cameras.";
 	name = "Security Camera Monitor";
+	network = list("ss13");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -63368,6 +63390,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"pCq" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 0;
+	name = "Escape Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pCL" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -64914,7 +64947,7 @@
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
 	dir = 8;
-	network = list("ss13","engine")
+	network = list("ss13")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -65696,7 +65729,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Docking Bay 2";
 	dir = 8;
-	network = list("ss13","engine")
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -66040,7 +66073,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Arrivals Hallway APC";
 	pixel_y = 24
@@ -118254,7 +118287,7 @@ spz
 spz
 spz
 spz
-aYq
+cTD
 spz
 bjI
 spz
@@ -119025,7 +119058,7 @@ aaa
 aaa
 aaa
 spz
-aYs
+pCq
 aWM
 bjK
 spz


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Fixes our map from having incorrect network tags assigned to cameras and telescreens pointing the the wrong networks
tweak: Removed cycle linked airlocks on doors that had the helper
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
