### PR TITLE
Fixes nanosuit causes runtime errors from overrides

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -652,7 +652,7 @@
 		var/obj/item/clothing/suit/space/hardsuit/nano/NS = wear_suit
 		if(statpanel("Crynet Nanosuit"))
 			stat("Crynet Protocols : Engaged")
-			stat("Energy Charge:", "[round(NS.cell.charge*100/NS.cell.maxcharge)]%")
+			stat("Energy Charge:", "[round(NS.cell.percent())]%")
 			stat("Mode:", "[NS.mode]")
 			stat("Overall Status:", "[health]% healthy")
 			stat("Nutrition Status:", "[nutrition]")
@@ -871,19 +871,23 @@
 
 /obj/item/afterattack(atom/O, mob/living/carbon/human/user, proximity)
 	..()
-	if(istype(user.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
-		var/obj/item/clothing/suit/space/hardsuit/nano/NS = user.wear_suit
-		NS.kill_cloak()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
+			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
+			NS.kill_cloak()
 
 /obj/item/gun/afterattack(atom/O, mob/living/carbon/human/user, proximity)
 	..()
-	if(istype(user.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
-		var/obj/item/clothing/suit/space/hardsuit/nano/NS = user.wear_suit
-		if(can_shoot())
-			NS.kill_cloak(suppressed)
-		if(proximity) //It's adjacent, is the user, or is on the user's person
-			if(!ismob(O) || user.a_intent == INTENT_HARM) //melee attack
-				NS.kill_cloak()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
+			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
+			if(can_shoot())
+				NS.kill_cloak(suppressed)
+			if(proximity) //It's adjacent, is the user, or is on the user's person
+				if(!ismob(O) || user.a_intent == INTENT_HARM) //melee attack
+					NS.kill_cloak()
 
 /obj/item/gun/attack(mob/M as mob, mob/living/carbon/user)
 	..()
@@ -896,21 +900,27 @@
 
 /obj/item/weldingtool/afterattack(atom/O, mob/living/carbon/human/user, proximity)
 	..()
-	if(istype(user.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
-		var/obj/item/clothing/suit/space/hardsuit/nano/NS = user.wear_suit
-		NS.kill_cloak()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
+			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
+			NS.kill_cloak()
 
 /obj/item/twohanded/fireaxe/afterattack(atom/A, mob/living/carbon/human/user, proximity)
 	..()
-	if(istype(user.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
-		var/obj/item/clothing/suit/space/hardsuit/nano/NS = user.wear_suit
-		NS.kill_cloak()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
+			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
+			NS.kill_cloak()
 
 /datum/species/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
 	..()
-	if(istype(M.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
-		var/obj/item/clothing/suit/space/hardsuit/nano/NS = M.wear_suit
-		NS.kill_cloak()
+	if(ishuman(M))
+		var/mob/living/carbon/human/user = M
+		if(istype(user.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
+			var/obj/item/clothing/suit/space/hardsuit/nano/NS = user.wear_suit
+			NS.kill_cloak()
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/kill_cloak(temp)
 	if(mode == CLOAK)
@@ -983,7 +993,6 @@
 	..()
 	air_contents.assert_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	START_PROCESSING(SSobj, src)
 	return
 
 /obj/item/tank/internals/emergency_oxygen/recharge/process()

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -869,7 +869,7 @@
 					return
 	.=..()
 
-/obj/item/afterattack(atom/O, mob/living/carbon/human/user, proximity)
+/obj/item/afterattack(atom/O, mob/user, proximity)
 	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -877,7 +877,7 @@
 			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
 			NS.kill_cloak()
 
-/obj/item/gun/afterattack(atom/O, mob/living/carbon/human/user, proximity)
+/obj/item/gun/afterattack(atom/O, mob/user, proximity)
 	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -889,7 +889,7 @@
 				if(!ismob(O) || user.a_intent == INTENT_HARM) //melee attack
 					NS.kill_cloak()
 
-/obj/item/gun/attack(mob/M as mob, mob/living/carbon/user)
+/obj/item/gun/attack(mob/M as mob, mob/user)
 	..()
 	if(user && ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -898,7 +898,7 @@
 			if(user.a_intent == INTENT_HARM)
 				NS.kill_cloak()
 
-/obj/item/weldingtool/afterattack(atom/O, mob/living/carbon/human/user, proximity)
+/obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
 	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -906,7 +906,7 @@
 			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
 			NS.kill_cloak()
 
-/obj/item/twohanded/fireaxe/afterattack(atom/A, mob/living/carbon/human/user, proximity)
+/obj/item/twohanded/fireaxe/afterattack(atom/A, mob/user, proximity)
 	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -914,7 +914,7 @@
 			var/obj/item/clothing/suit/space/hardsuit/nano/NS = H.wear_suit
 			NS.kill_cloak()
 
-/datum/species/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
+/datum/species/spec_attack_hand(mob/M, mob/H, datum/martial_art/attacker_style)
 	..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/user = M


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Runtimes were being thrown by afterattack and possibly other proc overrides in nanosuit.dm when the source was a non-human. This has been corrected.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
