### PR TITLE
Adds martial arts to security, removing the krav maga implant "system"

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -57,8 +57,8 @@
 
 /datum/martial_art/krav_maga/teach(mob/living/carbon/human/H,make_temporary=0)
 	if(..())
-		to_chat(H, "<span class = 'userdanger'>You know the arts of [name]!</span>")
-		to_chat(H, "<span class = 'danger'>Place your cursor over a move at the top of the screen to see what it does.</span>")
+		//to_chat(H, "<span class = 'userdanger'>You know the arts of [name]!</span>") - Hippie change and shit
+		//to_chat(H, "<span class = 'danger'>Place your cursor over a move at the top of the screen to see what it does.</span>")
 		neckchop.Grant(H)
 		legsweep.Grant(H)
 		lungpunch.Grant(H)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -114,7 +114,7 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/flashlight/seclite(src)
-	new /obj/item/clothing/gloves/krav_maga/sec(src)
+	//new /obj/item/clothing/gloves/krav_maga/sec(src) - Hippie change, Warden starts with Krav Maga in them instead
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2719,6 +2719,7 @@
 #include "hippiestation\code\datums\martial\krav_maga.dm"
 #include "hippiestation\code\datums\martial\monk.dm"
 #include "hippiestation\code\datums\martial\plasma_fist.dm"
+#include "hippiestation\code\datums\martial\security_arts.dm"
 #include "hippiestation\code\datums\martial\sleeping_carp.dm"
 #include "hippiestation\code\datums\mood_events\generic_positive_events.dm"
 #include "hippiestation\code\datums\status_effects\buffs.dm"

--- a/hippiestation/code/datums/martial.dm
+++ b/hippiestation/code/datums/martial.dm
@@ -1,4 +1,5 @@
 /datum/martial_art
+	var/constant_block = 0 // rather than a block chance while being on throw mode, this is constant
 	var/mob/living/carbon/human/owner // was it this fucking hard to add a simple link to the human?
 
 /datum/martial_art/teach(mob/living/carbon/human/H,make_temporary=0)

--- a/hippiestation/code/datums/martial/security_arts.dm
+++ b/hippiestation/code/datums/martial/security_arts.dm
@@ -20,7 +20,7 @@
 		D.apply_damage(15, BRUTE)
 		var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
 		D.throw_at(throwtarget, 4, 2, A)
-		D.Knockdown(35) //3.5 milisecond stun, because why not
+		D.Knockdown(35) //3.5 second stun, because why not
 		return TRUE
 	..()
 
@@ -52,7 +52,7 @@
 	desc = "Getting dropped as a child has given you some pretty hard times in life, now it shines. You can headbutt people, just make sure you AIM FOR THEIR HEAD and they have no helmets on."
 
 /datum/martial_art/sec/headbutter/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	if(prob(50) && !istype(D.head, /obj/item/clothing/head/helmet) && A.zone_selected == BODY_ZONE_HEAD)
+	if(prob(50) && !istype(D.head, /obj/item/clothing/head/helmet) && !istype(D.head, /obj/item/clothing/head/hardhat) && A.zone_selected == BODY_ZONE_HEAD)
 		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 		D.visible_message("<span class='danger'>[A] headbutts [D]!</span>", \
 				  "<span class='userdanger'>[A] headbutts you!</span>")

--- a/hippiestation/code/datums/martial/security_arts.dm
+++ b/hippiestation/code/datums/martial/security_arts.dm
@@ -1,0 +1,97 @@
+/datum/martial_art/sec/
+ 	name = "Security Art"
+ 	constant_block = 5
+ 	var/desc = ""
+
+/datum/martial_art/sec/flipper
+	name = "Cool Flips Bro"
+	desc = "You've become adept to flipping, you are likely to kick people right in the face during unarmed combat."
+
+/datum/martial_art/sec/flipper/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	if(prob(75))
+		A.emote("flip")
+		A.visible_message("<span class = 'danger'><B>[A] does a flip, kicking [D] back!</B></span>")
+		playsound(A.loc, "swing_hit", 50, 1)
+		D.apply_damage(15, BRUTE)
+		var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
+		D.throw_at(throwtarget, 4, 2, A)
+		D.Knockdown(35) //3.5 milisecond stun, because why not
+		return TRUE
+	..()
+
+/datum/martial_art/sec/blocker
+	name = "Block Affinity"
+	constant_block = 25
+	desc = "Show those pesky greytiders who's boss! You commonly block melee attacks with JUST your arms."
+
+
+
+/datum/martial_art/sec/puncher
+	name = "Heavy Hitter"
+	desc = "Getting your ass handed to you in training pushed you to do something better with your life, you know how to sucker punch people, delivering a good, stunning, blow."
+
+/datum/martial_art/sec/puncher/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	if(prob(50))
+		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+		D.visible_message("<span class='danger'>[A] sucker punches [D]!</span>", \
+				  "<span class='userdanger'>[A] sucker punches you!</span>")     // hoping for more punch names or whatever, but no idea for now
+		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, 1, -1)
+		D.apply_damage(rand(10,15), BRUTE)
+		if(prob(20))
+			D.Stun(20) //minimal stun
+		return TRUE
+	..()
+
+/datum/martial_art/sec/headbutter
+	name = "Hard Headed"
+	desc = "Getting dropped as a child has given you some pretty hard times in life, now it shines. You can headbutt people, just make sure you AIM FOR THEIR HEAD and they have no helmets on."
+
+/datum/martial_art/sec/headbutter/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	if(prob(50) && !istype(D.head, /obj/item/clothing/head/helmet) && A.zone_selected == BODY_ZONE_HEAD)
+		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+		D.visible_message("<span class='danger'>[A] headbutts [D]!</span>", \
+				  "<span class='userdanger'>[A] headbutts you!</span>")
+		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, 1, -1)
+		D.apply_damage(12, BRUTE, BODY_ZONE_HEAD)
+		D.Knockdown(rand(5,30))
+		return TRUE
+	..()
+
+/datum/martial_art/sec/grabber
+	name = "Fierce Grabber"
+	desc = "Apart from being an avid kleptomaniac in your youth, your grip has been strengthened. You can aggressively grab people faster than others."
+
+/datum/martial_art/sec/grabber/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(A.grab_state >= GRAB_AGGRESSIVE)  // this isnt stolen from sleeping carp code, i dont know what you're talking about
+		D.grabbedby(A, 1)
+	else
+		A.start_pulling(D, 1)
+		if(A.pulling)
+			D.drop_all_held_items()
+			D.stop_pulling()
+			if(A.a_intent == INTENT_GRAB)
+				D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
+				  "<span class='userdanger'>[A] violently grabs you!</span>")
+				A.grab_state = GRAB_AGGRESSIVE
+			else
+				A.grab_state = GRAB_PASSIVE
+	return TRUE
+
+/datum/martial_art/sec/disarmer
+	name = "Tactical Disarmer"
+	desc = "Slapping weapons out of peoples hands? Pushing?! Those are weak tactics. You yank things out of peoples hands when disarming, but pushing them down is too dishonorable for you."
+
+/datum/martial_art/sec/disarmer/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(prob(50))
+		var/obj/item/I = D.get_active_held_item()
+		if(I)
+			if(D.temporarilyRemoveItemFromInventory(I))
+				A.put_in_hands(I)
+		D.visible_message("<span class='danger'>[A] has disarmed [D]!</span>", \
+						"<span class='userdanger'>[A] has disarmed [D]!</span>")
+		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+	else
+		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", \
+							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
+		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+	return TRUE

--- a/hippiestation/code/datums/martial/security_arts.dm
+++ b/hippiestation/code/datums/martial/security_arts.dm
@@ -3,6 +3,11 @@
  	constant_block = 5
  	var/desc = ""
 
+/datum/martial_art/sec/teach(mob/living/carbon/human/H,make_temporary=0,mob/M)
+	. = ..()
+	to_chat(M, "<span class='bold info'><font size='2'>[desc]</font></span>")
+
+
 /datum/martial_art/sec/flipper
 	name = "Cool Flips Bro"
 	desc = "You've become adept to flipping, you are likely to kick people right in the face during unarmed combat."

--- a/hippiestation/code/modules/jobs/job_types/security.dm
+++ b/hippiestation/code/modules/jobs/job_types/security.dm
@@ -2,51 +2,38 @@
 	. = ..()
 	var/datum/martial_art/cqc/seccqc = new
 	seccqc.teach(H)
-	to_chat(H, "<span class='bold info'><font size='2'>In the academy not only did you essentially get abused, but you've gained a life skill, the art of Close Quarters Combat.</span></font>")
+	to_chat(M, "<span class='bold info'><font size='2'>In the academy not only did you essentially get abused, but you've gained a life skill, the art of Close Quarters Combat.</font></span>")
 
 /datum/job/warden/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	var/datum/martial_art/krav_maga/brigdefense = new
 	brigdefense.teach(H)
-	to_chat(H, "<span class='bold info'><font size='2'>During your strict training to become a mall cop, they gave you some sort of nanites and a promotion. You know the arts of Krav Maga.</span></font>")
+	to_chat(M, "<span class='bold info'><font size='2'>During your strict training to become a mall cop, they gave you some sort of nanites and a promotion. You know the arts of Krav Maga.</font></span>")
 
 /datum/job/officer/after_spawn(mob/living/carbon/human/H, mob/M)
-	var/art = pickweight("Flip" = 10,"Block" = 30,"Punch" = 30,"Headbutt" = 20,"Grab" = 20,"Disarm" = 25)
-	var/description = ""
+	. = ..()
+	var/art = pickweight(list("Flip" = 10,"Block" = 30,"Punch" = 30,"Headbutt" = 20,"Grab" = 20,"Disarm" = 25))
 	switch(art)
 		if("Block")
 			var/datum/martial_art/sec/blocker/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
+			martialart.teach(H,,M)
 
 		if("Punch")
 			var/datum/martial_art/sec/puncher/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
-
+			martialart.teach(H,,M)
 
 		if("Headbutt")
 			var/datum/martial_art/sec/headbutter/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
-
+			martialart.teach(H,,M)
 
 		if("Grab")
 			var/datum/martial_art/sec/grabber/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
-
+			martialart.teach(H,,M)
 
 		if("Disarm")
 			var/datum/martial_art/sec/disarmer/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
-
+			martialart.teach(H,,M)
 
 		if("Flip")
 			var/datum/martial_art/sec/flipper/martialart = new
-			description = martialart.desc
-			martialart.teach(H)
-
-	to_chat(M, "<span class='bold info'><font size='2'[description]</span></font>")
-	..()
+			martialart.teach(H,,M)

--- a/hippiestation/code/modules/jobs/job_types/security.dm
+++ b/hippiestation/code/modules/jobs/job_types/security.dm
@@ -1,8 +1,52 @@
-/datum/outfit/job/hos
-	implants = list(/obj/item/implant/mindshield/, /obj/item/implant/krav_maga)
+/datum/job/hos/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	var/datum/martial_art/cqc/seccqc = new
+	seccqc.teach(H)
+	to_chat(H, "<span class='bold info'><font size='2'>In the academy not only did you essentially get abused, but you've gained a life skill, the art of Close Quarters Combat.</span></font>")
 
-/datum/outfit/job/warden
-	implants = list(/obj/item/implant/mindshield/, /obj/item/implant/krav_maga)
+/datum/job/warden/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	var/datum/martial_art/krav_maga/brigdefense = new
+	brigdefense.teach(H)
+	to_chat(H, "<span class='bold info'><font size='2'>During your strict training to become a mall cop, they gave you some sort of nanites and a promotion. You know the arts of Krav Maga.</span></font>")
 
-/datum/outfit/job/security
-	implants = list(/obj/item/implant/mindshield/, /obj/item/implant/krav_maga)
+/datum/job/officer/after_spawn(mob/living/carbon/human/H, mob/M)
+	var/art = pickweight("Flip" = 10,"Block" = 30,"Punch" = 30,"Headbutt" = 20,"Grab" = 20,"Disarm" = 25)
+	var/description = ""
+	switch(art)
+		if("Block")
+			var/datum/martial_art/sec/blocker/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+		if("Punch")
+			var/datum/martial_art/sec/puncher/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+
+		if("Headbutt")
+			var/datum/martial_art/sec/headbutter/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+
+		if("Grab")
+			var/datum/martial_art/sec/grabber/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+
+		if("Disarm")
+			var/datum/martial_art/sec/disarmer/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+
+		if("Flip")
+			var/datum/martial_art/sec/flipper/martialart = new
+			description = martialart.desc
+			martialart.teach(H)
+
+	to_chat(M, "<span class='bold info'><font size='2'[description]</span></font>")
+	..()

--- a/hippiestation/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/human_defense.dm
@@ -1,5 +1,11 @@
 /mob/living/carbon/human/grabbedby(mob/living/user, supress_message = 0)
 	if (checkbuttinspect(user))
 		return FALSE
-	
+
 	return ..()
+
+/mob/living/carbon/human/check_block()
+	if(mind)
+		if(mind.martial_art && prob(mind.martial_art.constant_block) && mind.martial_art.can_use(src) && !incapacitated(FALSE, TRUE))
+			return TRUE
+	..()


### PR DESCRIPTION
What the title says.
HoS gets CQC.
Warden gets Krav Maga, known rather than an implant you can toggle. Removed the Krav Maga gloves.
Security officers randomly get 1 of 6 martial arts, all with different effects to some degreee, sharing a `very minimal` melee block chance.
Detective gets nothing because they still have `what is essentially the most OP gun on station`
### The martial arts are : 
**Cool Flips Bro** : You commonly do flip attacks.
**Block Affinity** : You're prone to preemptively blocking.
**Heavy Hitter** : You beat the shit out of people.
**Hard Headed** : You lack a couple brain cells and usually headbutt people.
**Fierce Grabber** : Your grip is pretty strong.  
**Tactical Disarmer** : You yank those weapons right out.
*Figure out what they do better by playing or being a lame shit and looking at the code.*