### PR TITLE
Lube won't slip no slips shoes anymore. (Experimental)

### DIFF
--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -75,7 +75,7 @@
 			lube_flags = NO_SLIP_WHEN_WALKING
 		if(TURF_WET_LUBE)
 			intensity = 80
-			lube_flags = SLIDE | GALOSHES_DONT_HELP
+			lube_flags = SLIDE //hippie code. Removed this free 8 second stun for users smart enough to obtain magboots or no slips
 		if(TURF_WET_ICE)
 			intensity = 120
 			lube_flags = SLIDE | GALOSHES_DONT_HELP


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
del: Removed the GALOSHES_DONT_HELP flag from lubed floors
balance: Lube no longer works with non-slips (chameleon no slips, magboots turned on, high traction boots)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Because fuck you thats why. Everyone spams lube as the most common slip item and considering it takes 2 seconds to make and you can spam it almost endlessly. Magboots, galoshes, high traction boots, camo no slips will be safe from lube so you still have options to combat a luber using this.