### PR TITLE
Merge pull request #39728 from YPOQ/areaenteredfix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -164,9 +164,13 @@
 
 	// Past this is the point of no return
 	var/atom/oldloc = loc
+	var/area/oldarea = get_area(oldloc)
+	var/area/newarea = get_area(newloc)
 	loc = newloc
 	. = TRUE
 	oldloc.Exited(src, newloc)
+	if(oldarea != newarea)
+		oldarea.Exited(src, newloc)
 
 	for(var/i in oldloc)
 		if(i == src) // Multi tile objects
@@ -175,6 +179,8 @@
 		thing.Uncrossed(src)
 
 	newloc.Entered(src, oldloc)
+	if(oldarea != newarea)
+		newarea.Entered(src, oldloc)
 
 	for(var/i in loc)
 		if(i == src) // Multi tile objects
@@ -377,7 +383,7 @@
 		if(!same_loc)
 			if(oldloc)
 				oldloc.Exited(src, destination)
-				if(old_area)
+				if(old_area && old_area != destarea)
 					old_area.Exited(src, destination)
 			for(var/atom/movable/AM in oldloc)
 				AM.Uncrossed(src)


### PR DESCRIPTION
🆑
fix: Roundstart motion-detecting cameras work again
/🆑

Fixes #39346
Fixes ship ambience not playing and machines not updating power status when moved between areas.

This used to be handled by byond's built in Move()

Also fixes teleporting between two spots in the same area calling area/Exited()