### PR TITLE
Sound options - voice, scream and main

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -61,7 +61,7 @@
 
 	if(R.mind)
 		R.mind.grab_ghost()
-		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice")
+		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice") // hippie -- additional argument added for sound control options
 
 	R.revive()
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -61,7 +61,7 @@
 
 	if(R.mind)
 		R.mind.grab_ghost()
-		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
+		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice")
 
 	R.revive()
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1119,7 +1119,7 @@
 		audible_message("<span class='danger'>[icon2html(src, viewers(src))] Hiss!</span>")
 		var/list/possible_sounds = list('sound/voice/hiss1.ogg', 'sound/voice/hiss2.ogg', 'sound/voice/hiss3.ogg', 'sound/voice/hiss4.ogg')
 		var/chosen_sound = pick(possible_sounds)
-		playsound(get_turf(src), chosen_sound, 50, 1)
+		playsound(get_turf(src), chosen_sound, 50, 1, type = "voice")
 		spawn(45)
 			if(src)
 				icon_state = "[initial(icon_state)]"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1119,7 +1119,7 @@
 		audible_message("<span class='danger'>[icon2html(src, viewers(src))] Hiss!</span>")
 		var/list/possible_sounds = list('sound/voice/hiss1.ogg', 'sound/voice/hiss2.ogg', 'sound/voice/hiss3.ogg', 'sound/voice/hiss4.ogg')
 		var/chosen_sound = pick(possible_sounds)
-		playsound(get_turf(src), chosen_sound, 50, 1, type = "voice")
+		playsound(get_turf(src), chosen_sound, 50, 1, type = "voice") // hippie -- additional argument added for sound control options)
 		spawn(45)
 			if(src)
 				icon_state = "[initial(icon_state)]"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,4 +1,4 @@
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, type = "default")
 	if(isarea(source))
 		throw EXCEPTION("playsound(): source is an area")
 		return
@@ -20,11 +20,20 @@
 			continue
 		var/distance = get_dist(M, turf_source)
 
+		//Hippie start -- sound prefs
+		var/pref_vol = M.client.prefs.other_volume  / 100 * vol
+		if(type != "default")
+			switch(type)
+				if("scream")
+					pref_vol = M.client.prefs.scream_volume / 100 * vol
+				if("voice")
+					pref_vol = M.client.prefs.voice_volume / 100 * vol
+		//Hippie end
+
 		if(distance <= maxdistance)
 			var/turf/T = get_turf(M)
-
 			if(T && T.z == turf_source.z)
-				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
+				M.playsound_local(turf_source, soundin, pref_vol, vary, frequency, falloff, channel, pressure_affected, S)
 
 /mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S)
 	if(!client || !can_hear())

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,4 +1,4 @@
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, type = "default")
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, type = "default") // Hippie - added "type" argument
 	if(isarea(source))
 		throw EXCEPTION("playsound(): source is an area")
 		return
@@ -33,7 +33,7 @@
 		if(distance <= maxdistance)
 			var/turf/T = get_turf(M)
 			if(T && T.z == turf_source.z)
-				M.playsound_local(turf_source, soundin, pref_vol, vary, frequency, falloff, channel, pressure_affected, S)
+				M.playsound_local(turf_source, soundin, pref_vol, vary, frequency, falloff, channel, pressure_affected, S) //Hippie -- passes above pref_vol rather than just vol
 
 /mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S)
 	if(!client || !can_hear())

--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -89,7 +89,7 @@
 	src.log_talk(message, LOG_SAY, tag="clockwork eminence")
 	if(GLOB.ratvar_awakens)
 		visible_message("<span class='brass'><b>You feel light slam into your mind and form words:</b> \"[capitalize(message)]\"</span>")
-		playsound(src, 'sound/machines/clockcult/ark_scream.ogg', 50, FALSE, type = "scream")
+		playsound(src, 'sound/machines/clockcult/ark_scream.ogg', 50, FALSE, type = "scream") // hippie -- additional argument added for sound control options)
 	message = "<span class='big brass'><b>The [GLOB.ratvar_awakens ? "Radiance" : "Eminence"]:</b> \"[message]\"</span>"
 	for(var/mob/M in servants_and_ghosts())
 		if(isobserver(M))

--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -89,7 +89,7 @@
 	src.log_talk(message, LOG_SAY, tag="clockwork eminence")
 	if(GLOB.ratvar_awakens)
 		visible_message("<span class='brass'><b>You feel light slam into your mind and form words:</b> \"[capitalize(message)]\"</span>")
-		playsound(src, 'sound/machines/clockcult/ark_scream.ogg', 50, FALSE)
+		playsound(src, 'sound/machines/clockcult/ark_scream.ogg', 50, FALSE, type = "scream")
 	message = "<span class='big brass'><b>The [GLOB.ratvar_awakens ? "Radiance" : "Eminence"]:</b> \"[message]\"</span>"
 	for(var/mob/M in servants_and_ghosts())
 		if(isobserver(M))

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -54,7 +54,7 @@
 				var/mob/M = V
 				var/turf/T = get_turf(M)
 				if((T && T.z == z) || is_servant_of_ratvar(M) || isobserver(M))
-					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE, type = "scream")
+					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE, type = "scream") // hippie -- additional argument added for sound control options)
 			hierophant_message("<span class='big boldwarning'>The Ark is taking damage!</span>")
 	last_scream = world.time + ARK_SCREAM_COOLDOWN
 

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -54,7 +54,7 @@
 				var/mob/M = V
 				var/turf/T = get_turf(M)
 				if((T && T.z == z) || is_servant_of_ratvar(M) || isobserver(M))
-					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE)
+					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE, type = "scream")
 			hierophant_message("<span class='big boldwarning'>The Ark is taking damage!</span>")
 	last_scream = world.time + ARK_SCREAM_COOLDOWN
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -588,7 +588,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<br>"
 				dat += "<b>Combo HUD Lighting:</b> <a href = '?_src_=prefs;preference=combohud_lighting'>[(toggles & COMBOHUD_LIGHTING)?"Full-bright":"No Change"]</a><br>"
 				dat += "</td>"
+
+			dat +="<td width='300px' height='300px' valign='top'>"
+			dat += hippie_dat_replace(current_tab)
+			dat += "</td>"
 			dat += "</tr></table>"
+
 		if(3) // hippie start -- loadout system
 			dat += hippie_dat_replace(current_tab) // hippie end
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -589,10 +589,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<b>Combo HUD Lighting:</b> <a href = '?_src_=prefs;preference=combohud_lighting'>[(toggles & COMBOHUD_LIGHTING)?"Full-bright":"No Change"]</a><br>"
 				dat += "</td>"
 
+			//Hippie start -- adds hippie content to OOC preferences tab
 			dat +="<td width='300px' height='300px' valign='top'>"
 			dat += hippie_dat_replace(current_tab)
 			dat += "</td>"
 			dat += "</tr></table>"
+			//Hippie end
 
 		if(3) // hippie start -- loadout system
 			dat += hippie_dat_replace(current_tab) // hippie end

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -178,6 +178,6 @@
 					phrase_sound = "dredd"
 
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[phrase_text]</b></font>")
-		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4, type="voice")
+		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4, type="voice") // hippie -- additional argument added for sound control options
 		cooldown = world.time
 		cooldown_special = world.time

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -178,6 +178,6 @@
 					phrase_sound = "dredd"
 
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[phrase_text]</b></font>")
-		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4)
+		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4, type="voice")
 		cooldown = world.time
 		cooldown_special = world.time

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -578,7 +578,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			A = image('icons/mob/mob.dmi',target,"daemon")
 		if("robot")//Cyborg
 			A = image('icons/mob/robots.dmi',target,"robot")
-			target.playsound_local(target,'sound/voice/liveagain.ogg', 75, 1, type="voice")
+			target.playsound_local(target,'sound/voice/liveagain.ogg', 75, 1, type="voice") // hippie -- additional argument added for sound control options
 		if("custom")
 			A = image(custom_icon_file, target, custom_icon)
 	A.override = 1
@@ -795,7 +795,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		if("alarm")
 			target.playsound_local(source, 'sound/machines/alarm.ogg', 100, 0)
 		if("beepsky")
-			target.playsound_local(source, 'sound/voice/bfreeze.ogg', 35, 0, type="voice")
+			target.playsound_local(source, 'sound/voice/bfreeze.ogg', 35, 0, type="voice") // hippie -- additional argument added for sound control options
 		if("mech")
 			var/mech_dir = pick(GLOB.cardinals)
 			for(var/i in 1 to rand(4,9))
@@ -849,9 +849,9 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			target.playsound_local(source, 'sound/misc/compiler-failure.ogg', 50)
 		if("laughter")
 			if(prob(50))
-				target.playsound_local(source, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice")
+				target.playsound_local(source, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice") // hippie -- additional argument added for sound control options
 			else
-				target.playsound_local(source, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice")
+				target.playsound_local(source, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice") // hippie -- additional argument added for sound control options
 		if("creepy")
 		//These sounds are (mostly) taken from Hidden: Source
 			target.playsound_local(source, pick(CREEPY_SOUNDS), 50, 1)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -578,7 +578,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			A = image('icons/mob/mob.dmi',target,"daemon")
 		if("robot")//Cyborg
 			A = image('icons/mob/robots.dmi',target,"robot")
-			target.playsound_local(target,'sound/voice/liveagain.ogg', 75, 1)
+			target.playsound_local(target,'sound/voice/liveagain.ogg', 75, 1, type="voice")
 		if("custom")
 			A = image(custom_icon_file, target, custom_icon)
 	A.override = 1
@@ -795,7 +795,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		if("alarm")
 			target.playsound_local(source, 'sound/machines/alarm.ogg', 100, 0)
 		if("beepsky")
-			target.playsound_local(source, 'sound/voice/bfreeze.ogg', 35, 0)
+			target.playsound_local(source, 'sound/voice/bfreeze.ogg', 35, 0, type="voice")
 		if("mech")
 			var/mech_dir = pick(GLOB.cardinals)
 			for(var/i in 1 to rand(4,9))
@@ -849,9 +849,9 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			target.playsound_local(source, 'sound/misc/compiler-failure.ogg', 50)
 		if("laughter")
 			if(prob(50))
-				target.playsound_local(source, 'sound/voice/human/womanlaugh.ogg', 50, 1)
+				target.playsound_local(source, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice")
 			else
-				target.playsound_local(source, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1)
+				target.playsound_local(source, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice")
 		if("creepy")
 		//These sounds are (mostly) taken from Hidden: Source
 			target.playsound_local(source, pick(CREEPY_SOUNDS), 50, 1)

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -71,7 +71,7 @@
 
 	else if(trapped == SPOOKY_SKELETON)
 		visible_message("<span class='userdanger'><font size='5'>BOO!</font></span>")
-		playsound(loc, 'sound/spookoween/girlscream.ogg', 300, 1)
+		playsound(loc, 'sound/spookoween/girlscream.ogg', 300, 1, type = "scream")
 		trapped = 0
 		QDEL_IN(trapped_mob, 90)
 

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -71,7 +71,7 @@
 
 	else if(trapped == SPOOKY_SKELETON)
 		visible_message("<span class='userdanger'><font size='5'>BOO!</font></span>")
-		playsound(loc, 'sound/spookoween/girlscream.ogg', 300, 1, type = "scream")
+		playsound(loc, 'sound/spookoween/girlscream.ogg', 300, 1, type = "scream") // hippie -- additional argument added for sound control options)
 		trapped = 0
 		QDEL_IN(trapped_mob, 90)
 

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -27,4 +27,4 @@
 /datum/emote/living/alien/roar/run_emote(mob/user, params)
 	. = ..()
 	if(. && isalienadult(user))
-		playsound(user.loc, 'sound/voice/hiss5.ogg', 40, 1, 1)
+		playsound(user.loc, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice")

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -27,4 +27,4 @@
 /datum/emote/living/alien/roar/run_emote(mob/user, params)
 	. = ..()
 	if(. && isalienadult(user))
-		playsound(user.loc, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice")
+		playsound(user.loc, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice") // hippie -- additional argument added for sound control options

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -66,7 +66,7 @@
 				dropItemToGround(l_store)
 
 /mob/living/carbon/alien/humanoid/cuff_resist(obj/item/I)
-	playsound(src, 'sound/voice/hiss5.ogg', 40, 1, 1)  //Alien roars when starting to break free
+	playsound(src, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice")  //Alien roars when starting to break free
 	..(I, cuff_break = INSTANT_CUFFBREAK)
 
 /mob/living/carbon/alien/humanoid/resist_grab(moving_resist)
@@ -115,5 +115,5 @@
 
 /mob/living/carbon/alien/humanoid/check_breath(datum/gas_mixture/breath)
 	if(breath && breath.total_moles() > 0 && !sneaking)
-		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5)
+		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5, type="voice")
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -66,7 +66,7 @@
 				dropItemToGround(l_store)
 
 /mob/living/carbon/alien/humanoid/cuff_resist(obj/item/I)
-	playsound(src, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice")  //Alien roars when starting to break free
+	playsound(src, 'sound/voice/hiss5.ogg', 40, 1, 1, type="voice") // hippie -- additional argument added for sound control options  //Alien roars when starting to break free
 	..(I, cuff_break = INSTANT_CUFFBREAK)
 
 /mob/living/carbon/alien/humanoid/resist_grab(moving_resist)
@@ -115,5 +115,5 @@
 
 /mob/living/carbon/alien/humanoid/check_breath(datum/gas_mixture/breath)
 	if(breath && breath.total_moles() > 0 && !sneaking)
-		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5, type="voice")
+		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5, type="voice") // hippie -- additional argument added for sound control options
 	..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -88,7 +88,7 @@
 	. = ..()
 	message_simple = initial(message_simple)
 	if(. && isalienadult(user))
-		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
+		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1, type="voice")
 
 /datum/emote/living/drool
 	key = "drool"
@@ -213,9 +213,9 @@
 		var/mob/living/carbon/human/H = user
 		if(H.dna.species.id == "human" && (!H.mind || !H.mind.miming))
 			if(user.gender == FEMALE)
-				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1)
+				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice")
 			else
-				playsound(H, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1)
+				playsound(H, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice")
 
 /datum/emote/living/look
 	key = "look"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -88,7 +88,7 @@
 	. = ..()
 	message_simple = initial(message_simple)
 	if(. && isalienadult(user))
-		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1, type="voice")
+		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1, type="voice") // hippie -- additional argument added for sound control options
 
 /datum/emote/living/drool
 	key = "drool"
@@ -213,9 +213,9 @@
 		var/mob/living/carbon/human/H = user
 		if(H.dna.species.id == "human" && (!H.mind || !H.mind.miming))
 			if(user.gender == FEMALE)
-				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice")
+				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1, type="voice") // hippie -- additional argument added for sound control options
 			else
-				playsound(H, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice")
+				playsound(H, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1, type="voice") // hippie -- additional argument added for sound control options
 
 /datum/emote/living/look
 	key = "look"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,7 +165,7 @@
 
 	equippable_hats = typecacheof(equippable_hats)
 
-	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
+	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice")
 	aicamera = new/obj/item/camera/siliconcam/robot_camera(src)
 	toner = tonermax
 	diag_hud_set_borgcell()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -165,7 +165,7 @@
 
 	equippable_hats = typecacheof(equippable_hats)
 
-	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice")
+	playsound(loc, 'sound/voice/liveagain.ogg', 75, 1, type="voice") // hippie -- additional argument added for sound control options
 	aicamera = new/obj/item/camera/siliconcam/robot_camera(src)
 	toner = tonermax
 	diag_hud_set_borgcell()

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -116,7 +116,7 @@
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE)
+			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice")
 			playsound(src,'sound/weapons/saberon.ogg',50,TRUE,-1)
 			visible_message("[src] ignites his energy swords!")
 			icon_state = "grievous-c"

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -116,7 +116,7 @@
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice")
+			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice") // hippie -- additional argument added for sound control options)
 			playsound(src,'sound/weapons/saberon.ogg',50,TRUE,-1)
 			visible_message("[src] ignites his energy swords!")
 			icon_state = "grievous-c"

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -357,7 +357,7 @@ Auto Patrol[]"},
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/ed209_20sec.ogg', 'sound/voice/edplaceholder.ogg'), 50, FALSE, type="voice")
+			playsound(src, pick('sound/voice/ed209_20sec.ogg', 'sound/voice/edplaceholder.ogg'), 50, FALSE, type="voice") // hippie -- additional argument added for sound control options
 			visible_message("<b>[src]</b> points at [C.name]!")
 			mode = BOT_HUNT
 			spawn(0)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -357,7 +357,7 @@ Auto Patrol[]"},
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/ed209_20sec.ogg', 'sound/voice/edplaceholder.ogg'), 50, FALSE)
+			playsound(src, pick('sound/voice/ed209_20sec.ogg', 'sound/voice/edplaceholder.ogg'), 50, FALSE, type="voice")
 			visible_message("<b>[src]</b> points at [C.name]!")
 			mode = BOT_HUNT
 			spawn(0)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -264,7 +264,7 @@
 			var/list/messagevoice = list("Hey, [H.name]! Hold on, I'm coming." = 'sound/voice/mcoming.ogg',"Wait [H.name]! I want to help!" = 'sound/voice/mhelp.ogg',"[H.name], you appear to be injured!" = 'sound/voice/minjured.ogg')
 			var/message = pick(messagevoice)
 			speak(message)
-			playsound(loc, messagevoice[message], 50, 0)
+			playsound(loc, messagevoice[message], 50, 0, type = "voice")
 			last_newpatient_speak = world.time
 		return H
 	else
@@ -292,7 +292,7 @@
 			var/list/messagevoice = list("Radar, put a mask on!" = 'sound/voice/mradar.ogg',"There's always a catch, and I'm the best there is." = 'sound/voice/mcatch.ogg',"I knew it, I should've been a plastic surgeon." = 'sound/voice/msurgeon.ogg',"What kind of medbay is this? Everyone's dropping like flies." = 'sound/voice/mflies.ogg',"Delicious!" = 'sound/voice/mdelicious.ogg')
 			var/message = pick(messagevoice)
 			speak(message)
-			playsound(loc, messagevoice[message], 50, 0)
+			playsound(loc, messagevoice[message], 50, 0, type = "voice")
 		var/scan_range = (stationary_mode ? 1 : DEFAULT_SCAN_RANGE) //If in stationary mode, scan range is limited to adjacent patients.
 		patient = scan(/mob/living/carbon/human, oldpatient, scan_range)
 		oldpatient = patient
@@ -425,7 +425,7 @@
 		var/list/messagevoice = list("No! Stay with me!" = 'sound/voice/mno.ogg',"Live, damnit! LIVE!" = 'sound/voice/mlive.ogg',"I...I've never lost a patient before. Not today, I mean." = 'sound/voice/mlost.ogg')
 		var/message = pick(messagevoice)
 		speak(message)
-		playsound(loc, messagevoice[message], 50, 0)
+		playsound(loc, messagevoice[message], 50, 0, type = "voice")
 		oldpatient = patient
 		soft_reset()
 		return
@@ -479,7 +479,7 @@
 		var/list/messagevoice = list("All patched up!" = 'sound/voice/mpatchedup.ogg',"An apple a day keeps me away." = 'sound/voice/mapple.ogg',"Feel better soon!" = 'sound/voice/mfeelbetter.ogg')
 		var/message = pick(messagevoice)
 		speak(message)
-		playsound(loc, messagevoice[message], 50, 0)
+		playsound(loc, messagevoice[message], 50, 0, type = "voice")
 		bot_reset()
 		return
 	else
@@ -540,7 +540,7 @@
 		drop_part(robot_arm, Tsec)
 
 	if(emagged && prob(25))
-		playsound(loc, 'sound/voice/minsult.ogg', 50, 0)
+		playsound(loc, 'sound/voice/minsult.ogg', 50, 0, type = "voice")
 
 	do_sparks(3, TRUE, src)
 	..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -264,7 +264,7 @@
 			var/list/messagevoice = list("Hey, [H.name]! Hold on, I'm coming." = 'sound/voice/mcoming.ogg',"Wait [H.name]! I want to help!" = 'sound/voice/mhelp.ogg',"[H.name], you appear to be injured!" = 'sound/voice/minjured.ogg')
 			var/message = pick(messagevoice)
 			speak(message)
-			playsound(loc, messagevoice[message], 50, 0, type = "voice")
+			playsound(loc, messagevoice[message], 50, 0, type = "voice") // hippie -- additional argument added for sound control options)
 			last_newpatient_speak = world.time
 		return H
 	else
@@ -292,7 +292,7 @@
 			var/list/messagevoice = list("Radar, put a mask on!" = 'sound/voice/mradar.ogg',"There's always a catch, and I'm the best there is." = 'sound/voice/mcatch.ogg',"I knew it, I should've been a plastic surgeon." = 'sound/voice/msurgeon.ogg',"What kind of medbay is this? Everyone's dropping like flies." = 'sound/voice/mflies.ogg',"Delicious!" = 'sound/voice/mdelicious.ogg')
 			var/message = pick(messagevoice)
 			speak(message)
-			playsound(loc, messagevoice[message], 50, 0, type = "voice")
+			playsound(loc, messagevoice[message], 50, 0, type = "voice") // hippie -- additional argument added for sound control options)
 		var/scan_range = (stationary_mode ? 1 : DEFAULT_SCAN_RANGE) //If in stationary mode, scan range is limited to adjacent patients.
 		patient = scan(/mob/living/carbon/human, oldpatient, scan_range)
 		oldpatient = patient
@@ -425,7 +425,7 @@
 		var/list/messagevoice = list("No! Stay with me!" = 'sound/voice/mno.ogg',"Live, damnit! LIVE!" = 'sound/voice/mlive.ogg',"I...I've never lost a patient before. Not today, I mean." = 'sound/voice/mlost.ogg')
 		var/message = pick(messagevoice)
 		speak(message)
-		playsound(loc, messagevoice[message], 50, 0, type = "voice")
+		playsound(loc, messagevoice[message], 50, 0, type = "voice") // hippie -- additional argument added for sound control options)
 		oldpatient = patient
 		soft_reset()
 		return
@@ -479,7 +479,7 @@
 		var/list/messagevoice = list("All patched up!" = 'sound/voice/mpatchedup.ogg',"An apple a day keeps me away." = 'sound/voice/mapple.ogg',"Feel better soon!" = 'sound/voice/mfeelbetter.ogg')
 		var/message = pick(messagevoice)
 		speak(message)
-		playsound(loc, messagevoice[message], 50, 0, type = "voice")
+		playsound(loc, messagevoice[message], 50, 0, type = "voice") // hippie -- additional argument added for sound control options)
 		bot_reset()
 		return
 	else
@@ -540,7 +540,7 @@
 		drop_part(robot_arm, Tsec)
 
 	if(emagged && prob(25))
-		playsound(loc, 'sound/voice/minsult.ogg', 50, 0, type = "voice")
+		playsound(loc, 'sound/voice/minsult.ogg', 50, 0, type = "voice") // hippie -- additional argument added for sound control options)
 
 	do_sparks(3, TRUE, src)
 	..()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -390,7 +390,7 @@ Auto Patrol: []"},
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE)
+			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice")
 			visible_message("<b>[src]</b> points at [C.name]!")
 			mode = BOT_HUNT
 			INVOKE_ASYNC(src, .proc/handle_automated_action)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -390,7 +390,7 @@ Auto Patrol: []"},
 			target = C
 			oldtarget_name = C.name
 			speak("Level [threatlevel] infraction alert!")
-			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice")
+			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE, type = "voice") // hippie -- additional argument added for sound control options)
 			visible_message("<b>[src]</b> points at [C.name]!")
 			mode = BOT_HUNT
 			INVOKE_ASYNC(src, .proc/handle_automated_action)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
@@ -109,7 +109,7 @@
 		update_icons()
 		new /obj/effect/temp_visual/mook_dust(get_turf(src))
 		playsound(src, 'sound/weapons/thudswoosh.ogg', 25, 1)
-		playsound(src, 'sound/voice/mook_leap_yell.ogg', 100, 1, type = "voice")
+		playsound(src, 'sound/voice/mook_leap_yell.ogg', 100, 1, type = "voice") // hippie -- additional argument added for sound control options)
 		var/target_turf = get_turf(target)
 		throw_at(target_turf, 7, 1, src, FALSE, callback = CALLBACK(src, .proc/AttackRecovery))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
@@ -109,7 +109,7 @@
 		update_icons()
 		new /obj/effect/temp_visual/mook_dust(get_turf(src))
 		playsound(src, 'sound/weapons/thudswoosh.ogg', 25, 1)
-		playsound(src, 'sound/voice/mook_leap_yell.ogg', 100, 1)
+		playsound(src, 'sound/voice/mook_leap_yell.ogg', 100, 1, type = "voice")
 		var/target_turf = get_turf(target)
 		throw_at(target_turf, 7, 1, src, FALSE, callback = CALLBACK(src, .proc/AttackRecovery))
 		return

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -42,9 +42,9 @@
 /obj/item/photo/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!</span>")//when you wanna look at photo of waifu one last time before you die...
 	if (user.gender == MALE)
-		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, 1)//EVERY TIME I DO IT MAKES ME LAUGH
+		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, 1, type = "voice")//EVERY TIME I DO IT MAKES ME LAUGH
 	else if (user.gender == FEMALE)
-		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, 1)
+		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, 1, type = "voice")
 	return OXYLOSS
 
 /obj/item/photo/attack_self(mob/user)

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -42,9 +42,9 @@
 /obj/item/photo/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!</span>")//when you wanna look at photo of waifu one last time before you die...
 	if (user.gender == MALE)
-		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, 1, type = "voice")//EVERY TIME I DO IT MAKES ME LAUGH
+		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, 1, type = "voice") // hippie -- additional argument added for sound control options)//EVERY TIME I DO IT MAKES ME LAUGH
 	else if (user.gender == FEMALE)
-		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, 1, type = "voice")
+		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, 1, type = "voice") // hippie -- additional argument added for sound control options)
 	return OXYLOSS
 
 /obj/item/photo/attack_self(mob/user)

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -315,7 +315,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/repulse/xeno/cast(list/targets,mob/user = usr)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
-		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1, type = "voice")
+		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1, type = "voice") // hippie -- additional argument added for sound control options)
 		C.spin(6,1)
 	..(targets, user, 60)
 

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -315,7 +315,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/repulse/xeno/cast(list/targets,mob/user = usr)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
-		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1)
+		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1, type = "voice")
 		C.spin(6,1)
 	..(targets, user, 60)
 

--- a/hippiestation/code/game/objects/effects/effect_system/effects_cloud.dm
+++ b/hippiestation/code/game/objects/effects/effect_system/effects_cloud.dm
@@ -5,6 +5,6 @@
 
 /obj/effect/cloud/New()
 	..(loc)
-	playsound(loc, 'hippiestation/sound/voice/meeseeksspawn.ogg', 40, type = "voice")
+	playsound(loc, 'hippiestation/sound/voice/meeseeksspawn.ogg', 40, type = "voice") // hippie -- additional argument added for sound control options)
 	icon_state = "smoke"
 	QDEL_IN(src, 12)

--- a/hippiestation/code/game/objects/effects/effect_system/effects_cloud.dm
+++ b/hippiestation/code/game/objects/effects/effect_system/effects_cloud.dm
@@ -5,6 +5,6 @@
 
 /obj/effect/cloud/New()
 	..(loc)
-	playsound(loc, 'hippiestation/sound/voice/meeseeksspawn.ogg', 40)
+	playsound(loc, 'hippiestation/sound/voice/meeseeksspawn.ogg', 40, type = "voice")
 	icon_state = "smoke"
 	QDEL_IN(src, 12)

--- a/hippiestation/code/game/objects/items/devices/meeseeks_box.dm
+++ b/hippiestation/code/game/objects/items/devices/meeseeks_box.dm
@@ -71,7 +71,7 @@
 				meeseeks = null
 				masters = null
 				return
-			playsound(loc, 'hippiestation/sound/voice/cando.ogg', 40)
+			playsound(loc, 'hippiestation/sound/voice/cando.ogg', 40, type = "voice")
 			message_admins("[key_name_admin(user)] has summoned a Mr. Meeseeks([key_name_admin(meeseeks)]) with the request: [request]")
 			log_game("[key_name(user)] has summoned a Mr. Meeseeks([key_name(meeseeks)]) with the request: [request]")
 			if(meeseeks.mind)

--- a/hippiestation/code/game/objects/items/devices/meeseeks_box.dm
+++ b/hippiestation/code/game/objects/items/devices/meeseeks_box.dm
@@ -71,7 +71,7 @@
 				meeseeks = null
 				masters = null
 				return
-			playsound(loc, 'hippiestation/sound/voice/cando.ogg', 40, type = "voice")
+			playsound(loc, 'hippiestation/sound/voice/cando.ogg', 40, type = "voice") // hippie -- additional argument added for sound control options)
 			message_admins("[key_name_admin(user)] has summoned a Mr. Meeseeks([key_name_admin(meeseeks)]) with the request: [request]")
 			log_game("[key_name(user)] has summoned a Mr. Meeseeks([key_name(meeseeks)]) with the request: [request]")
 			if(meeseeks.mind)

--- a/hippiestation/code/modules/antagonists/changeling/horrorform.dm
+++ b/hippiestation/code/modules/antagonists/changeling/horrorform.dm
@@ -130,10 +130,10 @@
 				if(M_turf && M_turf.z == z)
 					var/dist = get_dist(M_turf, src)
 					if(dist <= 7) //source of sound very close
-						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream.ogg', 80, 1, frequency, falloff = 2)
+						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream.ogg', 80, 1, frequency, falloff = 2, type = "scream")
 					else
 						var/vol = CLAMP(100-((dist-7)*5), 10, 100) //Every tile decreases sound volume by 5
-						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream_reverb.ogg', vol, 1, frequency, falloff = 5)
+						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream_reverb.ogg', vol, 1, frequency, falloff = 5, type = "scream")
 				if(M.stat == DEAD && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(get_turf(src),null)))
 					M.show_message(message)
 		audible_message(message)

--- a/hippiestation/code/modules/antagonists/changeling/horrorform.dm
+++ b/hippiestation/code/modules/antagonists/changeling/horrorform.dm
@@ -130,10 +130,10 @@
 				if(M_turf && M_turf.z == z)
 					var/dist = get_dist(M_turf, src)
 					if(dist <= 7) //source of sound very close
-						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream.ogg', 80, 1, frequency, falloff = 2, type = "scream")
+						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream.ogg', 80, 1, frequency, falloff = 2, type = "scream") // hippie -- additional argument added for sound control options)
 					else
 						var/vol = CLAMP(100-((dist-7)*5), 10, 100) //Every tile decreases sound volume by 5
-						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream_reverb.ogg', vol, 1, frequency, falloff = 5, type = "scream")
+						M.playsound_local(src, 'hippiestation/sound/effects/horror_scream_reverb.ogg', vol, 1, frequency, falloff = 5, type = "scream") // hippie -- additional argument added for sound control options)
 				if(M.stat == DEAD && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(get_turf(src),null)))
 					M.show_message(message)
 		audible_message(message)

--- a/hippiestation/code/modules/client/preferences.dm
+++ b/hippiestation/code/modules/client/preferences.dm
@@ -10,6 +10,11 @@
 	var/gear_tab
 	max_save_slots = 6
 
+	//sound preferences
+	var/scream_volume = 100
+	var/other_volume = 100
+	var/voice_volume = 100
+
 /datum/preferences/New(client/C)
 	..()
 	LAZYINITLIST(chosen_gear)
@@ -27,11 +32,24 @@
 
 /datum/preferences/proc/process_hippie_link(mob/user, list/href_list)
 	if(href_list["task"] == "input")
-		if(href_list["preference"] == "ipc_screen")
-			var/new_ipc_screen
-			new_ipc_screen = input(user, "Choose your character's screen:", "Character Preference") as null|anything in GLOB.ipc_screens_list
-			if(new_ipc_screen)
-				features["ipc_screen"] = new_ipc_screen
+		switch(href_list["preference"])
+			if("ipc_screen")
+				var/new_ipc_screen
+				new_ipc_screen = input(user, "Choose your character's screen:", "Character Preference") as null|anything in GLOB.ipc_screens_list
+				if(new_ipc_screen)
+					features["ipc_screen"] = new_ipc_screen
+			if ("screamvol")
+				var/desired_scream_vol = input(user, "Choose your desired scream sound volume. (currently:[scream_volume]%)", "Character Preference", scream_volume)  as null|num
+				if (!isnull(desired_scream_vol))
+					scream_volume = desired_scream_vol
+			if ("voicevol")
+				var/desired_voice_vol = input(user, "Choose your desired voice sound volume. (currently:[voice_volume]%)", "Character Preference", voice_volume)  as null|num
+				if (!isnull(desired_voice_vol))
+					voice_volume = desired_voice_vol
+			if ("othervol")
+				var/desired_other_vol = input(user, "Choose your desired sound volume for non voice/scream sounds. (currently:[other_volume]%)", "Character Preference", other_volume)  as null|num
+				if (!isnull(desired_other_vol))
+					other_volume = desired_other_vol
 	if(href_list["preference"] == "gear")
 		if(href_list["clear_loadout"])
 			LAZYCLEARLIST(chosen_gear)
@@ -59,6 +77,11 @@
 
 /datum/preferences/proc/hippie_dat_replace(current_tab)
 	//This proc is for menus other than game pref and char pref
+	if(current_tab == 2)
+		. += "<h2>Sound Settings</h2>"
+		. += "<b>Scream Volume:</b> <a href='?_src_=prefs;preference=screamvol;task=input'>[scream_volume]%</a><br>"
+		. += "<b>Voice Volume:</b> <a href='?_src_=prefs;preference=voicevol;task=input'>[voice_volume]%</a><br>"
+		. += "<b>Main Volume:</b> <a href='?_src_=prefs;preference=othervol;task=input'>[other_volume]%</a><br>"
 	if(current_tab == 3)
 		if(!gear_tab)
 			gear_tab = GLOB.loadout_items[1]

--- a/hippiestation/code/modules/clothing/masks/hailer.dm
+++ b/hippiestation/code/modules/clothing/masks/hailer.dm
@@ -208,6 +208,6 @@
 				phrase_sound = 'hippiestation/sound/voice/complionator/bane8.ogg'
 
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[phrase_text]</b></font>")
-		playsound(src.loc, phrase_sound, 100, 0, 4)
+		playsound(src.loc, phrase_sound, 100, 0, 4, type = "voice")
 		cooldown = world.time
 		cooldown_special = world.time

--- a/hippiestation/code/modules/clothing/masks/hailer.dm
+++ b/hippiestation/code/modules/clothing/masks/hailer.dm
@@ -208,6 +208,6 @@
 				phrase_sound = 'hippiestation/sound/voice/complionator/bane8.ogg'
 
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[phrase_text]</b></font>")
-		playsound(src.loc, phrase_sound, 100, 0, 4, type = "voice")
+		playsound(src.loc, phrase_sound, 100, 0, 4, type = "voice") // hippie -- additional argument added for sound control options)
 		cooldown = world.time
 		cooldown_special = world.time

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/meeseeks.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/meeseeks.dm
@@ -46,7 +46,7 @@
 		message_admins("[key_name_admin(H)] has become a stage-two Mr. Meeseeks.")
 		log_game("[key_name(H)] has become a stage-two Mr. Meeseeks.")
 		to_chat(H, "<span class='userdanger'>You're starting to feel desperate. Help your master quickly! Meeseeks aren't meant to exist this long!</span>")
-		playsound(H.loc, 'hippiestation/sound/voice/meeseeks2.ogg', 40, 0, 1)
+		playsound(H.loc, 'hippiestation/sound/voice/meeseeks2.ogg', 40, 0, 1, type="voice")
 		to_chat(master, "<span class='danger'>Your Mr. Meeseeks is getting sick of existing!</span>")
 	if(stage_ticks == MEESEEKS_TICKS_STAGE_THREE)
 		message_admins("[key_name_admin(H)] has become a stage-three Mr. Meeseeks.")
@@ -61,7 +61,7 @@
 		H.mind.objectives += killmaster
 		killmaster.owner = H.mind
 		objective = killmaster
-		playsound(H.loc, 'hippiestation/sound/voice/meeseeks3.ogg', 40, 0, 1)
+		playsound(H.loc, 'hippiestation/sound/voice/meeseeks3.ogg', 40, 0, 1, type="voice")
 	stage_ticks++
 
 /proc/destroy_meeseeks(mob/living/carbon/human/H, datum/species/meeseeks/SM)

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/meeseeks.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/meeseeks.dm
@@ -46,7 +46,7 @@
 		message_admins("[key_name_admin(H)] has become a stage-two Mr. Meeseeks.")
 		log_game("[key_name(H)] has become a stage-two Mr. Meeseeks.")
 		to_chat(H, "<span class='userdanger'>You're starting to feel desperate. Help your master quickly! Meeseeks aren't meant to exist this long!</span>")
-		playsound(H.loc, 'hippiestation/sound/voice/meeseeks2.ogg', 40, 0, 1, type="voice")
+		playsound(H.loc, 'hippiestation/sound/voice/meeseeks2.ogg', 40, 0, 1, type="voice") // hippie -- additional argument added for sound control options
 		to_chat(master, "<span class='danger'>Your Mr. Meeseeks is getting sick of existing!</span>")
 	if(stage_ticks == MEESEEKS_TICKS_STAGE_THREE)
 		message_admins("[key_name_admin(H)] has become a stage-three Mr. Meeseeks.")
@@ -61,7 +61,7 @@
 		H.mind.objectives += killmaster
 		killmaster.owner = H.mind
 		objective = killmaster
-		playsound(H.loc, 'hippiestation/sound/voice/meeseeks3.ogg', 40, 0, 1, type="voice")
+		playsound(H.loc, 'hippiestation/sound/voice/meeseeks3.ogg', 40, 0, 1, type="voice") // hippie -- additional argument added for sound control options
 	stage_ticks++
 
 /proc/destroy_meeseeks(mob/living/carbon/human/H, datum/species/meeseeks/SM)

--- a/hippiestation/code/modules/mob/living/emote.dm
+++ b/hippiestation/code/modules/mob/living/emote.dm
@@ -45,7 +45,7 @@
 		LAZYINITLIST(user.alternate_screams)
 		if(LAZYLEN(user.alternate_screams))
 			sound = pick(user.alternate_screams)
-		playsound(user.loc, sound, user.scream_vol, 1, 4, 1.2, type = "scream")
+		playsound(user.loc, sound, user.scream_vol, 1, 4, 1.2, type = "scream") // hippie -- additional argument added for sound control options)
 		message = "screams!"
 	else if(miming)
 		message = "acts out a scream."
@@ -79,7 +79,7 @@
 		var/coughsound = pick('hippiestation/sound/voice/cough1.ogg', 'hippiestation/sound/voice/cough2.ogg', 'hippiestation/sound/voice/cough3.ogg', 'hippiestation/sound/voice/cough4.ogg')
 		if(user.gender == FEMALE)
 			coughsound = pick('hippiestation/sound/voice/cough_f1.ogg', 'hippiestation/sound/voice/cough_f2.ogg', 'hippiestation/sound/voice/cough_f3.ogg')
-		playsound(user.loc, coughsound, 50, 1, 5, type="voice")
+		playsound(user.loc, coughsound, 50, 1, 5, type="voice") // hippie -- additional argument added for sound control options
 		user.adjustOxyLoss(5)
 
 /datum/emote/living/snap
@@ -96,7 +96,7 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap.ogg', 50, 1, -1, type="voice")
+		playsound(user, 'hippiestation/sound/voice/snap.ogg', 50, 1, -1, type="voice") // hippie -- additional argument added for sound control options
 
 /datum/emote/living/snap2
 	key = "snap2"
@@ -112,7 +112,7 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap2.ogg', 50, 1, -1, type="voice")
+		playsound(user, 'hippiestation/sound/voice/snap2.ogg', 50, 1, -1, type="voice") // hippie -- additional argument added for sound control options
 
 /datum/emote/living/snap3
 	key = "snap3"
@@ -128,4 +128,4 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap3.ogg', 50, 1, -1, type="voice")
+		playsound(user, 'hippiestation/sound/voice/snap3.ogg', 50, 1, -1, type="voice") // hippie -- additional argument added for sound control options

--- a/hippiestation/code/modules/mob/living/emote.dm
+++ b/hippiestation/code/modules/mob/living/emote.dm
@@ -45,7 +45,7 @@
 		LAZYINITLIST(user.alternate_screams)
 		if(LAZYLEN(user.alternate_screams))
 			sound = pick(user.alternate_screams)
-		playsound(user.loc, sound, user.scream_vol, 1, 4, 1.2)
+		playsound(user.loc, sound, user.scream_vol, 1, 4, 1.2, type = "scream")
 		message = "screams!"
 	else if(miming)
 		message = "acts out a scream."
@@ -79,7 +79,7 @@
 		var/coughsound = pick('hippiestation/sound/voice/cough1.ogg', 'hippiestation/sound/voice/cough2.ogg', 'hippiestation/sound/voice/cough3.ogg', 'hippiestation/sound/voice/cough4.ogg')
 		if(user.gender == FEMALE)
 			coughsound = pick('hippiestation/sound/voice/cough_f1.ogg', 'hippiestation/sound/voice/cough_f2.ogg', 'hippiestation/sound/voice/cough_f3.ogg')
-		playsound(user.loc, coughsound, 50, 1, 5)
+		playsound(user.loc, coughsound, 50, 1, 5, type="voice")
 		user.adjustOxyLoss(5)
 
 /datum/emote/living/snap
@@ -96,7 +96,7 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap.ogg', 50, 1, -1)
+		playsound(user, 'hippiestation/sound/voice/snap.ogg', 50, 1, -1, type="voice")
 
 /datum/emote/living/snap2
 	key = "snap2"
@@ -112,7 +112,7 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap2.ogg', 50, 1, -1)
+		playsound(user, 'hippiestation/sound/voice/snap2.ogg', 50, 1, -1, type="voice")
 
 /datum/emote/living/snap3
 	key = "snap3"
@@ -128,4 +128,4 @@
 		if(user.nextsoundemote >= world.time)
 			return
 		user.nextsoundemote = world.time + 7
-		playsound(user, 'hippiestation/sound/voice/snap3.ogg', 50, 1, -1)
+		playsound(user, 'hippiestation/sound/voice/snap3.ogg', 50, 1, -1, type="voice")

--- a/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
@@ -196,7 +196,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				H.blur_eyes(1)
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 1)
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 1, type="voice")
 
 			if(prob(5))
 				H.playsound_local(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 5)
@@ -215,10 +215,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				to_chat(H, "<span class='warning'>The floor shifts underneath you!</span>")
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2.ogg', 2)
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2.ogg', 2, type="voice")
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 2)
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 2, type="voice")
 
 			if(prob(5))
 				H.playsound_local(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 10)
@@ -259,10 +259,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				playsound(src,pick('sound/spookoween/scary_horn.ogg', 'sound/spookoween/scary_horn2.ogg', 'sound/spookoween/scary_horn3.ogg'), 30, 1)
 
 			if(prob(3))
-				playsound(src,'hippiestation/sound/voice/cluwnelaugh1.ogg', 30, 1)
+				playsound(src,'hippiestation/sound/voice/cluwnelaugh1.ogg', 30, 1, type="voice")
 
 			if(prob(3))
-				playsound(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 30, 1)
+				playsound(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 30, 1, type="voice")
 
 			if(prob(5))
 				playsound(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 30, 1)
@@ -339,10 +339,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 		if(do_after(src, 10, target = H))
 			step_towards(H, src)
-			playsound(H, pick('hippiestation/sound/effects/bodyscrape-01.ogg', 'hippiestation/sound/effects/bodyscrape-02.ogg'), 20, 1, -4)
+			playsound(H, pick('hippiestation/sound/effects/bodyscrape-01.ogg', 'hippiestation/sound/effects/bodyscrape-02.ogg'), 20, 1, -4, type = "voice")
 			H.emote("scream")
 			if(prob(25))
-				playsound(src, pick('hippiestation/sound/voice/cluwnelaugh1.ogg', 'hippiestation/sound/voice/cluwnelaugh2.ogg', 'hippiestation/sound/voice/cluwnelaugh3.ogg'), 50, 1)
+				playsound(src, pick('hippiestation/sound/voice/cluwnelaugh1.ogg', 'hippiestation/sound/voice/cluwnelaugh2.ogg', 'hippiestation/sound/voice/cluwnelaugh3.ogg'), 50, 1, type="voice")
 
 	if(get_dist(src,H) <= 1)
 		visible_message("<span class='danger'>[src] begins dragging [H] under the floor!</span>")

--- a/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
@@ -196,7 +196,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				H.blur_eyes(1)
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 1, type="voice")
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 1, type="voice") // hippie -- additional argument added for sound control options
 
 			if(prob(5))
 				H.playsound_local(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 5)
@@ -215,10 +215,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				to_chat(H, "<span class='warning'>The floor shifts underneath you!</span>")
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2.ogg', 2, type="voice")
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2.ogg', 2, type="voice") // hippie -- additional argument added for sound control options
 
 			if(prob(5))
-				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 2, type="voice")
+				H.playsound_local(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 2, type="voice") // hippie -- additional argument added for sound control options
 
 			if(prob(5))
 				H.playsound_local(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 10)
@@ -259,10 +259,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 				playsound(src,pick('sound/spookoween/scary_horn.ogg', 'sound/spookoween/scary_horn2.ogg', 'sound/spookoween/scary_horn3.ogg'), 30, 1)
 
 			if(prob(3))
-				playsound(src,'hippiestation/sound/voice/cluwnelaugh1.ogg', 30, 1, type="voice")
+				playsound(src,'hippiestation/sound/voice/cluwnelaugh1.ogg', 30, 1, type="voice") // hippie -- additional argument added for sound control options
 
 			if(prob(3))
-				playsound(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 30, 1, type="voice")
+				playsound(src,'hippiestation/sound/voice/cluwnelaugh2_reversed.ogg', 30, 1, type="voice") // hippie -- additional argument added for sound control options
 
 			if(prob(5))
 				playsound(src,'hippiestation/sound/misc/bikehorn_creepy.ogg', 30, 1)
@@ -339,10 +339,10 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 		if(do_after(src, 10, target = H))
 			step_towards(H, src)
-			playsound(H, pick('hippiestation/sound/effects/bodyscrape-01.ogg', 'hippiestation/sound/effects/bodyscrape-02.ogg'), 20, 1, -4, type = "voice")
+			playsound(H, pick('hippiestation/sound/effects/bodyscrape-01.ogg', 'hippiestation/sound/effects/bodyscrape-02.ogg'), 20, 1, -4, type = "voice") // hippie -- additional argument added for sound control options)
 			H.emote("scream")
 			if(prob(25))
-				playsound(src, pick('hippiestation/sound/voice/cluwnelaugh1.ogg', 'hippiestation/sound/voice/cluwnelaugh2.ogg', 'hippiestation/sound/voice/cluwnelaugh3.ogg'), 50, 1, type="voice")
+				playsound(src, pick('hippiestation/sound/voice/cluwnelaugh1.ogg', 'hippiestation/sound/voice/cluwnelaugh2.ogg', 'hippiestation/sound/voice/cluwnelaugh3.ogg'), 50, 1, type="voice") // hippie -- additional argument added for sound control options
 
 	if(get_dist(src,H) <= 1)
 		visible_message("<span class='danger'>[src] begins dragging [H] under the floor!</span>")

--- a/hippiestation/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -12,7 +12,7 @@
 	addtimer(CALLBACK(src, .proc/catscreech), 95)
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/catscreech()
-	playsound(src, 'hippiestation/sound/voice/scream_cat.ogg', 75, 1, type = "voice") //REE
+	playsound(src, 'hippiestation/sound/voice/scream_cat.ogg', 75, 1, type = "voice") // hippie -- additional argument added for sound control options) //REE
 	SpinAnimation(500,1)
 	animate(src, transform = matrix()*1.5, time = 5)
 	addtimer(CALLBACK(src, .proc/catsplode), 5) //comedic timing

--- a/hippiestation/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -12,7 +12,7 @@
 	addtimer(CALLBACK(src, .proc/catscreech), 95)
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/catscreech()
-	playsound(src, 'hippiestation/sound/voice/scream_cat.ogg', 75, 1) //REE
+	playsound(src, 'hippiestation/sound/voice/scream_cat.ogg', 75, 1, type = "voice") //REE
 	SpinAnimation(500,1)
 	animate(src, transform = matrix()*1.5, time = 5)
 	addtimer(CALLBACK(src, .proc/catsplode), 5) //comedic timing


### PR DESCRIPTION
Adds new sound options in the OOC preferences tab on character setup. I'll probably make further PRs with new options and tweaks to avoid one overly huge PR with hundreds of file changes. 

Allows players to set their own sound volume for voices (things said ingame), screaming sounds, and anything that isn't the previous two things.

Does not affect adminhelps or mentorhelps, as due to being relatively ancient code they use a different proc entirely to playsound, which was modified to allow these new options to happen. They'll need to be adjusted in the future if sound options are desired for those. Also does not affect anything that does not use the playsound proc, such as round-end or round-start sounds. 

![screenshot_1](https://user-images.githubusercontent.com/7481072/44442953-0248bc00-a5cd-11e8-9fd2-494237fdbf12.png)


