### PR TITLE
Fixes chem dispenser icon disappearing when power turns off

### DIFF
--- a/hippiestation/code/modules/reagents/machinery.dm
+++ b/hippiestation/code/modules/reagents/machinery.dm
@@ -1,5 +1,7 @@
 /obj/machinery/chem_dispenser
 	icon_hippie = 'hippiestation/icons/obj/chemical.dmi'
+	working_state = "dispenser"
+	nopower_state = "dispenser"
 
 /obj/machinery/chem_master
 	icon_hippie = 'hippiestation/icons/obj/chemical.dmi'


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixed chem dispenser disappearing when power goes out.
/:cl:

[why]: 
Fixes #8832 