### PR TITLE
Adds Thermo-electric Generator to Supermatter Engine Loop

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -45750,6 +45750,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cko" = (
@@ -49011,6 +49012,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csH" = (
@@ -49145,7 +49147,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csV" = (
@@ -49153,11 +49154,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csW" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/engine/engineering)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -49617,6 +49617,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cuc" = (
@@ -53031,7 +53034,6 @@
 /area/engine/supermatter)
 "cCD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cCE" = (
@@ -53456,6 +53458,9 @@
 /area/engine/engineering)
 "cDD" = (
 /obj/structure/sign/warning/electricshock,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cDE" = (
@@ -53475,7 +53480,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "cDK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -54422,6 +54426,9 @@
 /obj/item/crowbar/large,
 /obj/structure/rack,
 /obj/item/flashlight,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGy" = (
@@ -57433,11 +57440,6 @@
 "dmH" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -57684,6 +57686,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"dJC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dKp" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -57832,6 +57838,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"dYe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "dYn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58040,6 +58053,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"ewB" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "eyc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -58172,6 +58191,13 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"eJQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "eKo" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -58580,6 +58606,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"fAm" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fCl" = (
 /obj/machinery/light/small{
 	brightness = 5;
@@ -58633,6 +58667,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fHU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fHV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58707,6 +58749,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fRd" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "fTz" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -58900,6 +58946,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
+"gmN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/science/circuit)
 "gog" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58959,6 +59012,13 @@
 /area/security/checkpoint/auxiliary{
 	name = "Security Checkpoint - Arrivals"
 	})
+"gtG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gxm" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
@@ -59096,6 +59156,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/science/explab)
+"gLs" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gPK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59155,6 +59221,13 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"gVK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Passive Coolant Pump"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gWg" = (
 /turf/open/floor/plasteel/red/side,
 /area/hallway/secondary/entry)
@@ -59399,6 +59472,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
+"hsS" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "htW" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light{
@@ -59672,6 +59749,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hRR" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hTJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -59843,6 +59924,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"igF" = (
+/obj/structure/sign/warning/fire,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "iix" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -59881,6 +59969,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ile" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "imS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
@@ -60409,6 +60504,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jjM" = (
@@ -60997,6 +61093,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kwC" = (
@@ -61034,6 +61131,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kyW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "kzN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -61061,6 +61165,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
+"kBA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "kBI" = (
 /obj/machinery/light{
 	dir = 8
@@ -61280,6 +61391,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"laI" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "lcC" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -61401,6 +61516,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
+"lmR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "lnJ" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -61414,6 +61538,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lqj" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "lrb" = (
 /obj/machinery/light{
 	dir = 8
@@ -61475,6 +61603,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"lvO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "lxd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61614,6 +61750,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"lJP" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "lKd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61694,6 +61834,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lNs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "lNS" = (
 /obj/item/radio/intercom{
 	freerange = 0;
@@ -62536,6 +62682,12 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"nsO" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nti" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -62823,6 +62975,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
+"oaB" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oaP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62989,6 +63148,12 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
+"owW" = (
+/obj/machinery/atmospherics/components/unary/heat_exchanger{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ozm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -63336,6 +63501,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pir" = (
+/obj/machinery/atmospherics/components/unary/heat_exchanger{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "piK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63881,6 +64052,13 @@
 "qpU" = (
 /turf/open/floor/plating,
 /area/space)
+"qrC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "qrY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -64338,6 +64516,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rrV" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/heat_exchanger{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rsd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -64458,6 +64643,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"rIv" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
+/area/crew_quarters/bar/maint)
+"rKh" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rMi" = (
 /obj/structure/table/wood,
 /obj/item/toy/eightball,
@@ -64504,6 +64698,12 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"rPl" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "rQg" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
@@ -64659,6 +64859,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sfF" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	target_temperature = 80;
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "sgE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65042,6 +65250,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"sSQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "sTa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -65539,6 +65756,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "tVk" = (
@@ -65798,7 +66018,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uHI" = (
@@ -65902,6 +66121,9 @@
 "uOy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -66421,6 +66643,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"vXF" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "vXL" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -67108,6 +67337,12 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"xfc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "xfx" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
@@ -67598,6 +67833,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xYs" = (
@@ -77116,7 +77352,7 @@ twI
 aCK
 aWO
 ayG
-aRf
+laI
 qeJ
 aRf
 aRf
@@ -87620,7 +87856,7 @@ aad
 aaa
 aaa
 akn
-alf
+rIv
 alY
 alf
 anT
@@ -93361,7 +93597,7 @@ cnN
 cdI
 cqe
 clH
-csD
+lqj
 csD
 cuJ
 cvy
@@ -93619,7 +93855,7 @@ cdI
 cqe
 clH
 eoL
-ctJ
+csD
 cuK
 ctJ
 ctJ
@@ -95187,7 +95423,7 @@ sXO
 cEw
 sXO
 cGt
-clH
+sXO
 clH
 cGe
 aad
@@ -95444,7 +95680,7 @@ rdB
 qbk
 sXO
 sXO
-clH
+sXO
 clH
 cGe
 aai
@@ -95700,8 +95936,8 @@ mYc
 riN
 sPv
 cGg
+ctJ
 cGu
-clH
 clH
 czf
 aai
@@ -95958,7 +96194,7 @@ qSW
 eyl
 eyl
 ctJ
-clH
+ctJ
 clH
 cGe
 abf
@@ -96205,17 +96441,17 @@ cDi
 hpW
 jxj
 dMV
-clH
+rPl
 jjf
 kvn
-qtI
-clH
+fHU
+fRd
 xYc
-sXO
-sXO
-sXO
-sXO
-clH
+hsS
+dJC
+dJC
+dJC
+gLs
 clH
 cGe
 abf
@@ -96460,8 +96696,8 @@ qrY
 cCC
 cDj
 uOy
-uOy
-uOy
+ile
+sSQ
 cDD
 kpZ
 cFj
@@ -96471,8 +96707,8 @@ pyl
 sXO
 sXO
 lYW
-sXO
-clH
+rKh
+xJZ
 clH
 cGe
 abf
@@ -96716,7 +96952,7 @@ cBw
 cBX
 cCD
 cDk
-cDN
+lNs
 aab
 cDN
 cCB
@@ -96728,8 +96964,8 @@ dIF
 sXO
 dIF
 cGh
-sXO
-clH
+sfF
+xJZ
 clH
 cGe
 aai
@@ -96974,9 +97210,9 @@ cBY
 cCE
 cDl
 tSY
-tSY
-tSY
-wYv
+qrC
+lmR
+igF
 sIg
 cFl
 cFu
@@ -96986,7 +97222,7 @@ sXO
 sXO
 dYS
 sXO
-clH
+gVK
 clH
 cGe
 abf
@@ -97233,17 +97469,17 @@ lQA
 rZX
 rZX
 hkb
-clH
+ewB
 jjf
 kvn
-qtI
-clH
+fHU
+fRd
 xYc
-sXO
-sXO
-sXO
-sXO
-clH
+hsS
+dJC
+dJC
+cEi
+xJZ
 clH
 cGe
 aai
@@ -97499,8 +97735,8 @@ ctJ
 qGt
 rXs
 qGt
-ctJ
-clH
+owW
+owW
 clH
 cGe
 aai
@@ -97756,8 +97992,8 @@ mYc
 rNB
 rNB
 hoK
-cGu
-clH
+pir
+rrV
 clH
 czf
 aai
@@ -98012,9 +98248,9 @@ kWH
 dpb
 dpb
 nmD
-sXO
-sXO
-clH
+nsO
+lJP
+xJZ
 clH
 cGe
 aai
@@ -98269,9 +98505,9 @@ cok
 mBf
 sXO
 knd
-sXO
+sKc
 cGw
-clH
+fAm
 clH
 cGe
 abp
@@ -98526,8 +98762,8 @@ nsj
 clH
 clH
 clH
-clH
-clH
+xfc
+xfc
 clH
 clH
 cGe
@@ -98780,11 +99016,11 @@ kYE
 sBj
 xjM
 mXX
+mXX
 peq
-aak
 aad
-aai
-aaa
+dYe
+kyW
 aag
 clH
 cGe
@@ -99039,9 +99275,9 @@ clH
 aak
 aak
 aak
-aad
-aaa
-aaa
+gtG
+lvO
+eJQ
 ahy
 aaa
 aaa
@@ -99296,9 +99532,9 @@ clH
 aaa
 aaa
 aai
-aad
-aaa
-aaa
+oaB
+lvO
+vXF
 ahy
 aaa
 aaa
@@ -99553,9 +99789,9 @@ clH
 aai
 aai
 aai
-aad
-aaa
-aaa
+qAK
+lvO
+eJQ
 ahy
 aaa
 aaa
@@ -99810,9 +100046,9 @@ aaa
 aaa
 aaa
 aaa
-aad
-aaa
-aaa
+cEt
+lvO
+vXF
 aad
 aaa
 aaa
@@ -100068,8 +100304,8 @@ aaa
 aaa
 aaa
 aad
-aaa
-aaa
+kBA
+eJQ
 aad
 aaa
 aaa
@@ -104875,7 +105111,7 @@ aOK
 aOK
 bcB
 aOK
-aOK
+hRR
 aNo
 bfW
 bfW
@@ -116736,7 +116972,7 @@ cah
 cah
 cdB
 cez
-cez
+gmN
 cgO
 chM
 cah

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -11238,6 +11238,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aBR" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "aBT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -53490,13 +53497,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDL" = (
-/obj/machinery/atmospherics/components/binary/circulator{
-	flipped = 1
+/obj/effect/turf_decal/loading_area/red{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "cDM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53753,6 +53761,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEw" = (
@@ -57372,11 +57381,10 @@
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
 "dcn" = (
-/obj/machinery/atmospherics/components/binary/circulator/cold{
-	dir = 1;
-	flipped = 1
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "dda" = (
 /obj/structure/table/wood,
@@ -59222,9 +59230,9 @@
 	},
 /area/hallway/secondary/entry)
 "gVK" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
-	name = "Passive Coolant Pump"
+	name = "Coolant to Loop"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -59473,7 +59481,10 @@
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
 "hsS" = (
-/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "htW" = (
@@ -61752,6 +61763,7 @@
 /area/maintenance/disposal/incinerator)
 "lJP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lKd" = (
@@ -62891,6 +62903,32 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
+"nPe" = (
+/obj/structure/closet/crate/engineering{
+	name = "T.E.G. crate"
+	},
+/obj/machinery/power/generator{
+	anchored = 0;
+	dir = 4;
+	panel_open = 1
+	},
+/obj/machinery/atmospherics/components/binary/circulator{
+	anchored = 0;
+	flipped = 1;
+	panel_open = 1
+	},
+/obj/machinery/atmospherics/components/binary/circulator/cold{
+	anchored = 0;
+	dir = 1;
+	flipped = 1;
+	panel_open = 1
+	},
+/obj/item/paper{
+	info = "<h>Order #7751</h><p>This pack contains all components of a Thermoelectric Generator. Unpack crack and install at pre-designated area in the engine room. Use multitool to connect circulators.</p> ";
+	name = "T.E.G. Order"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "nSR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64860,11 +64898,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sfF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	target_temperature = 80;
-	dir = 2;
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sgE" = (
@@ -65793,6 +65827,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tWQ" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tXn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67186,9 +67225,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/generator{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "wOt" = (
@@ -94115,7 +94152,7 @@ eoL
 ctJ
 ctJ
 ctJ
-ctJ
+nPe
 cvz
 clH
 cyX
@@ -96447,11 +96484,11 @@ kvn
 fHU
 fRd
 xYc
-hsS
-dJC
-dJC
-dJC
 gLs
+sXO
+sXO
+sXO
+sXO
 clH
 cGe
 abf
@@ -96704,11 +96741,11 @@ cFj
 cFs
 xxi
 pyl
-sXO
+sKc
 sXO
 lYW
 rKh
-xJZ
+gLs
 clH
 cGe
 abf
@@ -96961,11 +96998,11 @@ cFk
 cFk
 fmU
 dIF
-sXO
+sKc
 dIF
 cGh
 sfF
-xJZ
+tWQ
 clH
 cGe
 aai
@@ -97218,7 +97255,7 @@ cFl
 cFu
 xxi
 sXO
-sXO
+sKc
 sXO
 dYS
 sXO
@@ -97478,7 +97515,7 @@ xYc
 hsS
 dJC
 dJC
-cEi
+aBR
 xJZ
 clH
 cGe

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -12491,8 +12491,8 @@
 /area/hallway/secondary/entry)
 "aFp" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "1"
+	name = "Infirmary Maintenance";
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -34178,12 +34178,12 @@
 /area/crew_quarters/heads/hor)
 "bIp" = (
 /obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/explab)
 "bIq" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/explab)
 "bIr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -34867,6 +34867,9 @@
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -37199,9 +37202,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPl" = (
@@ -37209,9 +37209,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPn" = (
@@ -51811,9 +51808,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "czx" = (
@@ -53479,37 +53474,27 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"cDJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "cDK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/binary/circulator{
+	flipped = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Gas to Cooling Loop"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cDM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53517,7 +53502,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cDN" = (
 /turf/open/floor/engine,
@@ -53624,37 +53609,28 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEe" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Emergency Cooling Loop Bypass"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cEg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -53764,8 +53740,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cEv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -53777,31 +53759,26 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Cooling Loop Bypass"
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEy" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cEA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -53911,33 +53888,28 @@
 /area/engine/engineering)
 "cEL" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Cooling Loop to Gas"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_on_map";
+	name = "Cold to Engine Loop";
+	on = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
@@ -54042,16 +54014,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cFb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cFc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
@@ -57396,6 +57364,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
+"dcn" = (
+/obj/machinery/atmospherics/components/binary/circulator/cold{
+	dir = 1;
+	flipped = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "dda" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXtwentythree,
@@ -57408,6 +57383,14 @@
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"der" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "deA" = (
@@ -57921,8 +57904,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ehW" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "ejm" = (
@@ -58056,9 +58041,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "eyc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -58111,19 +58093,17 @@
 	},
 /area/hallway/secondary/entry)
 "eBA" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("engine");
-	pixel_x = 23
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "eDi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58152,15 +58132,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"eEA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "eED" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
@@ -58310,9 +58281,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eUC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -58563,6 +58531,15 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"fxk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "fxr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -59088,6 +59065,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"gIm" = (
+/turf/open/space/basic,
+/area/construction/mining/aux_base)
 "gIn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59112,6 +59092,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"gJM" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/science/explab)
 "gPK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59374,6 +59358,28 @@
 	dir = 4
 	},
 /area/security/prison)
+"hpW" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 2;
+	network = list("engine");
+	pixel_x = 11
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "hqn" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -59680,6 +59686,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hUc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "hUj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59920,6 +59932,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"iqf" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "iqS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59964,10 +59988,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ivM" = (
 /obj/structure/table/glass,
@@ -60137,19 +60165,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iKH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "iKM" = (
 /obj/machinery/door/firedoor,
@@ -60252,17 +60276,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "iXV" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "iZb" = (
 /obj/machinery/power/tesla_coil,
@@ -60330,8 +60350,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jgL" = (
-/obj/machinery/ai_status_display,
-/turf/closed/wall/r_wall,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "jhA" = (
 /obj/machinery/door/firedoor,
@@ -60458,9 +60483,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jsa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -60469,6 +60491,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60636,6 +60662,17 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"jEA" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"jFq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "jGE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -61024,6 +61061,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
+"kBI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kCt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61234,6 +61280,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lcC" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "lcD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -61947,6 +61997,15 @@
 "mqf" = (
 /turf/open/space/basic,
 /area/engine/port_engineering)
+"muO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mvb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -62130,6 +62189,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"mOl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Heat Exchanger to Loop"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mOM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -62224,6 +62293,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mWr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "mXB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -62398,6 +62473,15 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nkH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -62435,7 +62519,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "nsj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62828,7 +62917,10 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -63284,16 +63376,21 @@
 	},
 /area/engine/atmos)
 "pmn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_on_map";
+	name = "Hot to Generator";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pmV" = (
@@ -63781,6 +63878,9 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"qpU" = (
+/turf/open/floor/plating,
+/area/space)
 "qrY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -63844,6 +63944,10 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"qyz" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/construction/mining/aux_base)
 "qyM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -64252,16 +64356,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "rvj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rvk" = (
@@ -64338,7 +64439,6 @@
 /turf/closed/wall,
 /area/science/circuit)
 "rIp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -64346,6 +64446,15 @@
 	c_tag = "Engineering Supermatter Port";
 	dir = 4;
 	network = list("ss13","engine")
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -64550,6 +64659,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sgE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	icon_state = "pump_map";
+	name = "Hot to Heat Exchanger";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "shd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -64564,6 +64685,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"sid" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "siG" = (
 /obj/machinery/conveyor{
 	id = "arrivalright"
@@ -64739,10 +64866,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "sFQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -64792,6 +64919,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
+"sJC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sKc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -65034,18 +65168,14 @@
 	},
 /area/engine/port_engineering)
 "tcz" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "tcT" = (
 /obj/structure/cable/yellow{
@@ -65351,6 +65481,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tOr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tOI" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas{
@@ -65367,6 +65506,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tQR" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "tQS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -65531,6 +65673,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uoH" = (
@@ -65540,8 +65685,8 @@
 /turf/open/floor/plasteel/red/side,
 /area/engine/atmos)
 "uqb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -65645,6 +65790,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"uFF" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uHI" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -65785,10 +65941,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
+"uQM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uRH" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
+"uRW" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "uRY" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
@@ -66172,6 +66347,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
+"vOM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "vSu" = (
 /obj/structure/closet,
 /obj/machinery/airalarm{
@@ -66205,6 +66386,12 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vUv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "vVb" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -66766,6 +66953,15 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"wNs" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/generator{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wOt" = (
 /obj/structure/chair{
 	dir = 4
@@ -67008,10 +67204,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xph" = (
@@ -67296,6 +67498,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"xQj" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/science/explab)
 "xQD" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -70235,16 +70441,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+jEA
+jEA
 aae
+aFi
+aFi
+jEA
+jEA
 aae
-aae
-aaa
-aaa
-aae
-aae
-aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -70486,8 +70692,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+bqy
+bqy
 aad
 aad
 aad
@@ -70501,13 +70707,13 @@ aad
 aad
 aad
 aad
+aFi
+aFi
+bqy
+bqy
 aad
-aad
-aaa
-aaa
-aad
-aad
-aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -70743,10 +70949,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
-aaj
+bqy
+lcC
 aaj
 aaj
 aaj
@@ -70766,6 +70970,8 @@ aaj
 aaj
 aad
 aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -71001,28 +71207,28 @@ aaa
 aaa
 aaa
 aaa
+lcC
+bqy
+aFi
+aad
+aaa
+aFi
 aaa
 aaa
+bqy
+bqy
+aFi
+aFi
+aaa
+bqy
+aaa
+aad
+bqy
 aaj
 aad
-aaa
 aad
-aaa
-aaa
-aaa
-aaa
-aad
-aad
-aaa
-aaa
-aaa
-aad
-aaa
-aad
-aad
-aaj
-aad
-aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -71257,12 +71463,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
-aaj
+bqy
+lcC
 aad
 aad
+avz
+avz
 aoz
 aoz
 aoz
@@ -71272,14 +71478,14 @@ aoz
 aoz
 aoz
 aoz
-aoz
-aoz
-aad
-aad
+qyz
+qyz
 aad
 aaj
 aad
 aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -71514,14 +71720,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
-aaj
+bqy
+lcC
 aad
 aad
-aoz
-apw
+avz
+tQR
 apw
 apw
 apw
@@ -71531,12 +71735,14 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
-aad
-aaj
+gIm
+gIm
+bqy
+lcC
 aad
 aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -71771,14 +71977,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+bqy
+lcC
 aad
-aaj
-aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -71788,12 +71992,14 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
+gIm
+gIm
+bqy
+lcC
 aad
-aaj
 aad
-aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -72027,15 +72233,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aad
+jEA
+bqy
 aaj
 aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -72045,12 +72249,14 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
+gIm
+gIm
+bqy
+lcC
 aad
-aaj
 aad
-aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -72283,16 +72489,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aae
+jEA
+jEA
 aad
 aaj
 aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -72302,12 +72506,14 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
-aad
-aaj
+gIm
+gIm
+bqy
+lcC
 aad
 aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -72540,16 +72746,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aae
+jEA
+jEA
 aad
 aaj
 aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -72559,12 +72763,14 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
-aad
-aaj
+gIm
+gIm
+bqy
+lcC
 aad
 aae
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -72797,16 +73003,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aae
+jEA
+jEA
 aad
 aaj
 aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -72816,12 +73020,14 @@ apw
 apw
 apw
 aoz
-aad
-aad
+qyz
+qyz
 aad
 aaj
 aad
 aad
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -73055,15 +73261,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aad
+jEA
+bqy
 aaj
 aad
 aad
-aoz
-apw
+avz
+tQR
 apw
 apw
 apw
@@ -73073,11 +73277,13 @@ apw
 apw
 apw
 aoz
-aaa
-aaa
-aad
-aaj
-aad
+gIm
+gIm
+bqy
+bqy
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -73312,15 +73518,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aad
+jEA
+bqy
 aaj
 aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -73330,11 +73534,13 @@ apw
 apw
 apw
 aoz
+gIm
+gIm
 aaa
 aaa
-aad
-aaj
-aad
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -73570,14 +73776,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+bqy
+lcC
 aad
-aaj
-aad
-aaa
-aoz
-apw
+aFi
+avz
+qpU
 apw
 apw
 apw
@@ -73587,12 +73791,14 @@ apw
 apw
 apw
 aoz
+gIm
+gIm
 aaa
 aaa
-aad
-aaj
-aad
-aad
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -73827,12 +74033,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
-aaj
+bqy
+lcC
 aad
 aad
+avz
+avz
 aoz
 aoz
 aoz
@@ -73842,14 +74048,14 @@ xGA
 ipS
 aoz
 aoz
-aoz
-aoz
-aad
-aad
-aad
-aaj
-aad
-aaf
+gIm
+gIm
+aFi
+aFi
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -74085,9 +74291,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lcC
 aad
-aaj
+aFi
 aad
 aaa
 aaa
@@ -74103,10 +74309,10 @@ aaa
 aaa
 aaa
 aaa
-aad
-aaj
-aad
-aaf
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -74342,9 +74548,9 @@ aaa
 aaa
 aaa
 aaa
+lcC
 aaa
-aaa
-aaj
+aFi
 aad
 aaa
 aaa
@@ -74360,10 +74566,10 @@ aaa
 aaa
 aaa
 aaa
-aad
-aaj
-aad
-aad
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -74599,9 +74805,9 @@ aae
 aae
 aae
 aaa
+lcC
 aaa
-aaa
-aaj
+aFi
 aaa
 aaa
 aaa
@@ -74617,7 +74823,7 @@ aaa
 aaa
 aaa
 aaa
-aad
+aFi
 aaa
 aaa
 aaa
@@ -74856,9 +75062,9 @@ uJb
 aad
 aad
 aad
-aaa
-aaa
-aaj
+lcC
+bqy
+aFi
 aad
 aaa
 aaa
@@ -74874,8 +75080,8 @@ aaa
 aaa
 aaa
 aaa
-aad
-bqy
+aFi
+aaa
 aaa
 aaa
 aaa
@@ -75114,8 +75320,8 @@ aaj
 aaj
 aaj
 aaj
-aaj
-aaj
+aad
+aad
 aad
 aad
 aaa
@@ -75130,11 +75336,11 @@ aoz
 aaa
 aaa
 aaa
-aad
-aad
-aad
-aad
-aad
+aFi
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -75370,8 +75576,8 @@ aad
 aad
 aad
 aaa
-aaa
-aaa
+bqy
+bqy
 aad
 aad
 aad
@@ -75385,9 +75591,9 @@ mQC
 eMb
 aCH
 aaa
-aad
-aad
-aad
+aFi
+aFi
+aFi
 aaa
 aaa
 sMx
@@ -75641,9 +75847,9 @@ ikp
 beK
 aBy
 aCH
-aad
-aad
-aad
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -75899,11 +76105,11 @@ iLq
 bla
 aCH
 aaa
-aad
-aad
-aad
-aad
-aad
+aFi
+aFi
+aFi
+aFi
+aFi
 aaa
 aaa
 aaa
@@ -94199,7 +94405,7 @@ cCx
 cDh
 cDI
 xDw
-cEt
+sJC
 ehW
 wcs
 lpx
@@ -94451,13 +94657,13 @@ cza
 czN
 cAy
 xxi
-clH
-clH
-clH
-cDJ
 iLK
-cEu
+cxz
+cxz
 cEK
+cxz
+der
+mWr
 cEu
 cEu
 pcA
@@ -94708,8 +94914,8 @@ czb
 czO
 cAz
 mJX
-mJX
-mJX
+fxk
+tOr
 rIp
 cDK
 omM
@@ -94966,13 +95172,13 @@ czP
 cAA
 cBs
 cBs
-cBs
-cBs
+sgE
+uFF
 cDL
-cBs
-cBs
+wNs
+dcn
 cEL
-cBs
+mOl
 tqz
 yhF
 czc
@@ -95223,7 +95429,7 @@ czQ
 rSk
 jrq
 cBW
-cBW
+iqf
 pmn
 jsa
 cEd
@@ -95443,7 +95649,7 @@ bJT
 bKT
 oAG
 bNP
-eEA
+bPi
 bQO
 bRZ
 bTj
@@ -95483,9 +95689,9 @@ vWT
 cCz
 jgL
 cDM
-cEe
+cDM
 cEy
-gXP
+muO
 uqb
 mee
 wPy
@@ -95738,11 +95944,11 @@ cAC
 mmp
 xBe
 cCz
-clH
+gXP
 eBA
 nqU
-nqU
-clH
+eBA
+gXP
 obw
 vJD
 qtI
@@ -95996,7 +96202,7 @@ cBu
 keK
 clH
 cDi
-jxj
+hpW
 jxj
 dMV
 clH
@@ -97280,11 +97486,11 @@ nHy
 jwc
 lum
 lLq
-clH
+gXP
 ivA
-ivA
-ivA
-clH
+uQM
+uQM
+gXP
 nFo
 lvb
 qtI
@@ -97537,11 +97743,11 @@ cAI
 jwc
 xIc
 lLq
-gXP
+nkH
 tcz
 iKH
 iXV
-jgL
+kBI
 sFQ
 vpg
 pRd
@@ -116510,9 +116716,9 @@ bBO
 bDe
 bEK
 bxD
-bHi
-bHi
-bHi
+gJM
+sid
+uRW
 bxD
 bLV
 bNq
@@ -116767,9 +116973,9 @@ bBP
 bDf
 bEL
 bFS
-bHi
+xQj
 bIp
-bHi
+jFq
 bxD
 bLW
 bNr
@@ -117024,7 +117230,7 @@ bBQ
 bDg
 bEM
 bFS
-bHi
+xQj
 bIq
 bJK
 bxD
@@ -117281,9 +117487,9 @@ bBR
 bDf
 bEN
 bFS
-bHi
-bHi
-bHi
+hUc
+vOM
+vUv
 bxD
 bLY
 brs


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
add: Added in a TEG engine to the supermatter loop. 
add: Added in a passive coolant loop to remove excess heat for high energy SM operations.
add: Added in trash bins in various locations around the map.
add: Added in a shower in the engineering airlock.
fix: Aux base no longer clips white ship when docked.
fix: Fixes infirmary maintenance airlock name and access requirement.
add: Added warning outline turf decals to EXPERI-mentor machine.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Supermatter rarely generates more than 300kw during a round and a lot of the gas is currently wasted by being cooled and then expelled into space. We can now take advantage of these hot gasses by having it power one side of a TEG, put those gases in a space sided heat exchanger and then used the cooled return gases to power the other side of that TEG. Boom. Power plus an efficiently running supermatter. 

Edit:
Before
![image](https://user-images.githubusercontent.com/32651551/43305020-2fec7fae-9144-11e8-869e-f92aad691a16.png)
After
![image](https://user-images.githubusercontent.com/32651551/43353734-fed8552c-920c-11e8-8d77-54ffe308fdc2.png)

![image](https://user-images.githubusercontent.com/32651551/43188027-27eea46e-8fc1-11e8-8010-ca103139adf0.png)

![image](https://user-images.githubusercontent.com/32651551/43188051-37610004-8fc1-11e8-96d7-c7fc1030ba43.png)

