### PR TITLE
Fixes reagent dispensers icons and adds glow in dark locker lights

### DIFF
--- a/hippiestation/code/game/objects/structures/crates_lockers/closets.dm
+++ b/hippiestation/code/game/objects/structures/crates_lockers/closets.dm
@@ -7,3 +7,26 @@ Sorry for doing this, but apparently the Hippie community hates art and new thin
 
 /obj/structure/closet
 	icon_hippie = 'hippiestation/icons/obj/closet.dmi'
+
+/obj/structure/closet/update_icon()
+	cut_overlays()
+	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
+	if(!opened)
+		layer = OBJ_LAYER
+		if(icon_door)
+			add_overlay("[icon_door]_door")
+		else
+			add_overlay("[icon_state]_door")
+		if(welded)
+			add_overlay("welded")
+		if(secure && !broken)
+			if(locked)
+				SSvis_overlays.add_vis_overlay(src, icon, "locked", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
+			else
+				SSvis_overlays.add_vis_overlay(src, icon, "unlocked", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
+	else
+		layer = BELOW_OBJ_LAYER
+		if(icon_door_override)
+			add_overlay("[icon_door]_open")
+		else
+			add_overlay("[icon_state]_open")

--- a/hippiestation/code/modules/reagents/reagent_dispenser.dm
+++ b/hippiestation/code/modules/reagents/reagent_dispenser.dm
@@ -21,7 +21,7 @@
 	if(!use_reagent_icon)
 		return
 	cut_overlays()
-	if(reagent_icon && reagents.total_volume)
+	if(reagent_icon && reagents && reagents.total_volume)
 		reagent_icon.icon_state = "tankfilling[CLAMP(round(reagents.total_volume / (tank_volume * 0.2)), 1, 4)]"
 		reagent_icon.color = mix_color_from_reagents(reagents.reagent_list)
 		add_overlay(reagent_icon)

--- a/hippiestation/code/modules/reagents/reagent_dispenser.dm
+++ b/hippiestation/code/modules/reagents/reagent_dispenser.dm
@@ -3,6 +3,10 @@
 	var/mutable_appearance/reagent_icon
 	var/use_reagent_icon = FALSE
 
+/obj/structure/reagent_dispensers/Initialize()
+	generate_reagent_icon()
+	. = ..()
+
 /obj/structure/reagent_dispensers/water_cooler
 	icon_hippie = 'hippiestation/icons/obj/vending.dmi'
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
add: Locker lights now appear visible in the dark
fix: Fuel and watertanks have been fixed and properly show their reagent icons
/:cl:

[why]: 
![image](https://user-images.githubusercontent.com/32651551/44826165-cb316680-abdb-11e8-954b-f01d075cd05e.png)
![image](https://user-images.githubusercontent.com/32651551/44826167-ce2c5700-abdb-11e8-951e-40b88c7378c6.png)


Thoughts?