### PR TITLE
Improves pool code and makes makes more objects return initialize hints [READY]

### DIFF
--- a/hippiestation/code/controllers/subsystem/ticker.dm
+++ b/hippiestation/code/controllers/subsystem/ticker.dm
@@ -2,8 +2,8 @@
 	var/login_music_name					// hippie - song name displayed when title theme plays
 
 /datum/controller/subsystem/ticker/Initialize(timeofday)
-	..()
 	login_music_name = pop(splittext(login_music, "/")) // title name will be last element of the list
+	.=..()
 
 /datum/controller/subsystem/ticker/Shutdown()
 	gather_newscaster() //called here so we ensure the log is created even upon admin reboot

--- a/hippiestation/code/datums/components/spell_catalyst.dm
+++ b/hippiestation/code/datums/components/spell_catalyst.dm
@@ -3,6 +3,7 @@
 
 /datum/component/spell_catalyst/Initialize()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE,.proc/OnExamine)
+	.=..()
 
 /datum/component/spell_catalyst/proc/OnExamine(datum/source, mob/user)
 	to_chat(user, "<span class='notice'>[parent] gives off a gentle, magical blue glow.</span>")

--- a/hippiestation/code/datums/dna.dm
+++ b/hippiestation/code/datums/dna.dm
@@ -10,8 +10,8 @@
 			tts_voice = pick("dennis", "frank", "harry", "kit", "paul")
 
 /datum/dna/initialize_dna()
-	. = ..()
 	create_random_voice()
+	.=..()
 
 /datum/dna/transfer_identity(mob/living/carbon/destination)
 	. = ..()

--- a/hippiestation/code/game/gamemodes/gangs/dominator.dm
+++ b/hippiestation/code/game/gamemodes/gangs/dominator.dm
@@ -21,13 +21,13 @@
 	var/obj/effect/countdown/dominator/countdown
 
 /obj/machinery/dominator/Initialize()
-	. = ..()
 	set_light(2)
 	GLOB.poi_list |= src
 	spark_system = new
 	spark_system.set_up(5, TRUE, src)
 	countdown = new(src)
 	update_icon()
+	.=..()
 
 /obj/machinery/dominator/Destroy()
 	if(!(stat & BROKEN))

--- a/hippiestation/code/game/gamemodes/gangs/gang_pen.dm
+++ b/hippiestation/code/game/gamemodes/gangs/gang_pen.dm
@@ -6,8 +6,8 @@
 	var/last_used
 
 /obj/item/pen/gang/Initialize()
-	..()
 	last_used = world.time
+	.=..()
 
 /obj/item/pen/gang/attack(mob/living/M, mob/user, stealth = TRUE)
 	if(!istype(M))

--- a/hippiestation/code/game/gamemodes/gangs/gangtool.dm
+++ b/hippiestation/code/game/gamemodes/gangs/gangtool.dm
@@ -21,7 +21,6 @@
 	var/list/tags = list()
 
 /obj/item/device/gangtool/Initialize()
-	..()
 	update_icon()
 	for(var/i in subtypesof(/datum/gang_item))
 		var/datum/gang_item/G = i
@@ -31,6 +30,7 @@
 			if(!islist(buyable_items[cat]))
 				buyable_items[cat] = list()
 			buyable_items[cat][id] = new G
+	.=..()
 
 /obj/item/device/gangtool/Destroy()
 	if(gang)

--- a/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -16,11 +16,11 @@
 			return FALSE
 
 /obj/effect/proc_holder/spell/Initialize()
-	. = ..()
 	if(vamp_req)
 		clothes_req = FALSE
 		range = 1
 		human_req = FALSE //so we can cast stuff while a bat, too
+	.=..()
 
 
 /obj/effect/proc_holder/spell/before_cast(list/targets)
@@ -152,8 +152,8 @@
 	vamp_req = TRUE
 
 /obj/effect/proc_holder/spell/self/cloak/Initialize()
-	. = ..()
 	update_name()
+	.=..()
 
 /obj/effect/proc_holder/spell/self/cloak/proc/update_name()
 	var/mob/living/user = loc
@@ -255,8 +255,8 @@
 	vamp_req = TRUE
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/mistform/Initialize()
-	. = ..()
 	range = -1
+	.=..()
 
 /obj/effect/proc_holder/spell/targeted/vampirize
 	name = "Lilith's Pact (500)"

--- a/hippiestation/code/game/machinery/doors/blastco.dm
+++ b/hippiestation/code/game/machinery/doors/blastco.dm
@@ -4,6 +4,6 @@
 var/list/global/blastco_doors
 
 /obj/machinery/door/poddoor/shutters/blastco/Initialize()
-	. = ..()
 	LAZYINITLIST(blastco_doors)
 	LAZYADD(blastco_doors, src)
+	.=..()

--- a/hippiestation/code/game/machinery/reagent_forge.dm
+++ b/hippiestation/code/game/machinery/reagent_forge.dm
@@ -23,9 +23,9 @@
 
 
 /obj/machinery/reagent_forge/Initialize()
-	. = ..()
 	AddComponent(/datum/component/material_container, list(MAT_REAGENT), 200000)
 	stored_research = new /datum/techweb/specialized/autounlocking/reagent_forge
+	.=..()
 
 
 /obj/machinery/reagent_forge/attackby(obj/item/I, mob/user)

--- a/hippiestation/code/game/machinery/reagent_material_manipulator.dm
+++ b/hippiestation/code/game/machinery/reagent_material_manipulator.dm
@@ -15,8 +15,8 @@
 
 
 /obj/machinery/reagent_material_manipulator/Initialize()
-	. =..()
 	create_reagents(100)
+	.=..()
 
 
 /obj/machinery/reagent_material_manipulator/attackby(obj/item/I, mob/user)

--- a/hippiestation/code/game/machinery/trapdoors.dm
+++ b/hippiestation/code/game/machinery/trapdoors.dm
@@ -42,10 +42,10 @@
 		return TRUE
 
 /obj/machinery/disposal/trapdoor/Initialize(loc,var/obj/structure/disposalconstruct/make_from)
-	. = ..()
 	trunk = locate() in loc
 	if(trunk)
 		trunk.linked = src
+	.=..()
 
 /obj/machinery/disposal/trapdoor/Crossed(AM as mob|obj)
 	if(open)

--- a/hippiestation/code/game/mecha/clockwork/clockwork_mech.dm
+++ b/hippiestation/code/game/mecha/clockwork/clockwork_mech.dm
@@ -72,10 +72,10 @@
 			CHECK_TICK
 
 /obj/mecha/neovgre/Initialize()
-	.=..()
 	GLOB.neovgre_exists ++
 	var/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy/neovgre/N = new
 	N.attach(src)
+	.=..()
 
 /obj/structure/mecha_wreckage/durand/neovgre
 	name = "\improper Neovgre wreckage?"

--- a/hippiestation/code/game/mecha/working/ripley.dm
+++ b/hippiestation/code/game/mecha/working/ripley.dm
@@ -6,9 +6,9 @@
 	name = "\improper APLU \"Miner\""
 
 /obj/mecha/working/ripley/mining_roundstart/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/drill/D = new
 	D.attach(src)
+	.=..()
 
 	cargo.Add(new /obj/structure/ore_box(src)) //Starts with its own nice little ore box.
 

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -26,14 +26,14 @@ GLOBAL_LIST_EMPTY(chempiles)
 		reagents.chem_pressure = pressure_difference / 100
 
 /obj/effect/decal/cleanable/chempile/Initialize()
-	. = ..()
 	GLOB.chempiles += src
 	if(reagents && reagents.total_volume)
 		if(reagents.total_volume < 5)
 			reagents.set_reacting(FALSE)
+	.=..()
 
 /obj/effect/decal/cleanable/chempile/Destroy()
-	..()
+	.=..()
 	GLOB.chempiles -= src
 
 /obj/effect/decal/cleanable/chempile/ex_act()

--- a/hippiestation/code/game/objects/effects/decals/crayon.dm
+++ b/hippiestation/code/game/objects/effects/decals/crayon.dm
@@ -1,10 +1,10 @@
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null)
-	. = ..()
 	if(type == "poseur tag")
 		var/datum/team/gang/gang = pick(subtypesof(/datum/team/gang))
 		var/gangname = initial(gang.name)
 		icon = 'hippiestation/icons/effects/crayondecal.dmi'
 		icon_state = "[gangname]"
+	.=..()
 
 /obj/effect/decal/cleanable/crayon/gang
 	icon = 'hippiestation/icons/effects/crayondecal.dmi'
@@ -23,7 +23,7 @@
 	icon_state = G.name
 	G.new_territories |= list(territory.type = territory.name)
 	//If this isn't tagged by a specific gangster there's no bonus income.
-	..(mapload, newcolor, icon_state, e_name, rotation)
+	.=..(mapload, newcolor, icon_state, e_name, rotation)
 
 /obj/effect/decal/cleanable/crayon/gang/Destroy()
 	if(gang)

--- a/hippiestation/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/hippiestation/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -1,9 +1,9 @@
 GLOBAL_LIST_EMPTY(smoke)
 /obj/effect/particle_effect/smoke/Initialize()
-	..()
 	LAZYADD(GLOB.smoke, src)
 	create_reagents(500)
 	START_PROCESSING(SSreagent_states, src)
+	.=..()
 
 
 /obj/effect/particle_effect/smoke/Destroy()

--- a/hippiestation/code/game/objects/inflatables.dm
+++ b/hippiestation/code/game/objects/inflatables.dm
@@ -31,8 +31,8 @@
 	var/itemtype = /obj/item/inflatable
 
 /obj/structure/inflatable/Initialize(location)
-	. = ..()
 	air_update_turf(1)
+	.=..()
 
 /obj/structure/inflatable/Destroy()
 	air_update_turf(1)
@@ -265,16 +265,16 @@
 	w_class = 3
 
 /obj/item/storage/inflatable/ComponentInitialize()
-	. = ..()
+	.=..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_combined_w_class = 21
 
 /obj/item/storage/inflatable/Initialize()
-	..()
 	for(var/i = 0, i < 8, i++)
 		new /obj/item/inflatable/door(src)
 	for(var/i = 0, i < 16, i ++)
 		new /obj/item/inflatable(src)
+	.=..()
 
 /obj/item/inflatable/suicide_act(mob/living/user)
 	visible_message(user, "<span class='danger'>[user] starts shoving the [src] up his ass! It looks like hes going to pull the cord, oh shit!</span>")

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -96,7 +96,7 @@
 	foodtype = GROSS | TOXIC
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
-	. = ..()
+	..()
 	var/datum/component/comp = GetComponent(/datum/component/slippery)
 	qdel(comp)
 

--- a/hippiestation/code/game/objects/items/cheapcuisine.dm
+++ b/hippiestation/code/game/objects/items/cheapcuisine.dm
@@ -96,7 +96,7 @@
 	foodtype = GROSS | TOXIC
 
 /obj/item/reagent_containers/food/snacks/butterdog/carbon/ComponentInitialize()
-	..()
+	.=..()
 	var/datum/component/comp = GetComponent(/datum/component/slippery)
 	qdel(comp)
 

--- a/hippiestation/code/game/objects/items/crayons.dm
+++ b/hippiestation/code/game/objects/items/crayons.dm
@@ -223,7 +223,7 @@
 	post_noise = TRUE
 
 /obj/item/toy/crayon/spraycan/gang/Initialize(loc, datum/team/gang/G)
-	..()
+	.=..()
 	if(G)
 		gang = G
 		paint_color = G.color

--- a/hippiestation/code/game/objects/items/implants/implant_gang.dm
+++ b/hippiestation/code/game/objects/items/implants/implant_gang.dm
@@ -5,7 +5,7 @@
 	var/datum/team/gang/gang
 
 /obj/item/implant/gang/Initialize(loc, setgang)
-	..()
+	.=..()
 	gang = setgang
 
 /obj/item/implant/gang/get_data()
@@ -54,4 +54,4 @@
 		qdel(src)
 		return
 	imp = new /obj/item/implant/gang(src,gang)
-	..()
+	.=..()

--- a/hippiestation/code/game/objects/items/implants/implant_teleporter.dm
+++ b/hippiestation/code/game/objects/items/implants/implant_teleporter.dm
@@ -9,6 +9,7 @@
 
 /obj/item/implant/teleporter/Initialize()
 	START_PROCESSING(SSobj, src)
+	.=..()
 
 /obj/item/implant/teleporter/process()
 

--- a/hippiestation/code/game/objects/items/staples.dm
+++ b/hippiestation/code/game/objects/items/staples.dm
@@ -43,7 +43,7 @@
 	var/obj/item/organ/butt/B
 
 /obj/item/staplegun/Initialize()
-	..()
+	.=..()
 	update_icon()
 
 /obj/item/staplegun/examine(mob/user)

--- a/hippiestation/code/game/objects/items/weaponry.dm
+++ b/hippiestation/code/game/objects/items/weaponry.dm
@@ -161,7 +161,7 @@
 	var/durability = 5
 
 /obj/item/brick/Initialize()
-	..()
+	.=..()
 	if(prob(0.5))
 		name = "brown brick"
 		desc = "<font color = #835C3B>I understand why all the kids are playing this game these days. It's because they like to build brown bricks with Minecrap. I also like to build brown bricks with Minecrap. It's the most fun you can possibly have.</font>"

--- a/hippiestation/code/game/objects/noose.dm
+++ b/hippiestation/code/game/objects/noose.dm
@@ -31,11 +31,11 @@
 	..()
 
 /obj/structure/chair/noose/Initialize()
-	. = ..()
 	pixel_y += 16 //Noose looks like it's "hanging" in the air
 	over = image(icon, "noose_overlay")
 	over.layer = FLY_LAYER
 	add_overlay(over, priority = 0)
+	.=..()
 
 /obj/structure/chair/noose/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -30,12 +30,13 @@
 	resistance_flags = INDESTRUCTIBLE|UNACIDABLE
 
 /obj/machinery/poolcontroller/Initialize()
-	. = ..()
+	START_PROCESSING(SSprocessing, src)
 	wires = new /datum/wires/poolcontroller(src)
 	for(var/turf/open/pool/W in range(srange,src)) //Search for /turf/open/beach/water in the range of var/srange
 		LAZYADD(linkedturfs, W)
 	for(var/obj/machinery/drain/pooldrain in range(srange,src))
 		linkeddrain = pooldrain
+	. = ..()
 
 /obj/machinery/poolcontroller/emag_act(user as mob) //Emag_act, this is called when it is hit with a cryptographic sequencer.
 	if(!(obj_flags & EMAGGED)) //If it is not already emagged, emag it.
@@ -312,7 +313,7 @@
 		else
 			return "Outside of possible range."
 
-/obj/machinery/poolcontroller/attack_hand(mob/user)
+/obj/machinery/poolcontroller/ui_interact(mob/user)
 	if(shocked && !(stat & NOPOWER))
 		shock(user,50)
 	if(panel_open && !isAI(user))
@@ -358,15 +359,6 @@
 		"})
 	popup.set_content(dat)
 	popup.open()
-
-/obj/machinery/poolcontroller/attack_paw(mob/user)
-	return attack_hand(user)
-
-/obj/machinery/poolcontroller/attack_alien(mob/user)
-	return attack_hand(user)
-
-/obj/machinery/poolcontroller/attack_hulk(mob/user)
-	return attack_hand(user)
 
 /obj/machinery/poolcontroller/proc/reset(wire)
 	switch(wire)

--- a/hippiestation/code/modules/pool/pool_drain.dm
+++ b/hippiestation/code/modules/pool/pool_drain.dm
@@ -13,9 +13,9 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 
 /obj/machinery/drain/Initialize()
-	. = ..()
 	for(var/obj/machinery/poolcontroller/control in range(srange,src))
 		src.poolcontrol += control
+	. = ..()
 
 /obj/machinery/drain/process()
 	if(!status) //don't drain an empty pool.

--- a/hippiestation/code/modules/pool/pool_main.dm
+++ b/hippiestation/code/modules/pool/pool_main.dm
@@ -11,8 +11,8 @@
 
 
 /turf/open/pool/Initialize()
-	. =..()
 	create_reagents(100)
+	. = ..()
 
 
 /turf/open/pool/proc/update_icon()
@@ -86,9 +86,9 @@
 	return ..()
 
 /turf/open/pool/Initialize()
-	. = ..()
 	watereffect = new /obj/effect/overlay/water(src)
 	watertop = new /obj/effect/overlay/water/top(src)
+	. = ..()
 
 /turf/open/pool/ex_act(severity, target)
 	return

--- a/hippiestation/code/modules/reagents/chemistry/machinery/lcasschem.dm
+++ b/hippiestation/code/modules/reagents/chemistry/machinery/lcasschem.dm
@@ -50,7 +50,7 @@
 	var/pressure = 0
 
 /obj/machinery/chem/pressure/Initialize()
-	..()
+	.=..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/pressure(null)
 	B.apply_default_parts(src)
 
@@ -111,7 +111,7 @@
 	var/target_radioactivity = 0
 
 /obj/machinery/chem/radioactive/Initialize()
-	..()
+	.=..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/radioactive(null)
 	B.apply_default_parts(src)
 
@@ -217,7 +217,7 @@
 	var/intensity = 0
 
 /obj/machinery/chem/bluespace/Initialize()
-	..()
+	.=..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/bluespace(null)
 	B.apply_default_parts(src)
 
@@ -320,7 +320,7 @@
 	var/time = 0
 
 /obj/machinery/chem/centrifuge/Initialize()
-	..()
+	.=..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/centrifuge(null)
 	B.apply_default_parts(src)
 

--- a/hippiestation/code/modules/teeth/teeth.dm
+++ b/hippiestation/code/modules/teeth/teeth.dm
@@ -18,7 +18,7 @@
 	singular_name = "human tooth"
 
 /obj/item/stack/teeth/human/Initialize()
-	..()
+	.=..()
 	transform *= TRANSFORM_USING_VARIABLE(0.25, 1) + 0.5 //Half-size the teeth
 
 /obj/item/stack/teeth/human/gold //Special traitor objective maybe?


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
code: Pool code now uses SSprocessing, initialization returns properly and uses ui_interact
code: Makes more hippie items return initialize hints
/:cl:

[why]: The pool actually counts down by proper seconds now and doesn't require you to reclick on the pool controller to refresh the ui. The reason why it was counting by 2 seconds was a result of the pool using machine processing which waits 2 seconds, as opposed to regular processing which only waits 1. Enjoy.