### PR TITLE
[READY] Fixes drift crawling in space while crit

### DIFF
--- a/hippiestation/code/modules/mob/mob_movement.dm
+++ b/hippiestation/code/modules/mob/mob_movement.dm
@@ -50,7 +50,7 @@
 
 /mob/living/carbon/Move(atom/newloc, direct)
 	. = ..(newloc, direct)
-	if(lying && !pulledby && !buckled && (stat == SOFT_CRIT || get_num_legs() == 0))
+	if(lying && !pulledby && !buckled && (stat == SOFT_CRIT || get_num_legs() == 0) && !inertia_moving)
 		if(stat == SOFT_CRIT)
 			visible_message("<span class='danger'>[src] painfully crawls forward!</span>", "<span class='userdanger'>You crawl forward at the expense of some of your strength.</span>")
 			apply_damage(1, OXY)


### PR DESCRIPTION
Fixes #4955 only nearly a year after even though it's priority:high, nice

:cl:
fix: Humans won't crawl while moving in space due to inertia anymore.
/:cl:

