### PR TITLE
[READY] Fixes mindshield nanites fucking up gangs badly

### DIFF
--- a/hippiestation/code/modules/antagonists/gang/gang.dm
+++ b/hippiestation/code/modules/antagonists/gang/gang.dm
@@ -12,8 +12,6 @@
 	if(.)
 		if(new_owner.unconvertable)
 			return FALSE
-		if(new_owner.current && new_owner.current.has_trait(TRAIT_MINDSHIELD))
-			return FALSE
 
 /datum/antagonist/gang/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current


### PR DESCRIPTION

:cl:
fix: Mindshield nanites won't fuck up gangs and other gamemodes anymore.
/:cl:

Mindshield is already checked in the pen convert proc. Implant breaker bypasses the check entirely, so this should work.