### PR TITLE
Fixes ling claw glitch

### DIFF
--- a/hippiestation/code/modules/antagonists/changeling/mutations.dm
+++ b/hippiestation/code/modules/antagonists/changeling/mutations.dm
@@ -130,8 +130,9 @@
 	item_state = "teslaclaw"
 	lefthand_file = 'hippiestation/icons/mob/inhands/changeling_lefthand.dmi'
 	righthand_file = 'hippiestation/icons/mob/inhands/changeling_righthand.dmi'
-	item_flags = ABSTRACT | NODROP | DROPDEL
+	item_flags = NEEDS_PERMIT | ABSTRACT | NODROP | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
+	slot_flags = null
 	force = 0
 	throwforce = 5
 	stunforce = 50


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
fix: Fixed changeling tesla claw from going into your belt slot and staying there. 
fix: Added permit flags for consistency 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Closes https://github.com/HippieStation/HippieStation/issues/8599

This was just caused by the item slog flags not being nullified. 

Was able to reproduce the issue and fix it, confirmed by testing. 