### PR TITLE
Moths can now eat clothes

### DIFF
--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -53,7 +53,7 @@
 			var/obj/item/clothing/C = W
 			playsound(get_turf(src), 'sound/items/eatfood.ogg', 70,1)
 			visible_message("<span class='alert'>[user] bites into a [C].</span>")
-			nutrition += 20
-			C.take_damage(50, BRUTE, "melee", 1)
+			nutrition += 10
+			C.take_damage(3, BRUTE, "melee", 1)
 		else
 			return ..()

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -37,6 +37,23 @@
 		to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
 		H.dna.features["moth_wings"] = "Burnt Off"
 		handle_mutant_bodyparts(H)
-		
+
 /datum/species/moth/check_roundstart_eligible()
 	return TRUE
+
+/mob/living/carbon/human/attackby(obj/item/W, mob/living/carbon/human/user)
+	if(dna.species.id == "moth") //specifies the species
+		var/static/list/item_types = list(/obj/item/clothing,
+		/obj/item/clothing/neck,
+		/obj/item/clothing/head,
+		/obj/item/clothing/mask,
+		/obj/item/clothing/under,
+		/obj/item/clothing/shoes) //lists the tasty snacks
+		if(is_type_in_list(W, /obj/item/clothing))
+			var/obj/item/clothing/C = W
+			playsound(get_turf(src), 'sound/items/eatfood.ogg', 70,1)
+			visible_message("<span class='alert'>[user] bites into a [C].</span>")
+			nutrition += 20
+			C.take_damage(50, BRUTE, "melee", 1)
+		else
+			return ..()

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -54,6 +54,6 @@
 			playsound(get_turf(src), 'sound/items/eatfood.ogg', 70,1)
 			visible_message("<span class='alert'>[user] bites into a [C].</span>")
 			nutrition += 10
-			C.take_damage(3, BRUTE, "melee", 1)
+			C.take_damage(50, BRUTE, "melee", 1)
 		else
 			return ..()

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -49,7 +49,7 @@
 		/obj/item/clothing/mask,
 		/obj/item/clothing/under,
 		/obj/item/clothing/shoes) //lists the tasty snacks
-		if(is_type_in_list(W, /obj/item/clothing))
+		if(is_type_in_list(W, item_types))
 			var/obj/item/clothing/C = W
 			playsound(get_turf(src), 'sound/items/eatfood.ogg', 70,1)
 			visible_message("<span class='alert'>[user] bites into a [C].</span>")


### PR DESCRIPTION
Moths can now eat certain clothes.

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Challade
Moths can now refresh themselves on the clothing off their back, and of their generous companions. Provides nutrition and fury from nude stationmates.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
