### PR TITLE
Fixes SMES terminals and connection issues

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -11,9 +11,9 @@
 	var/mob/living/carbon/attached = null
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker = null
-	var/static/list/drip_containers = list(/obj/item/reagent_containers/blood,
-		/obj/item/reagent_containers/food,
-		/obj/item/reagent_containers/glass)
+	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
+									/obj/item/reagent_containers/food,
+									/obj/item/reagent_containers/glass))
 
 /obj/machinery/iv_drip/Initialize()
 	. = ..()
@@ -92,7 +92,7 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/W, mob/user, params)
-	if(is_type_in_list(W, drip_containers))//hippie code
+	if(is_type_in_typecache(W, drip_containers))
 		if(beaker)
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -112,7 +112,7 @@
 
 /obj/machinery/iv_drip/process()
 	if(!attached)
-		return
+		return PROCESS_KILL
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, "<span class='userdanger'>The IV drip needle is ripped out of you!</span>")

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -11,9 +11,9 @@
 	var/mob/living/carbon/attached = null
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker = null
-	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
-									/obj/item/reagent_containers/food,
-									/obj/item/reagent_containers/glass))
+	var/static/list/drip_containers = list(/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/food,
+		/obj/item/reagent_containers/glass)
 
 /obj/machinery/iv_drip/Initialize()
 	. = ..()
@@ -92,7 +92,7 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/W, mob/user, params)
-	if(is_type_in_typecache(W, drip_containers))
+	if(is_type_in_list(W, drip_containers))//hippie code
 		if(beaker)
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return
@@ -112,7 +112,7 @@
 
 /obj/machinery/iv_drip/process()
 	if(!attached)
-		return PROCESS_KILL
+		return
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, "<span class='userdanger'>The IV drip needle is ripped out of you!</span>")

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -53,11 +53,11 @@
 					terminal = term
 					break dir_loop
 
-		if(!terminal)
-			stat |= BROKEN
-			return
-		terminal.master = src
-		update_icon()
+	if(!terminal)
+		stat |= BROKEN
+		return
+	terminal.master = src
+	update_icon()
 
 /obj/machinery/power/smes/RefreshParts()
 	var/IO = 0
@@ -141,11 +141,7 @@
 			//build the terminal and link it to the network
 			make_terminal(T)
 			terminal.connect_to_network()
-		return
-
-	//disassembling the terminal
-	if(istype(I, /obj/item/wirecutters) && terminal && panel_open)
-		terminal.dismantle(user, I)
+			connect_to_network()
 		return
 
 	//crowbarring it !
@@ -159,6 +155,13 @@
 		return
 
 	return ..()
+
+/obj/machinery/power/smes/wirecutter_act(mob/living/user, obj/item/I)
+	//disassembling the terminal
+	if(terminal)
+		terminal.dismantle(user, I)
+		return TRUE
+
 
 /obj/machinery/power/smes/default_deconstruction_crowbar(obj/item/crowbar/C)
 	if(istype(C) && terminal)
@@ -192,7 +195,6 @@
 /obj/machinery/power/smes/disconnect_terminal()
 	if(terminal)
 		terminal.master = null
-		terminal = null
 		stat |= BROKEN
 
 

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -71,6 +71,9 @@
 
 		new /obj/item/stack/cable_coil(drop_location(), 10)
 		to_chat(user, "<span class='notice'>You cut the cables and dismantle the power terminal.</span>")
+		var/obj/machinery/power/smes/S = master
+		if(istype(S, /obj/machinery/power/smes))
+			S.terminal = null
 		qdel(src)
 
 /obj/machinery/power/terminal/wirecutter_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: SMES power terminals not actually deleting the terminal reference when by cutting the terminal itself rather than the SMES.
fix: SMES now reconnect to the grid properly after construction.
refactor: SMES now uses wirecutter act to handle terminal deconstruction.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
