### PR TITLE
Fixes ghosts interacting with pool controller

### DIFF
--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -265,7 +265,11 @@
 	update_icon()
 
 /obj/machinery/poolcontroller/Topic(href, href_list)
-	..()
+	if(..())
+		return
+	if(!allowed(usr))
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
+		return
 	if(timer > 0)
 		return
 	if(href_list["IncreaseTemp"])
@@ -314,6 +318,9 @@
 			return "Outside of possible range."
 
 /obj/machinery/poolcontroller/ui_interact(mob/user)
+	. = ..()
+	if(.)
+		return
 	if(shocked && !(stat & NOPOWER))
 		shock(user,50)
 	if(panel_open && !isAI(user))

--- a/hippiestation/code/modules/pool/pool_main.dm
+++ b/hippiestation/code/modules/pool/pool_main.dm
@@ -14,7 +14,6 @@
 	create_reagents(100)
 	. = ..()
 
-
 /turf/open/pool/proc/update_icon()
 	if(!filled)
 		name = "drained pool"


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Ghosts can no longer interact with the pool controller and change it's temperature
/:cl:

[why]: 