### PR TITLE
Scream and fart keybinds have been changed back to using ctrl instead of shift

### DIFF
--- a/hippiestation/code/modules/keybindings/bindings_hippie.dm
+++ b/hippiestation/code/modules/keybindings/bindings_hippie.dm
@@ -1,5 +1,5 @@
 /mob/key_down(_key, client/user)
-	if(client.keys_held["Shift"])
+	if(client.keys_held["Ctrl"])
 		switch(_key)
 			if("F")
 				emote("fart")


### PR DESCRIPTION
WOOWOO now you will no longer move when screaming and stuff

:cl:
tweak: Changed back scream and fart hotkeys to using ctrl instead of shift
/:cl: