### PR TITLE
Fix vote spamming

### DIFF
--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -186,15 +186,13 @@ datum/controller/subsystem/vote
 				if(min_restart_time < world.time)
 					initiate_vote("restart",usr.key)
 				else
-					to_chat(world, "<span style='boldannounce'>Restart can only initiate after [DisplayTimeText(min_restart_time)].</span>")
-					message_admins("A restart vote cannot start until [DisplayTimeText(min_restart_time)] into the round.")
+					to_chat(usr, "<span style='boldannounce'>Restart can only initiate after [DisplayTimeText(min_restart_time)].</span>")
 		if("shuttlecall")
 			if(CONFIG_GET(flag/allow_vote_shuttlecall) || usr.client.holder)
 				if(min_shuttle_time < world.time)
 					initiate_vote("shuttlecall",usr.key)
 				else
-					to_chat(world, "<span style='boldannounce'>Shuttle call can only initiate after [DisplayTimeText(min_shuttle_time)].</span>")
-					message_admins("A shuttle call vote cannot start until [DisplayTimeText(min_shuttle_time)] into the round.")
+					to_chat(usr, "<span style='boldannounce'>Shuttle call can only initiate after [DisplayTimeText(min_shuttle_time)].</span>")
 		if("gamemode")
 			if(CONFIG_GET(flag/allow_vote_mode) || usr.client.holder)
 				initiate_vote("gamemode",usr.key)


### PR DESCRIPTION

:cl: 
fix: You can no longer spam-start the chat with vote attempts.
/:cl:
