### PR TITLE
Nerfs carbonhell's cheap cuisine

### DIFF
--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -97,7 +97,8 @@
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 0)
+	var/component/todel = GetComponent(/datum/component/slippery, 80)
+	qdel(todel)
 
 /obj/item/reagent_containers/food/snacks/hamdisc
 	name = "ham disc"

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -97,7 +97,7 @@
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 40)
+	AddComponent(/datum/component/slippery, 0)
 
 /obj/item/reagent_containers/food/snacks/hamdisc
 	name = "ham disc"

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -97,8 +97,8 @@
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
 	. = ..()
-	var/component/todel = GetComponent(/datum/component/slippery)
-	qdel(todel)
+	var/datum/component/comp = GetComponent(/datum/component/slippery)
+	qdel(comp)
 
 /obj/item/reagent_containers/food/snacks/hamdisc
 	name = "ham disc"

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -97,7 +97,7 @@
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
 	. = ..()
-	var/component/todel = GetComponent(/datum/component/slippery, 80)
+	var/component/todel = GetComponent(/datum/component/slippery)
 	qdel(todel)
 
 /obj/item/reagent_containers/food/snacks/hamdisc

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -95,6 +95,10 @@
 	bitesize = 2
 	foodtype = GROSS | TOXIC
 
+/obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/slippery, 40)
+
 /obj/item/reagent_containers/food/snacks/hamdisc
 	name = "ham disc"
 	desc = "The laziest food someone could possibly make, alongside some corn."

--- a/hippiestation/code/modules/vending/snack.dm
+++ b/hippiestation/code/modules/vending/snack.dm
@@ -1,2 +1,2 @@
 /obj/machinery/vending/snack
-	hippie_products = list(/obj/item/cheapcuisine = 6)
+	hippie_contraband = list(/obj/item/cheapcuisine = 4)

--- a/hippiestation/code/modules/vending/snack.dm
+++ b/hippiestation/code/modules/vending/snack.dm
@@ -1,2 +1,2 @@
 /obj/machinery/vending/snack
-	hippie_contraband = list(/obj/item/cheapcuisine = 4)
+	hippie_products = list(/obj/item/cheapcuisine = 4)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
tweak: Carbonhell cheap cuisine vendor is now available only as contraband in vending machines
tweak: The amount of cheap cusines per vendor has been reduced from 6 to 4
balance: Reduced carbon's butterdog slip time to 4 from 8 
/:cl:

[why]: op Roundstart 8 slips that were added in as a "meme" (powergame code that somehow got post headmin approval) are op, nuff said