### PR TITLE
Null rods are now cosmetic differences only

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2805,6 +2805,7 @@
 #include "hippiestation\code\game\objects\items\forged_weapons.dm"
 #include "hippiestation\code\game\objects\items\garrote.dm"
 #include "hippiestation\code\game\objects\items\holotool.dm"
+#include "hippiestation\code\game\objects\items\holy_weapons.dm"
 #include "hippiestation\code\game\objects\items\manuals.dm"
 #include "hippiestation\code\game\objects\items\meat.dm"
 #include "hippiestation\code\game\objects\items\special_attacks.dm"

--- a/hippiestation/code/game/objects/items/holy_weapons.dm
+++ b/hippiestation/code/game/objects/items/holy_weapons.dm
@@ -1,0 +1,302 @@
+/obj/item/nullrod/reskin_holy_weapon(mob/M)
+	if(SSreligion.holy_weapon_type)
+		return
+	var/obj/item/nullrod/holy_weapon
+	var/list/holy_weapons_list = typesof(/obj/item/nullrod/hippie)
+	var/list/display_names = list()
+	for(var/V in holy_weapons_list)
+		var/obj/item/nullrod/rodtype = V
+		if (initial(rodtype.chaplain_spawnable))
+			display_names[initial(rodtype.name)] = rodtype
+
+	var/choice = input(M,"What theme would you like for your holy weapon?","Holy Weapon Theme") as null|anything in display_names
+	if(QDELETED(src) || !choice || M.stat || !in_range(M, src) || M.restrained() || !M.canmove || reskinned)
+		return
+
+	var/A = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
+	holy_weapon = new A
+
+	SSreligion.holy_weapon_type = holy_weapon.type
+
+	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")
+
+	if(holy_weapon)
+		holy_weapon.reskinned = TRUE
+		qdel(src)
+		M.put_in_active_hand(holy_weapon)
+
+/obj/item/nullrod/hippie/godhand
+	icon_state = "disintegrate"
+	item_state = "disintegrate"
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	name = "god hand"
+	desc = "This hand of yours glows with an awesome power!"
+	hitsound = 'sound/weapons/sear.ogg'
+	damtype = BURN /* All nullrods are blunt so burn/brute should be the same, kept this since it was thematic for the item */
+	attack_verb = list("punched", "cross countered", "pummeled")
+
+/obj/item/nullrod/hippie/staff
+	icon_state = "godstaff-red"
+	item_state = "godstaff-red"
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+	name = "red holy staff"
+	desc = "It has a mysterious, protective aura."
+	var/shield_icon = "shield-red"
+
+/obj/item/nullrod/hippie/staff/worn_overlays(isinhands)
+	. = list()
+	if(isinhands)
+		. += mutable_appearance('icons/effects/effects.dmi', shield_icon, MOB_LAYER + 0.01)
+
+/obj/item/nullrod/hippie/staff/blue
+	name = "blue holy staff"
+	icon_state = "godstaff-blue"
+	item_state = "godstaff-blue"
+	shield_icon = "shield-old"
+
+/obj/item/nullrod/hippie/claymore
+	icon_state = "claymore"
+	item_state = "claymore"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	name = "holy claymore"
+	desc = "A weapon fit for a crusade!"
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/nullrod/hippie/claymore/darkblade
+	icon_state = "cultblade"
+	item_state = "cultblade"
+	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
+	name = "dark blade"
+	desc = "Spread the glory of the dark gods!"
+	hitsound = 'sound/hallucinations/growl1.ogg'
+
+/obj/item/nullrod/hippie/claymore/chainsaw_sword
+	icon_state = "chainswordon"
+	item_state = "chainswordon"
+	name = "sacred chainsaw sword"
+	desc = "Suffer not a heretic to live."
+	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
+
+/obj/item/nullrod/hippie/claymore/glowing
+	icon_state = "swordon"
+	item_state = "swordon"
+	name = "force weapon"
+	desc = "The blade glows with the power of faith. Or possibly a battery."
+
+/obj/item/nullrod/hippie/claymore/katana
+	name = "hanzo steel"
+	desc = "Capable of cutting clean through a holy claymore."
+	icon_state = "katana"
+	item_state = "katana"
+
+/obj/item/nullrod/hippie/claymore/multiverse
+	name = "extradimensional blade"
+	desc = "Once the harbinger of an interdimensional war."
+	icon_state = "multiverse"
+	item_state = "multiverse"
+
+/obj/item/nullrod/hippie/claymore/saber
+	name = "light energy sword"
+	hitsound = 'sound/weapons/blade1.ogg'
+	icon_state = "swordblue"
+	item_state = "swordblue"
+	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
+
+/obj/item/nullrod/hippie/claymore/saber/red
+	name = "dark energy sword"
+	icon_state = "swordred"
+	item_state = "swordred"
+	desc = "Woefully ineffective when used on steep terrain."
+
+/obj/item/nullrod/hippie/claymore/saber/pirate
+	name = "nautical energy sword"
+	icon_state = "cutlass1"
+	item_state = "cutlass1"
+	desc = "Convincing HR that your religion involved piracy was no mean feat."
+
+/obj/item/nullrod/hippie/sord
+	name = "\improper UNREAL SORD"
+	desc = "This thing is so unspeakably HOLY you are having a hard time even holding it."
+	icon_state = "sord"
+	item_state = "sord"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/nullrod/hippie/scythe
+	icon_state = "scythe1"
+	item_state = "scythe1"
+	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	name = "reaper scythe"
+	desc = "Ask not for whom the bell tolls..."
+	attack_verb = list("chopped", "sliced", "cut", "reaped")
+
+/obj/item/nullrod/hippie/scythe/vibro
+	icon_state = "hfrequency0"
+	item_state = "hfrequency1"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	name = "high frequency blade"
+	desc = "Bad references are the DNA of the soul."
+	attack_verb = list("chopped", "sliced", "cut", "zandatsu'd")
+	hitsound = 'sound/weapons/rapierhit.ogg'
+
+/obj/item/nullrod/hippie/scythe/spellblade
+	icon_state = "spellblade"
+	item_state = "spellblade"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	icon = 'icons/obj/guns/magic.dmi'
+	name = "dormant spellblade"
+	desc = "The blade grants the wielder nearly limitless power...if they can figure out how to turn it on, that is."
+	hitsound = 'sound/weapons/rapierhit.ogg'
+
+/obj/item/nullrod/hippie/scythe/talking
+	icon_state = "talking_sword"
+	item_state = "talking_sword"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	name = "possessed blade"
+	desc = "When the station falls into chaos, it's nice to have a friend by your side."
+	attack_verb = list("chopped", "sliced", "cut")
+	hitsound = 'sound/weapons/rapierhit.ogg'
+
+/obj/item/nullrod/hippie/scythe/talking/chainsword
+	icon_state = "chainswordon"
+	item_state = "chainswordon"
+	name = "possessed chainsaw sword"
+	desc = "Suffer not a heretic to live."
+	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
+
+
+/obj/item/nullrod/hippie/hammmer
+	icon_state = "hammeron"
+	item_state = "hammeron"
+	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+	name = "relic war hammer"
+	desc = "This war hammer cost the chaplain forty thousand space dollars."
+	attack_verb = list("smashed", "bashed", "hammered", "crunched")
+
+/obj/item/nullrod/hippie/chainsaw
+	name = "chainsaw hand"
+	desc = "Good? Bad? You're the guy with the chainsaw hand."
+	icon_state = "chainsaw_on"
+	item_state = "mounted_chainsaw"
+	lefthand_file = 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
+
+/obj/item/nullrod/hippie/clown
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "clownrender"
+	item_state = "render"
+	name = "clown dagger"
+	desc = "Used for absolutely hilarious sacrifices."
+	hitsound = 'sound/items/bikehorn.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/nullrod/hippie/pride_hammer
+	icon_state = "pride"
+	name = "Pride-struck Hammer"
+	desc = "It resonates an aura of Pride."
+	attack_verb = list("attacked", "smashed", "crushed", "splattered", "cracked")
+	hitsound = 'sound/weapons/blade1.ogg'
+
+/obj/item/nullrod/hippie/whip
+	name = "holy whip"
+	desc = "What a terrible night to be on Space Station 13."
+	icon_state = "chain"
+	item_state = "chain"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	attack_verb = list("whipped", "lashed")
+	hitsound = 'sound/weapons/chainhit.ogg'
+
+/obj/item/nullrod/hippie/fedora
+	name = "atheist's fedora"
+	desc = "The brim of the hat is as sharp as your wit. The edge would hurt almost as much as disproving the existence of God."
+	icon_state = "fedora"
+	item_state = "fedora"
+	icon = 'icons/obj/clothing/hats.dmi'
+	attack_verb = list("enlightened", "redpilled")
+
+/obj/item/nullrod/hippie/fedora/attack_self(mob/user)
+	visible_message("<span class='danger'>[user] tips [user.p_their()] the [name]!</span>")
+	..() //incase an admin allows you to reset the rod
+
+/obj/item/nullrod/hippie/armblade
+	name = "dark blessing"
+	desc = "Particularly twisted deities grant gifts of dubious value."
+	icon_state = "arm_blade"
+	item_state = "arm_blade"
+	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
+
+/obj/item/nullrod/hippie/armblade/tentacle
+	name = "unholy blessing"
+	icon_state = "tentacle"
+	item_state = "tentacle"
+
+/obj/item/nullrod/hippie/carp
+	name = "carp-sie plushie"
+	desc = "An adorable stuffed toy that resembles the god of all carp. The teeth look pretty sharp. Activate it to receive the blessing of Carp-Sie."
+	icon = 'icons/obj/plushes.dmi'
+	icon_state = "carpplush"
+	item_state = "carp_plushie"
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	attack_verb = list("bitten", "eaten", "fin slapped")
+	hitsound = 'sound/weapons/bite.ogg'
+
+/obj/item/nullrod/hippie/claymore/bostaff
+	name = "monk's staff"
+	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass the clown."
+	hitsound = "swing_hit"
+	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "bostaff0"
+	item_state = "bostaff0"
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+
+/obj/item/nullrod/hippie/tribal_knife
+	icon_state = "crysknife"
+	item_state = "crysknife"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	name = "arrhythmic knife"
+	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/nullrod/hippie/pitchfork
+	icon_state = "pitchfork0"
+	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	name = "unholy pitchfork"
+	desc = "Holding this makes you look absolutely devilish."
+	attack_verb = list("poked", "impaled", "pierced", "jabbed")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+
+/obj/item/nullrod/hippie/egyptian
+	name = "egyptian staff"
+	desc = "A tutorial in mummification is carved into the staff. You could probably craft the wraps if you had some cloth."
+	icon = 'icons/obj/guns/magic.dmi'
+	icon_state = "pharoah_sceptre"
+	item_state = "pharoah_sceptre"
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+	attack_verb = list("bashes", "smacks", "whacks")

--- a/hippiestation/code/game/objects/items/holy_weapons.dm
+++ b/hippiestation/code/game/objects/items/holy_weapons.dm
@@ -234,7 +234,7 @@
 	attack_verb = list("enlightened", "redpilled")
 
 /obj/item/nullrod/hippie/fedora/attack_self(mob/user)
-	visible_message("<span class='danger'>[user] tips [user.p_their()] the [name]!</span>")
+	user.visible_message("<span class='danger'>[user] tips [user.p_their()] the [name]!</span>")
 	..() //incase an admin allows you to reset the rod
 
 /obj/item/nullrod/hippie/armblade

--- a/hippiestation/code/game/objects/items/holy_weapons.dm
+++ b/hippiestation/code/game/objects/items/holy_weapons.dm
@@ -234,7 +234,7 @@
 	attack_verb = list("enlightened", "redpilled")
 
 /obj/item/nullrod/hippie/fedora/attack_self(mob/user)
-	user.visible_message("<span class='danger'>[user] tips [user.p_their()] the [name]!</span>")
+	user.visible_message("<span class='danger'>[user] tips [user.p_their()] [name]!</span>")
 	..() //incase an admin allows you to reset the rod
 
 /obj/item/nullrod/hippie/armblade


### PR DESCRIPTION
:cl:
tweak: Null rods reskins are now purely cosmetic.
add: Chain sword is now a selectable null rod.
del: Monk Manual is no longer a selectable null rod.
/:cl:

Requested by the headmins.
Chain sword is now selectable since /tg/ didn't allow it previously.
The changes work as thus, all /tg/ nullrods have been ported to the hippie file
the selection proc now only picks from files ported to the hippie selection after they've been stripped of balance changes

even if /tg/ adds a new null rod with balance changes, until someone modularises it, it can't be selected