### PR TITLE
Fixed preferences

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -16,7 +16,7 @@
 #define DISABLE_ARRIVALRATTLE	(1<<13)
 #define COMBOHUD_LIGHTING		(1<<14)
 
-#define SOUND_TTS               (1<<20) // hippie -- using 20 to allow tg to use 15 and on
+#define SOUND_TTS               (1<<15) // hippie -- using 20 to allow tg to use 15 and on
 
 #define TOGGLES_DEFAULT (SOUND_ADMINHELP|SOUND_MIDI|SOUND_AMBIENCE|SOUND_LOBBY|MEMBER_PUBLIC|INTENT_STYLE|MIDROUND_ANTAG|SOUND_INSTRUMENTS|SOUND_SHIP_AMBIENCE|SOUND_PRAYERS|SOUND_ANNOUNCEMENTS|SOUND_TTS) // hippie -- added tts
 

--- a/hippiestation/code/modules/client/preferences_toggles.dm
+++ b/hippiestation/code/modules/client/preferences_toggles.dm
@@ -9,3 +9,5 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggletts)()
 	else
 		to_chat(usr, "You will no longer hear text-to-speech sounds.")
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Hearing Text-to-Speech", "[usr.client.prefs.toggles & SOUND_TTS ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/verbs/menu/Settings/Sound/toggletts/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_TTS


### PR DESCRIPTION
:cl: JohnGinnane
fix: Fixed preferences not saving/loading properly, my bad!
/:cl:

[why]: Turns out using a large number for the define caused the number to mess up and not work correctly, so I've set it to 15 for now

In future I might look into creating our own preference toggles so we can avoid conflicting with /tg/

@Carbonhell can you speed merge this as it's bug fix

Fixes https://github.com/HippieStation/HippieStation/issues/8888