### PR TITLE
ChemistryChanges

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -356,7 +356,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "abj" = (
-/obj/machinery/ore_silo,
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
@@ -9385,7 +9384,6 @@
 /area/lawoffice)
 "axe" = (
 /obj/structure/table/wood,
-/obj/item/staplegun,
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
 /turf/open/floor/wood,
@@ -11245,13 +11243,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aBR" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "aBT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -12505,8 +12496,8 @@
 /area/hallway/secondary/entry)
 "aFp" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Infirmary Maintenance";
-	req_access_txt = "12"
+	name = "Security Maintenance";
+	req_access_txt = "1"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -24013,7 +24004,6 @@
 "bkf" = (
 /obj/item/folder/blue,
 /obj/structure/table/wood,
-/obj/item/staplegun,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bkh" = (
@@ -27231,8 +27221,9 @@
 /area/medical/medbay/central)
 "bsq" = (
 /obj/structure/table/reinforced,
-/obj/item/staplegun,
-/obj/item/reagent_containers/food/drinks/britcup,
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup."
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsr" = (
@@ -28609,17 +28600,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bvn" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/folder/white,
-/obj/item/radio/headset/headset_med,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "bvo" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -29226,14 +29206,13 @@
 "bwJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"bwK" = (
 /obj/structure/table,
 /obj/machinery/chem/centrifuge{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bwK" = (
-/obj/structure/chair,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwL" = (
@@ -29268,8 +29247,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -29826,19 +29806,8 @@
 /area/medical/chemistry)
 "byl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/medical/chemistry)
-"bym" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Chemistry Desk";
-	req_access_txt = "33"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/chemistry)
 "byn" = (
 /obj/structure/bed/roller,
@@ -30415,27 +30384,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/chemistry)
 "bzH" = (
 /obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/folder/white,
+/obj/item/radio/headset/headset_med,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 4
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -30447,7 +30416,7 @@
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -30457,7 +30426,7 @@
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30465,10 +30434,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bzL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30527,13 +30501,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bzR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzS" = (
@@ -30874,7 +30841,6 @@
 	pixel_x = -24
 	},
 /obj/item/folder/yellow,
-/obj/item/staplegun,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bAE" = (
@@ -31099,28 +31065,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
-"bBj" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/medical/chemistry)
 "bBk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31128,29 +31088,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bBn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bBo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	broadcasting = 0;
 	freerange = 0;
@@ -31166,25 +31116,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -31199,9 +31140,6 @@
 /area/medical/medbay/central)
 "bBt" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBv" = (
@@ -31600,16 +31538,12 @@
 	},
 /area/hallway/primary/central)
 "bCA" = (
-/obj/machinery/requests_console{
-	announcementConsole = 0;
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/medical/chemistry)
 "bCB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32145,50 +32079,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
-"bDV" = (
-/obj/machinery/door/window/eastleft{
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bDW" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bDX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bDY" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bDZ" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -32804,16 +32705,16 @@
 /area/hallway/primary/central)
 "bFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bFm" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgery Observation"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/camera{
+	c_tag = "Surgery Observation"
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bFn" = (
 /obj/structure/sink{
 	dir = 8;
@@ -33313,38 +33214,36 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGu" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
-"bGv" = (
-/obj/structure/chair,
-/obj/machinery/camera{
-	c_tag = "Surgery Observation"
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
+"bGv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGx" = (
-/obj/structure/chair,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGy" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/stack/ore/bluespace_crystal/refined,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bGz" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -33901,32 +33800,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHI" = (
-/obj/structure/chair,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/chem/bluespace,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHJ" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/obj/machinery/chem/radioactive,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHK" = (
-/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHL" = (
-/obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "bHM" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
@@ -33956,6 +33850,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/wrench/medical,
+/obj/item/crowbar,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bHQ" = (
@@ -34188,12 +34083,12 @@
 /area/crew_quarters/heads/hor)
 "bIp" = (
 /obj/machinery/rnd/experimentor,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/science/explab)
 "bIq" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/science/explab)
 "bIr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -34592,39 +34487,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "bJh" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bJi" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bJj" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -34878,9 +34762,6 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/science/explab)
 "bJL" = (
@@ -35056,6 +34937,7 @@
 /obj/item/gun/syringe,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bKh" = (
@@ -36751,9 +36633,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bOi" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -36781,6 +36660,7 @@
 /obj/structure/table,
 /obj/item/hand_labeler,
 /obj/item/gun/syringe,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bOm" = (
@@ -37212,6 +37092,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPl" = (
@@ -37219,6 +37102,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "bPn" = (
@@ -45760,7 +45646,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cko" = (
@@ -49022,7 +48907,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csH" = (
@@ -49157,6 +49041,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csV" = (
@@ -49164,10 +49049,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csW" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -49627,9 +49513,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cuc" = (
@@ -51821,7 +51704,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "czx" = (
@@ -53044,6 +52929,7 @@
 /area/engine/supermatter)
 "cCD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "cCE" = (
@@ -53468,9 +53354,6 @@
 /area/engine/engineering)
 "cDD" = (
 /obj/structure/sign/warning/electricshock,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cDE" = (
@@ -53490,26 +53373,30 @@
 /turf/open/space,
 /area/space/nearstation)
 "cDK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDL" = (
-/obj/effect/turf_decal/loading_area/red{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Cooling Loop"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cDM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53517,7 +53404,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cDN" = (
 /turf/open/floor/engine,
@@ -53624,28 +53511,22 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Emergency Cooling Loop Bypass"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -53755,16 +53636,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cEv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEw" = (
@@ -53775,26 +53649,31 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cEx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cEA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -53904,28 +53783,33 @@
 /area/engine/engineering)
 "cEL" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cooling Loop to Gas"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEM" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_on_map";
-	name = "Cold to Engine Loop";
-	on = 1
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
@@ -54030,12 +53914,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cFb" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cFc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
@@ -54438,9 +54326,6 @@
 /obj/item/crowbar/large,
 /obj/structure/rack,
 /obj/item/flashlight,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cGy" = (
@@ -57383,12 +57268,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
-"dcn" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault,
-/area/engine/engineering)
 "dda" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXtwentythree,
@@ -57401,14 +57280,6 @@
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"der" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "deA" = (
@@ -57451,6 +57322,11 @@
 "dmH" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -57697,10 +57573,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dJC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dKp" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -57849,13 +57721,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"dYe" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "dYn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57928,10 +57793,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ehW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "ejm" = (
@@ -58064,13 +57927,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ewB" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "eyc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -58123,17 +57983,19 @@
 	},
 /area/hallway/secondary/entry)
 "eBA" = (
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 2;
+	network = list("engine");
+	pixel_x = 23
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "eDi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -58202,13 +58064,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"eJQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "eKo" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -58318,6 +58173,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eUC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -58563,20 +58421,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"fsx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "fuh" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"fxk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "fxr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58617,14 +58472,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"fAm" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fCl" = (
 /obj/machinery/light/small{
 	brightness = 5;
@@ -58678,14 +58525,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"fHU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "fHV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58760,10 +58599,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fRd" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "fTz" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -58793,6 +58628,15 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"fVB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "fXx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58957,13 +58801,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
-"gmN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/science/circuit)
 "gog" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59023,13 +58860,6 @@
 /area/security/checkpoint/auxiliary{
 	name = "Security Checkpoint - Arrivals"
 	})
-"gtG" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "gxm" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
@@ -59136,9 +58966,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"gIm" = (
-/turf/open/space/basic,
-/area/construction/mining/aux_base)
 "gIn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59163,16 +58990,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"gJM" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/science/explab)
-"gLs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gPK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59232,13 +59049,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"gVK" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Coolant to Loop"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gWg" = (
 /turf/open/floor/plasteel/red/side,
 /area/hallway/secondary/entry)
@@ -59442,28 +59252,6 @@
 	dir = 4
 	},
 /area/security/prison)
-"hpW" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("engine");
-	pixel_x = 11
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "hqn" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -59483,13 +59271,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
-"hsS" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	initialize_directions = 11
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "htW" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light{
@@ -59763,10 +59544,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hRR" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "hTJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -59781,12 +59558,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hUc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "hUj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59938,13 +59709,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"igF" = (
-/obj/structure/sign/warning/fire,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "iix" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -59983,17 +59747,25 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ile" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "imS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"imY" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "imZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -60041,18 +59813,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"iqf" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iqS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60097,14 +59857,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "ivM" = (
 /obj/structure/table/glass,
@@ -60274,15 +60030,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iKH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "iKM" = (
 /obj/machinery/door/firedoor,
@@ -60385,13 +60145,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "iXV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "iZb" = (
 /obj/machinery/power/tesla_coil,
@@ -60459,13 +60223,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jgL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "jhA" = (
 /obj/machinery/door/firedoor,
@@ -60518,7 +60277,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jjM" = (
@@ -60593,6 +60351,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jsa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -60601,10 +60362,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60772,17 +60529,6 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
-"jEA" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"jFq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "jGE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -60949,6 +60695,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kgH" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "kgV" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -61018,6 +60768,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"knV" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "koh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61107,7 +60865,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kwC" = (
@@ -61145,13 +60902,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kyW" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "kzN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -61179,22 +60929,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
-"kBA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"kBI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kCt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61405,14 +61139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"laI" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
-"lcC" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "lcD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -61530,15 +61256,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
-"lmR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "lnJ" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -61552,10 +61269,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lqj" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "lrb" = (
 /obj/machinery/light{
 	dir = 8
@@ -61571,6 +61284,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lrG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/closed/wall,
+/area/medical/chemistry)
 "lsm" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/station_engineer,
@@ -61617,14 +61343,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"lvO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "lxd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61764,11 +61482,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"lJP" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "lKd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61849,12 +61562,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lNs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "lNS" = (
 /obj/item/radio/intercom{
 	freerange = 0;
@@ -62158,15 +61865,14 @@
 "mqf" = (
 /turf/open/space/basic,
 /area/engine/port_engineering)
-"muO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"mqq" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastleft{
+	name = "Medical Delivery";
+	req_access_txt = "5"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mvb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -62350,16 +62056,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"mOl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Heat Exchanger to Loop"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mOM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -62454,12 +62150,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mWr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "mXB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -62591,6 +62281,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nin" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "njB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -62634,15 +62330,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"nkH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -62680,12 +62367,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "nsj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62697,12 +62379,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"nsO" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nti" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -62906,32 +62582,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
-"nPe" = (
-/obj/structure/closet/crate/engineering{
-	name = "T.E.G. crate"
-	},
-/obj/machinery/power/generator{
-	anchored = 0;
-	dir = 4;
-	panel_open = 1
-	},
-/obj/machinery/atmospherics/components/binary/circulator{
-	anchored = 0;
-	flipped = 1;
-	panel_open = 1
-	},
-/obj/machinery/atmospherics/components/binary/circulator/cold{
-	anchored = 0;
-	dir = 1;
-	flipped = 1;
-	panel_open = 1
-	},
-/obj/item/paper{
-	info = "<h>Order #7751</h><p>This pack contains all components of a Thermoelectric Generator. Unpack crack and install at pre-designated area in the engine room. Use multitool to connect circulators.</p> ";
-	name = "T.E.G. Order"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "nSR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63016,13 +62666,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
-"oaB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "oaP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63117,10 +62760,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -63153,6 +62793,13 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
+"orV" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "orX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -63189,12 +62836,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
-"owW" = (
-/obj/machinery/atmospherics/components/unary/heat_exchanger{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "ozm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -63238,6 +62879,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"oBl" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "oDp" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -63542,12 +63187,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"pir" = (
-/obj/machinery/atmospherics/components/unary/heat_exchanger{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "piK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63588,21 +63227,16 @@
 	},
 /area/engine/atmos)
 "pmn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_on_map";
-	name = "Hot to Generator";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pmV" = (
@@ -64090,16 +63724,6 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
-"qpU" = (
-/turf/open/floor/plating,
-/area/space)
-"qrC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "qrY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
@@ -64163,10 +63787,6 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
-"qyz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/construction/mining/aux_base)
 "qyM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -64224,11 +63844,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
-"qFp" = (
-/obj/structure/table/wood,
-/obj/item/staplegun,
-/turf/open/floor/wood,
-/area/library)
 "qGe" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -64562,13 +64177,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rrV" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/heat_exchanger{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rsd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -64587,13 +64195,16 @@
 /turf/open/space,
 /area/space/nearstation)
 "rvj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rvk" = (
@@ -64610,6 +64221,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rzG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "rBH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -64670,6 +64286,7 @@
 /turf/closed/wall,
 /area/science/circuit)
 "rIp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -64678,25 +64295,7 @@
 	dir = 4;
 	network = list("ss13","engine")
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
 /turf/open/floor/engine,
-/area/engine/engineering)
-"rIv" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/crew_quarters/bar/maint)
-"rKh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rMi" = (
 /obj/structure/table/wood,
@@ -64744,12 +64343,6 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
-"rPl" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "rQg" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
@@ -64905,22 +64498,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"sfF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"sgE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	icon_state = "pump_map";
-	name = "Hot to Heat Exchanger";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "shd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -64935,12 +64512,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"sid" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "siG" = (
 /obj/machinery/conveyor{
 	id = "arrivalright"
@@ -65116,10 +64687,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "sFQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -65169,13 +64740,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
-"sJC" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sKc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -65292,15 +64856,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"sSQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "sTa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -65353,6 +64908,13 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"sTR" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/engine,
+/area/medical/chemistry)
 "sVJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -65427,14 +64989,18 @@
 	},
 /area/engine/port_engineering)
 "tcz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "tcT" = (
 /obj/structure/cable/yellow{
@@ -65740,15 +65306,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tOr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tOI" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas{
@@ -65765,9 +65322,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tQR" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "tQS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -65797,9 +65351,6 @@
 "tSY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -65835,11 +65386,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tWQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "tXn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65940,9 +65486,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uoH" = (
@@ -65952,8 +65495,8 @@
 /turf/open/floor/plasteel/red/side,
 /area/engine/atmos)
 "uqb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -66057,16 +65600,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uFF" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "uHI" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -66169,9 +65702,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "uOE" = (
@@ -66210,29 +65740,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
-"uQM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "uRH" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
-"uRW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "uRY" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
@@ -66616,12 +66127,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/port_engineering)
-"vOM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "vSu" = (
 /obj/structure/closet,
 /obj/machinery/airalarm{
@@ -66630,6 +66135,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"vSM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vSN" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_carp{
@@ -66655,12 +66166,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vUv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "vVb" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -66690,13 +66195,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vXF" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "vXL" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -67229,13 +66727,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"wNs" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wOt" = (
 /obj/structure/chair{
 	dir = 4
@@ -67382,12 +66873,6 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
-"xfc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "xfx" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
@@ -67484,16 +66969,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xph" = (
@@ -67778,10 +67257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"xQj" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/science/explab)
 "xQD" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -67878,7 +67353,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xYs" = (
@@ -70722,16 +70196,16 @@ aaa
 aaa
 aaa
 aaa
-jEA
-jEA
+aaa
+aaa
 aae
-aFi
-aFi
-jEA
-jEA
 aae
-aFi
-aFi
+aae
+aaa
+aaa
+aae
+aae
+aae
 aaa
 aaa
 aaa
@@ -70973,8 +70447,8 @@ aaa
 aaa
 aaa
 aaa
-bqy
-bqy
+aaa
+aaa
 aad
 aad
 aad
@@ -70988,13 +70462,13 @@ aad
 aad
 aad
 aad
-aFi
-aFi
-bqy
-bqy
 aad
-aFi
-aFi
+aad
+aaa
+aaa
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -71230,8 +70704,10 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aaj
 aaj
 aaj
@@ -71251,8 +70727,6 @@ aaj
 aaj
 aad
 aae
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -71488,28 +70962,28 @@ aaa
 aaa
 aaa
 aaa
-lcC
-bqy
-aFi
+aaa
+aaa
+aaj
 aad
 aaa
-aFi
+aad
 aaa
 aaa
-bqy
-bqy
-aFi
-aFi
 aaa
-bqy
 aaa
 aad
-bqy
+aad
+aaa
+aaa
+aaa
+aad
+aaa
+aad
+aad
 aaj
 aad
 aad
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -71744,12 +71218,12 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aad
-avz
-avz
 aoz
 aoz
 aoz
@@ -71759,14 +71233,14 @@ aoz
 aoz
 aoz
 aoz
-qyz
-qyz
+aoz
+aoz
+aad
+aad
 aad
 aaj
 aad
 aae
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -72001,12 +71475,14 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aad
-avz
-tQR
+aoz
+apw
 apw
 apw
 apw
@@ -72016,14 +71492,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aae
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -72258,12 +71732,14 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
 aad
-aFi
-avz
-qpU
+aaj
+aad
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -72273,14 +71749,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aad
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -72514,13 +71988,15 @@ aaa
 aaa
 aaa
 aaa
-jEA
-bqy
+aaa
+aaa
+aae
+aad
 aaj
 aad
-aFi
-avz
-qpU
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -72530,14 +72006,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aad
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -72770,14 +72244,16 @@ aaa
 aaa
 aaa
 aaa
-jEA
-jEA
+aaa
+aaa
+aae
+aae
 aad
 aaj
 aad
-aFi
-avz
-qpU
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -72787,14 +72263,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aae
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -73027,14 +72501,16 @@ aaa
 aaa
 aaa
 aaa
-jEA
-jEA
+aaa
+aaa
+aae
+aae
 aad
 aaj
 aad
-aFi
-avz
-qpU
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -73044,14 +72520,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aae
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -73284,14 +72758,16 @@ aaa
 aaa
 aaa
 aaa
-jEA
-jEA
+aaa
+aaa
+aae
+aae
 aad
 aaj
 aad
-aFi
-avz
-qpU
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -73301,14 +72777,12 @@ apw
 apw
 apw
 aoz
-qyz
-qyz
+aad
+aad
 aad
 aaj
 aad
 aad
-aFi
-aFi
 aaa
 aaa
 aaa
@@ -73542,13 +73016,15 @@ aaa
 aaa
 aaa
 aaa
-jEA
-bqy
+aaa
+aaa
+aae
+aad
 aaj
 aad
 aad
-avz
-tQR
+aoz
+apw
 apw
 apw
 apw
@@ -73558,13 +73034,11 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
-bqy
-bqy
-aFi
-aFi
-aFi
+aaa
+aaa
+aad
+aaj
+aad
 aaa
 aaa
 aaa
@@ -73799,13 +73273,15 @@ aaa
 aaa
 aaa
 aaa
-jEA
-bqy
+aaa
+aaa
+aae
+aad
 aaj
 aad
-aFi
-avz
-qpU
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -73815,13 +73291,11 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
 aaa
 aaa
-aFi
-aFi
-aFi
+aad
+aaj
+aad
 aaa
 aaa
 aaa
@@ -74057,12 +73531,14 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
 aad
-aFi
-avz
-qpU
+aaj
+aad
+aaa
+aoz
+apw
 apw
 apw
 apw
@@ -74072,14 +73548,12 @@ apw
 apw
 apw
 aoz
-gIm
-gIm
 aaa
 aaa
-aFi
-aFi
-aFi
-aFi
+aad
+aaj
+aad
+aad
 aaa
 aaa
 aaa
@@ -74314,12 +73788,12 @@ aaa
 aaa
 aaa
 aaa
-bqy
-lcC
+aaa
+aaa
+aad
+aaj
 aad
 aad
-avz
-avz
 aoz
 aoz
 aoz
@@ -74329,14 +73803,14 @@ xGA
 ipS
 aoz
 aoz
-gIm
-gIm
-aFi
-aFi
-aFi
-aFi
-aFi
-aFi
+aoz
+aoz
+aad
+aad
+aad
+aaj
+aad
+aaf
 aaa
 aaa
 aaa
@@ -74572,9 +74046,9 @@ aaa
 aaa
 aaa
 aaa
-lcC
+aaa
 aad
-aFi
+aaj
 aad
 aaa
 aaa
@@ -74590,10 +74064,10 @@ aaa
 aaa
 aaa
 aaa
-aFi
-aFi
-aFi
-aFi
+aad
+aaj
+aad
+aaf
 aaa
 aaa
 aaa
@@ -74829,9 +74303,9 @@ aaa
 aaa
 aaa
 aaa
-lcC
 aaa
-aFi
+aaa
+aaj
 aad
 aaa
 aaa
@@ -74847,10 +74321,10 @@ aaa
 aaa
 aaa
 aaa
-aFi
-aFi
-aFi
-aFi
+aad
+aaj
+aad
+aad
 aaa
 aaa
 aaa
@@ -75086,9 +74560,9 @@ aae
 aae
 aae
 aaa
-lcC
 aaa
-aFi
+aaa
+aaj
 aaa
 aaa
 aaa
@@ -75104,7 +74578,7 @@ aaa
 aaa
 aaa
 aaa
-aFi
+aad
 aaa
 aaa
 aaa
@@ -75343,9 +74817,9 @@ uJb
 aad
 aad
 aad
-lcC
-bqy
-aFi
+aaa
+aaa
+aaj
 aad
 aaa
 aaa
@@ -75361,8 +74835,8 @@ aaa
 aaa
 aaa
 aaa
-aFi
-aaa
+aad
+bqy
 aaa
 aaa
 aaa
@@ -75601,8 +75075,8 @@ aaj
 aaj
 aaj
 aaj
-aad
-aad
+aaj
+aaj
 aad
 aad
 aaa
@@ -75617,11 +75091,11 @@ aoz
 aaa
 aaa
 aaa
-aFi
-aFi
-aFi
-aFi
-aFi
+aad
+aad
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -75857,8 +75331,8 @@ aad
 aad
 aad
 aaa
-bqy
-bqy
+aaa
+aaa
 aad
 aad
 aad
@@ -75872,9 +75346,9 @@ mQC
 eMb
 aCH
 aaa
-aFi
-aFi
-aFi
+aad
+aad
+aad
 aaa
 aaa
 sMx
@@ -76128,9 +75602,9 @@ ikp
 beK
 aBy
 aCH
-aFi
-aFi
-aFi
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -76386,11 +75860,11 @@ iLq
 bla
 aCH
 aaa
-aFi
-aFi
-aFi
-aFi
-aFi
+aad
+aad
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -77397,7 +76871,7 @@ twI
 aCK
 aWO
 ayG
-laI
+aRf
 qeJ
 aRf
 aRf
@@ -87901,7 +87375,7 @@ aad
 aaa
 aaa
 akn
-rIv
+alf
 alY
 alf
 anT
@@ -93642,7 +93116,7 @@ cnN
 cdI
 cqe
 clH
-lqj
+csD
 csD
 cuJ
 cvy
@@ -93900,7 +93374,7 @@ cdI
 cqe
 clH
 eoL
-csD
+ctJ
 cuK
 ctJ
 ctJ
@@ -94160,7 +93634,7 @@ eoL
 ctJ
 ctJ
 ctJ
-nPe
+ctJ
 cvz
 clH
 cyX
@@ -94686,7 +94160,7 @@ cCx
 cDh
 cDI
 xDw
-sJC
+cEt
 ehW
 wcs
 lpx
@@ -94938,13 +94412,13 @@ cza
 czN
 cAy
 xxi
+clH
+clH
+clH
+fsx
 iLK
-cxz
-cxz
+cEu
 cEK
-cxz
-der
-mWr
 cEu
 cEu
 pcA
@@ -95195,8 +94669,8 @@ czb
 czO
 cAz
 mJX
-fxk
-tOr
+mJX
+mJX
 rIp
 cDK
 omM
@@ -95453,13 +94927,13 @@ czP
 cAA
 cBs
 cBs
-sgE
-uFF
+cBs
+cBs
 cDL
-wNs
-dcn
+cBs
+cBs
 cEL
-mOl
+cBs
 tqz
 yhF
 czc
@@ -95468,7 +94942,7 @@ sXO
 cEw
 sXO
 cGt
-sXO
+clH
 clH
 cGe
 aad
@@ -95710,7 +95184,7 @@ czQ
 rSk
 jrq
 cBW
-iqf
+cBW
 pmn
 jsa
 cEd
@@ -95725,7 +95199,7 @@ rdB
 qbk
 sXO
 sXO
-sXO
+clH
 clH
 cGe
 aai
@@ -95930,7 +95404,7 @@ bJT
 bKT
 oAG
 bNP
-bPi
+fVB
 bQO
 bRZ
 bTj
@@ -95970,9 +95444,9 @@ vWT
 cCz
 jgL
 cDM
-cDM
+imY
 cEy
-muO
+gXP
 uqb
 mee
 wPy
@@ -95981,8 +95455,8 @@ mYc
 riN
 sPv
 cGg
-ctJ
 cGu
+clH
 clH
 czf
 aai
@@ -96225,11 +95699,11 @@ cAC
 mmp
 xBe
 cCz
-gXP
+clH
 eBA
 nqU
-eBA
-gXP
+nqU
+clH
 obw
 vJD
 qtI
@@ -96239,7 +95713,7 @@ qSW
 eyl
 eyl
 ctJ
-ctJ
+clH
 clH
 cGe
 abf
@@ -96483,20 +95957,20 @@ cBu
 keK
 clH
 cDi
-hpW
+jxj
 jxj
 dMV
-rPl
+clH
 jjf
 kvn
-fHU
-fRd
+qtI
+clH
 xYc
-gLs
 sXO
 sXO
 sXO
 sXO
+clH
 clH
 cGe
 abf
@@ -96741,19 +96215,19 @@ qrY
 cCC
 cDj
 uOy
-ile
-sSQ
+uOy
+uOy
 cDD
 kpZ
 cFj
 cFs
 xxi
 pyl
-sKc
+sXO
 sXO
 lYW
-rKh
-gLs
+sXO
+clH
 clH
 cGe
 abf
@@ -96997,7 +96471,7 @@ cBw
 cBX
 cCD
 cDk
-lNs
+cDN
 aab
 cDN
 cCB
@@ -97006,11 +96480,11 @@ cFk
 cFk
 fmU
 dIF
-sKc
+sXO
 dIF
 cGh
-sfF
-tWQ
+sXO
+clH
 clH
 cGe
 aai
@@ -97255,19 +96729,19 @@ cBY
 cCE
 cDl
 tSY
-qrC
-lmR
-igF
+tSY
+tSY
+wYv
 sIg
 cFl
 cFu
 xxi
 sXO
-sKc
+sXO
 sXO
 dYS
 sXO
-gVK
+clH
 clH
 cGe
 abf
@@ -97514,17 +96988,17 @@ lQA
 rZX
 rZX
 hkb
-ewB
+clH
 jjf
 kvn
-fHU
-fRd
+qtI
+clH
 xYc
-hsS
-dJC
-dJC
-aBR
-xJZ
+sXO
+sXO
+sXO
+sXO
+clH
 clH
 cGe
 aai
@@ -97767,11 +97241,11 @@ nHy
 jwc
 lum
 lLq
-gXP
+clH
 ivA
-uQM
-uQM
-gXP
+ivA
+ivA
+clH
 nFo
 lvb
 qtI
@@ -97780,8 +97254,8 @@ ctJ
 qGt
 rXs
 qGt
-owW
-owW
+ctJ
+clH
 clH
 cGe
 aai
@@ -98024,11 +97498,11 @@ cAI
 jwc
 xIc
 lLq
-nkH
+gXP
 tcz
 iKH
 iXV
-kBI
+jgL
 sFQ
 vpg
 pRd
@@ -98037,8 +97511,8 @@ mYc
 rNB
 rNB
 hoK
-pir
-rrV
+cGu
+clH
 clH
 czf
 aai
@@ -98293,9 +97767,9 @@ kWH
 dpb
 dpb
 nmD
-nsO
-lJP
-xJZ
+sXO
+sXO
+clH
 clH
 cGe
 aai
@@ -98550,9 +98024,9 @@ cok
 mBf
 sXO
 knd
-sKc
+sXO
 cGw
-fAm
+clH
 clH
 cGe
 abp
@@ -98807,8 +98281,8 @@ nsj
 clH
 clH
 clH
-xfc
-xfc
+clH
+clH
 clH
 clH
 cGe
@@ -99061,11 +98535,11 @@ kYE
 sBj
 xjM
 mXX
-mXX
 peq
+aak
 aad
-dYe
-kyW
+aai
+aaa
 aag
 clH
 cGe
@@ -99320,9 +98794,9 @@ clH
 aak
 aak
 aak
-gtG
-lvO
-eJQ
+aad
+aaa
+aaa
 ahy
 aaa
 aaa
@@ -99577,9 +99051,9 @@ clH
 aaa
 aaa
 aai
-oaB
-lvO
-vXF
+aad
+aaa
+aaa
 ahy
 aaa
 aaa
@@ -99834,9 +99308,9 @@ clH
 aai
 aai
 aai
-qAK
-lvO
-eJQ
+aad
+aaa
+aaa
 ahy
 aaa
 aaa
@@ -100091,9 +99565,9 @@ aaa
 aaa
 aaa
 aaa
-cEt
-lvO
-vXF
+aad
+aaa
+aaa
 aad
 aaa
 aaa
@@ -100349,8 +99823,8 @@ aaa
 aaa
 aaa
 aad
-kBA
-eJQ
+aaa
+aaa
 aad
 aaa
 aaa
@@ -101574,12 +101048,12 @@ blX
 blX
 bzG
 bBi
-bvo
+lrG
 bDU
-bCD
-bCD
-bCD
-bCD
+bDU
+bDU
+bDU
+bDU
 bCD
 bCD
 bML
@@ -101830,10 +101304,10 @@ bvl
 bwI
 blX
 bzH
-bBj
-bvo
-bDV
-bCD
+bBi
+mqq
+bDU
+oBl
 bGu
 bHI
 bJe
@@ -102345,8 +101819,8 @@ bwJ
 byl
 bzJ
 bBl
-bCB
-bCB
+vSM
+rzG
 bFm
 bGw
 bHK
@@ -102599,15 +102073,15 @@ bnD
 btJ
 bnD
 bwK
-bym
+blX
 bzK
 bBm
-byq
-bDX
-bCD
+blX
+bDU
+nin
 bGx
 bHL
-bCE
+bDU
 bKe
 bLm
 bMP
@@ -102854,17 +102328,17 @@ bpc
 bqM
 bpc
 btK
-bvn
+bnD
 bwL
 blX
 bzL
-bBn
-bCC
-bDY
-bCD
+bys
+bvo
+bDU
+orV
 bGy
-bGy
-bCE
+sTR
+bDU
 bKf
 bLn
 bMQ
@@ -103116,16 +102590,16 @@ blX
 blX
 bzM
 bBo
-bCD
-bCD
-bCD
-bCD
-bCD
-bCD
+bvo
+blX
+bDU
+bDU
+bDU
+bDU
 bCD
 bLo
 bMR
-bCD
+kgH
 bCD
 bLo
 nOw
@@ -103372,7 +102846,7 @@ bvo
 bwM
 byn
 bzN
-bBn
+bys
 bCE
 bDZ
 bFn
@@ -103629,7 +103103,7 @@ bvp
 bsn
 byo
 bzO
-bBn
+bys
 bCF
 bEa
 bEa
@@ -104657,7 +104131,7 @@ bnJ
 bwO
 bnJ
 oaV
-bBs
+bnJ
 bCE
 bEe
 bFq
@@ -104914,7 +104388,7 @@ bvt
 bvo
 bnJ
 oaV
-bBs
+bnJ
 bCD
 bEf
 bFr
@@ -105156,7 +104630,7 @@ aOK
 aOK
 bcB
 aOK
-hRR
+aOK
 aNo
 bfW
 bfW
@@ -105171,7 +104645,7 @@ bmf
 bvo
 sKz
 oaV
-bBs
+bnJ
 bCE
 bEf
 bFs
@@ -105426,8 +104900,8 @@ bst
 btP
 bnL
 bwP
-byq
-bzR
+bnJ
+oaV
 bBt
 bCD
 bEf
@@ -106719,7 +106193,7 @@ bwX
 ozx
 bBv
 bBv
-bnJ
+knV
 bnJ
 bBs
 bvo
@@ -106976,7 +106450,7 @@ bEh
 bzX
 bGF
 bBv
-bJi
+bCC
 bnJ
 bLx
 bvo
@@ -113120,7 +112594,7 @@ aUO
 aWB
 aQP
 aZJ
-qFp
+aPa
 aTu
 aTu
 bbf
@@ -116997,9 +116471,9 @@ bBO
 bDe
 bEK
 bxD
-gJM
-sid
-uRW
+bHi
+bHi
+bHi
 bxD
 bLV
 bNq
@@ -117017,7 +116491,7 @@ cah
 cah
 cdB
 cez
-gmN
+cez
 cgO
 chM
 cah
@@ -117254,9 +116728,9 @@ bBP
 bDf
 bEL
 bFS
-xQj
+bHi
 bIp
-jFq
+bHi
 bxD
 bLW
 bNr
@@ -117511,7 +116985,7 @@ bBQ
 bDg
 bEM
 bFS
-xQj
+bHi
 bIq
 bJK
 bxD
@@ -117768,9 +117242,9 @@ bBR
 bDf
 bEN
 bFS
-hUc
-vOM
-vUv
+bHi
+bHi
+bHi
 bxD
 bLY
 brs


### PR DESCRIPTION

:cl: EagleEyes
add: Added new area to chemistry to hold the molecular reassembler (and some uranium to operate it) and the bluespace recombobulator (and a bulespace crystal to operate it). Also a window near the door of surgery was now placed to allow people to look in.
del: Surgery observation was the only thing intended to be completely removed since it offers little service anyway.
/:cl:

[why]: # this will allow chemistry to finally be able to actually create every chemical in lcass instead of only science. TRY 2 git shit
