### PR TITLE
Merge pull request #39710 from tgstation/MrStonedOne-patch-1

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -97,10 +97,11 @@ SUBSYSTEM_DEF(garbage)
 				queue = GC_QUEUE_CHECK+1
 			if (GC_QUEUE_HARDDELETE)
 				HandleQueue(GC_QUEUE_HARDDELETE)
+				if (state == SS_PAUSED) //make us wait again before the next run.
+					state = SS_RUNNING
 				break
 
-	if (state == SS_PAUSED) //make us wait again before the next run.
-		state = SS_RUNNING
+	
 
 //If you see this proc high on the profile, what you are really seeing is the garbage collection/soft delete overhead in byond.
 //Don't attempt to optimize, not worth the effort.
@@ -115,8 +116,9 @@ SUBSYSTEM_DEF(garbage)
 	for (var/ref in tobequeued)
 		count++
 		Queue(ref, GC_QUEUE_PREQUEUE+1)
+		tobequeued[count] = null
 		if (MC_TICK_CHECK)
-			break
+			return
 	if (count)
 		tobequeued.Cut(1,count+1)
 		count = 0
@@ -141,7 +143,7 @@ SUBSYSTEM_DEF(garbage)
 		if (!refID)
 			count++
 			if (MC_TICK_CHECK)
-				break
+				return
 			continue
 
 		var/GCd_at_time = queue[refID]
@@ -160,7 +162,7 @@ SUBSYSTEM_DEF(garbage)
 			reference_find_on_fail -= refID		//It's deleted we don't care anymore.
 			#endif
 			if (MC_TICK_CHECK)
-				break
+				return
 			continue
 
 		// Something's still referring to the qdel'd object.
@@ -183,13 +185,13 @@ SUBSYSTEM_DEF(garbage)
 			if (GC_QUEUE_HARDDELETE)
 				HardDelete(D)
 				if (MC_TICK_CHECK)
-					break
+					return
 				continue
 
 		Queue(D, level+1)
 
 		if (MC_TICK_CHECK)
-			break
+			return
 	if (count)
 		queue.Cut(1,count+1)
 		count = 0


### PR DESCRIPTION
**Unlike normal subsystems, if the garbage collector is tick_checked into pausing, rather than run next game tick to resume, it waits the full 2 seconds again.

I added that change because hard deletes can sometimes cause a large amount of lag, and so doing one again the next game tick is a stupid idea when 1 hard delete can cause a tick overrun on its own.

Now it only applies this when doing hard deletes, running again next tick otherwise.

This is still a background subsystem with a low priority, so its still only running on spare cpu (from the MC's prospective.)*
