### PR TITLE
ChemistryChanges

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -11109,6 +11109,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"aBs" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastleft{
+	name = "Medical Delivery"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
 "aBv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -28600,17 +28607,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bvn" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/folder/white,
-/obj/item/radio/headset/headset_med,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "bvo" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -29217,14 +29213,13 @@
 "bwJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"bwK" = (
 /obj/structure/table,
 /obj/machinery/chem/centrifuge{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bwK" = (
-/obj/structure/chair,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwL" = (
@@ -29261,6 +29256,10 @@
 "bwP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -29817,19 +29816,8 @@
 /area/medical/chemistry)
 "byl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/medical/chemistry)
-"bym" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Chemistry Desk";
-	req_access_txt = "33"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/chemistry)
 "byn" = (
 /obj/structure/bed/roller,
@@ -30406,27 +30394,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/chemistry)
 "bzH" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteyellow/corner{
-	dir = 4
-	},
-/area/medical/medbay/central)
+/obj/structure/table,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/folder/white,
+/obj/item/radio/headset/headset_med,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "bzI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -30438,28 +30424,31 @@
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 1
-	},
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "bzK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30518,13 +30507,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bzR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzS" = (
@@ -31089,28 +31071,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
-"bBj" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/chemistry)
 "bBk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31118,29 +31087,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bBn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	broadcasting = 0;
 	freerange = 0;
@@ -31156,25 +31115,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -31189,9 +31139,6 @@
 /area/medical/medbay/central)
 "bBt" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBv" = (
@@ -31590,16 +31537,12 @@
 	},
 /area/hallway/primary/central)
 "bCA" = (
-/obj/machinery/requests_console{
-	announcementConsole = 0;
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bCB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32135,50 +32078,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
-"bDV" = (
-/obj/machinery/door/window/eastleft{
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bDW" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bDX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bDY" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bDZ" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -32794,16 +32704,16 @@
 /area/hallway/primary/central)
 "bFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bFm" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgery Observation"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/camera{
+	c_tag = "Surgery Observation"
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bFn" = (
 /obj/structure/sink{
 	dir = 8;
@@ -33303,38 +33213,36 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGu" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
-"bGv" = (
-/obj/structure/chair,
-/obj/machinery/camera{
-	c_tag = "Surgery Observation"
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
+"bGv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGx" = (
-/obj/structure/chair,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGy" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGz" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -33891,32 +33799,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHI" = (
-/obj/structure/chair,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/chem/bluespace,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHJ" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/chem/radioactive,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHK" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHL" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHM" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
@@ -34582,39 +34485,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJh" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bJi" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bJj" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -35043,6 +34935,7 @@
 /obj/item/gun/syringe,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bKh" = (
@@ -36738,9 +36631,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bOi" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -52507,6 +52397,12 @@
 /obj/item/wirerod,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cBe" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "cBi" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58457,6 +58353,14 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ffi" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "fgp" = (
 /obj/item/seeds/banana,
 /turf/open/floor/plating,
@@ -58481,6 +58385,9 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"fkU" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
 "flz" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -59112,6 +59019,19 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"gKG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
 "gPK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60177,6 +60097,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"iNv" = (
+/obj/effect/spawner/structure/window,
+/turf/open/space/basic,
+/area/medical/sleeper)
 "iRs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63785,6 +63709,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"qsx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "qsC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -64522,6 +64452,11 @@
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/secondary/entry)
+"sbQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "sdf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -65942,6 +65877,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vqa" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "vrK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
@@ -66243,6 +66185,13 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"vZM" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "wae" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67335,6 +67284,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"xUD" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "xUX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -101087,12 +101040,12 @@ blX
 blX
 bzG
 bBi
-bvo
+gKG
 bDU
-bCD
-bCD
-bCD
-bCD
+bDU
+bDU
+bDU
+bDU
 bCD
 bCD
 bML
@@ -101343,10 +101296,10 @@ bvl
 bwI
 blX
 bzH
-bBj
-bvo
-bDV
-bCD
+bBi
+aBs
+bDU
+xUD
 bGu
 bHI
 bJe
@@ -101858,8 +101811,8 @@ bwJ
 byl
 bzJ
 bBl
-bCB
-bCB
+qsx
+sbQ
 bFm
 bGw
 bHK
@@ -102112,15 +102065,15 @@ bnD
 btJ
 bnD
 bwK
-bym
+blX
 bzK
 bBm
-byq
-bDX
-bCD
+blX
+bDU
+cBe
 bGx
 bHL
-bCE
+bDU
 bKe
 bLm
 bMP
@@ -102367,17 +102320,17 @@ bpc
 bqM
 bpc
 btK
-bvn
+bnD
 bwL
 blX
 bzL
-bBn
-bCC
-bDY
-bCD
+bys
+bvo
+bDU
+vZM
 bGy
-bGy
-bCE
+vqa
+bDU
 bKf
 bLn
 bMQ
@@ -102630,15 +102583,15 @@ blX
 bzM
 bBo
 bCD
-bCD
-bCD
-bCD
-bCD
-bCD
+fkU
+bDU
+bDU
+bDU
+bDU
 bCD
 bLo
 bMR
-bCD
+iNv
 bCD
 bLo
 nOw
@@ -102885,7 +102838,7 @@ bvo
 bwM
 byn
 bzN
-bBn
+bys
 bCE
 bDZ
 bFn
@@ -103142,7 +103095,7 @@ bvp
 bsn
 byo
 bzO
-bBn
+bys
 bCF
 bEa
 bEa
@@ -104170,7 +104123,7 @@ bnJ
 bwO
 bnJ
 oaV
-bBs
+bnJ
 bCE
 bEe
 bFq
@@ -104427,7 +104380,7 @@ bvt
 bvo
 bnJ
 oaV
-bBs
+bnJ
 bCD
 bEf
 bFr
@@ -104684,7 +104637,7 @@ bmf
 bvo
 sKz
 oaV
-bBs
+bnJ
 bCE
 bEf
 bFs
@@ -104939,8 +104892,8 @@ bst
 btP
 bnL
 bwP
-byq
-bzR
+bnJ
+oaV
 bBt
 bCD
 bEf
@@ -106232,7 +106185,7 @@ bwX
 ozx
 bBv
 bBv
-bnJ
+ffi
 bnJ
 bBs
 bvo
@@ -106489,7 +106442,7 @@ bEh
 bzX
 bGF
 bBv
-bJi
+bCC
 bnJ
 bLx
 bvo


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: EagleEyes
add: Added new area to chemistry to hold the molecular reassembler (and some uranium to operate it) and the bluespace recombobulator (and a bulespace crystal to operate it). Also a window near the  door of surgery was now placed to allow people to look in.
del: Surgery observation was the only thing intended to be completely removed since it offers little service anyway.
/:cl:

[why]: # this will allow chemistry to finally be able to actually create every chemical in lcass instead of only science
