### PR TITLE
[CURRENTLY REOPENED ON TG] Giving circuits possibility to load item while in assembly

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3019,6 +3019,8 @@
 #include "hippiestation\code\modules\hydroponics\buttflower.dm"
 #include "hippiestation\code\modules\hydroponics\limbflower.dm"
 #include "hippiestation\code\modules\hydroponics\seed_extractor.dm"
+#include "hippiestation\code\modules\integrated_electronics\core\assemblies.dm"
+#include "hippiestation\code\modules\integrated_electronics\core\integrated_circuit.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\input.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\lists.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\manipulation.dm"

--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -1,0 +1,114 @@
+/obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
+	if(can_anchor && default_unfasten_wrench(user, I, 20))
+		return
+	if(istype(I, /obj/item/integrated_circuit))
+		if(!user.canUnEquip(I))
+			return FALSE
+		if(try_add_component(I, user))
+			return TRUE
+		else
+			for(var/obj/item/integrated_circuit/input/S in assembly_components)
+				S.attackby_react(I,user,user.a_intent)
+			return ..()
+	else if(istype(I, /obj/item/multitool) || istype(I, /obj/item/integrated_electronics/wirer) || istype(I, /obj/item/integrated_electronics/debugger))
+		if(opened)
+			interact(user)
+			return TRUE
+		else
+			to_chat(user, "<span class='warning'>[src]'s hatch is closed, so you can't fiddle with the internal components.</span>")
+			for(var/obj/item/integrated_circuit/input/S in assembly_components)
+				S.attackby_react(I,user,user.a_intent)
+			return ..()
+	else if(istype(I, /obj/item/stock_parts/cell))
+		if(!opened)
+			to_chat(user, "<span class='warning'>[src]'s hatch is closed, so you can't access \the [src]'s power supplier.</span>")
+			for(var/obj/item/integrated_circuit/input/S in assembly_components)
+				S.attackby_react(I,user,user.a_intent)
+			return ..()
+		if(battery)
+			to_chat(user, "<span class='warning'>[src] already has \a [battery] installed. Remove it first if you want to replace it.</span>")
+			for(var/obj/item/integrated_circuit/input/S in assembly_components)
+				S.attackby_react(I,user,user.a_intent)
+			return ..()
+		I.forceMove(src)
+		battery = I
+		diag_hud_set_circuitstat() //update diagnostic hud
+		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+		to_chat(user, "<span class='notice'>You slot \the [I] inside \the [src]'s power supplier.</span>")
+		return TRUE
+	else if(istype(I, /obj/item/integrated_electronics/detailer))
+		var/obj/item/integrated_electronics/detailer/D = I
+		detail_color = D.detail_color
+		update_icon()
+	else
+		if(user.a_intent != "help")
+			return ..()
+		var/list/input_selection = list()
+		//Check all the components asking for an input
+		for(var/obj/item/integrated_circuit/input in assembly_components)
+			if((input.demands_object_input && opened) || (input.demands_object_input && input.can_input_object_when_closed))
+				var/i = 0
+				//Check if there is another component with the same name and append a number for identification
+				for(var/s in input_selection)
+					var/obj/item/integrated_circuit/s_circuit = input_selection[s]
+					if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
+						i++
+				var/disp_name= "[input.displayed_name] \[[input]\]"
+				if(i)
+					disp_name += " ([i+1])"
+				//Associative lists prevent me from needing another list and using a Find proc
+				input_selection[disp_name] = input
+
+		var/obj/item/integrated_circuit/choice
+		if(input_selection)
+			if(input_selection.len == 1)
+				choice = input_selection[input_selection[1]]
+			else
+				var/selection = input(user, "Where do you want to insert that item?", "Interaction") as null|anything in input_selection
+				if(!check_interactivity(user))
+					return ..()
+				if(selection)
+					choice = input_selection[selection]
+			if(choice)
+				choice.additem(I, user)
+		for(var/obj/item/integrated_circuit/input/S in assembly_components)
+			S.attackby_react(I,user,user.a_intent)
+		return ..()
+
+/obj/item/electronic_assembly/attack_self(mob/user)
+	if(!check_interactivity(user))
+		return
+	if(opened)
+		interact(user)
+
+	var/list/input_selection = list()
+	//Check all the components asking for an input
+	for(var/obj/item/integrated_circuit/input/input in assembly_components)
+		if(input.can_be_asked_input)
+			var/i = 0
+			//Check if there is another component with the same name and append a number for identification
+			for(var/s in input_selection)
+				var/obj/item/integrated_circuit/s_circuit = input_selection[s]
+				if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
+					i++
+			var/disp_name= "[input.displayed_name] \[[input]\]"
+			if(i)
+				disp_name += " ([i+1])"
+			//Associative lists prevent me from needing another list and using a Find proc
+			input_selection[disp_name] = input
+
+	var/obj/item/integrated_circuit/input/choice
+
+
+	if(input_selection)
+		if(input_selection.len ==1)
+			choice = input_selection[input_selection[1]]
+		else
+			var/selection = input(user, "What do you want to interact with?", "Interaction") as null|anything in input_selection
+			if(!check_interactivity(user))
+				return
+			if(selection)
+				choice = input_selection.[selection]
+
+	if(choice)
+		choice.ask_for_input(user)

--- a/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -1,5 +1,5 @@
 /obj/item/integrated_circuit
-  var/demands_object_input = FALSE
+	var/demands_object_input = FALSE
 	var/can_input_object_when_closed = FALSE
 
 // Can be called via electronic_assembly/attackby(). This also helps in case you want a circuit to behave differently

--- a/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -1,0 +1,7 @@
+/obj/item/integrated_circuit
+  var/demands_object_input = FALSE
+	var/can_input_object_when_closed = FALSE
+
+// Can be called via electronic_assembly/attackby(). This also helps in case you want a circuit to behave differently
+/obj/item/integrated_circuit/proc/additem(var/obj/item/I, var/mob/living/user)
+	attackby(I, user)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -2,7 +2,7 @@
 	return // thrown damage to 0 was disabled
 
 //You can insert weapons into finished assemblies
-/obj/item/integrated_circuit/manipulation/weapon_firing/var/demands_object_input = TRUE
+/obj/item/integrated_circuit/manipulation/weapon_firing/demands_object_input = TRUE
 
 //Same for grenades
-/obj/item/integrated_circuit/manipulation/grenade/var/demands_object_input = TRUE
+/obj/item/integrated_circuit/manipulation/grenade/demands_object_input = TRUE

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -1,2 +1,8 @@
 /obj/item/integrated_circuit/manipulation/thrower/post_throw(obj/item/A)
 	return // thrown damage to 0 was disabled
+
+//You can insert weapons into finished assemblies
+/obj/item/integrated_circuit/manipulation/weapon_firing/var/demands_object_input = TRUE
+
+//Same for grenades
+/obj/item/integrated_circuit/manipulation/grenade/var/demands_object_input = TRUE

--- a/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
@@ -25,6 +25,7 @@
 	power_draw_per_use = 150
 	can_be_asked_input = TRUE
 	var/obj/item/mmi/installed_brain
+	demands_object_input = TRUE
 
 /obj/item/integrated_circuit/input/mmi_tank/attackby(var/obj/item/mmi/O, var/mob/user)
 	if(!istype(O,/obj/item/mmi))
@@ -153,6 +154,7 @@
 	power_draw_per_use = 150
 	can_be_asked_input = TRUE
 	var/obj/item/paicard/installed_pai
+	demands_object_input = TRUE
 
 /obj/item/integrated_circuit/input/pAI_connector/attackby(var/obj/item/paicard/O, var/mob/user)
 	if(!istype(O,/obj/item/paicard))


### PR DESCRIPTION
Ok folks, it's all in there: https://github.com/tgstation/tgstation/pull/39454
Just let travis do his job to see if I modularized it all right plz. For the rest, I'm just too lazy and this is a copy paste:
[Changelogs]: #Adds the demand_object_input var and change the attackby() script so certain circuits can get an item while they are in an assembly. Also changed the attack_self proc so it doesn't require 2 lists and a list.Find() proc. It only uses 1 list now and that should do the trick. Also fixed a bug where the battery was inserted in the assembly but rather showed up on the location of the assembly instead of going into its contents.

:cl: Shdorsh
tweak:  Makes it possible to create circuits that can get an item loaded into them while they are in an assembly and the assembly is open, notable MMI tank and pAI connector so players can be circuited more easily.
code:  Optimized electronic assemblies also.
fix:  A bug pertaining putting batteries in assemblies.
/:cl:

[why]: # Initiating 2 lists is unneeded, so I optimized it all a little bit. Also, makes it easier to craft circuits.

Also, screw it, if tg can't review anything that's been done, tested and is ready for like a month or so I got nothing more to add. I even added a nice bugfix and code optimization just for them.