### PR TITLE
Adds a preference for footsteps, disables them by default

### DIFF
--- a/code/__DEFINES/~hippie_defines/preferences.dm
+++ b/code/__DEFINES/~hippie_defines/preferences.dm
@@ -1,3 +1,4 @@
 #define SOUND_TTS				(1<<0)
+#define SOUND_FOOTSTEPS			(1<<1)
 
 #define HIPPIE_TOGGLES_DEFAULT	(SOUND_TTS)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2748,6 +2748,7 @@
 #include "hippiestation\code\datums\antagonists\thrall.dm"
 #include "hippiestation\code\datums\antagonists\vampire.dm"
 #include "hippiestation\code\datums\antagonists\wizard.dm"
+#include "hippiestation\code\datums\components\footstep.dm"
 #include "hippiestation\code\datums\components\material_container.dm"
 #include "hippiestation\code\datums\components\spell_catalyst.dm"
 #include "hippiestation\code\datums\components\storage\concrete\butt.dm"

--- a/hippiestation/code/datums/components/footstep.dm
+++ b/hippiestation/code/datums/components/footstep.dm
@@ -1,0 +1,7 @@
+/datum/component/footstep/play_footstep()
+	var/mob/living/LM = parent
+	var/client/C = LM.client
+	if(C)
+		if(!(C.prefs.hippie_toggles & SOUND_FOOTSTEPS))
+			return
+	..()

--- a/hippiestation/code/modules/client/preferences.dm
+++ b/hippiestation/code/modules/client/preferences.dm
@@ -38,6 +38,8 @@
 			switch(href_list["preference"])
 				if("hear_tts")
 					hippie_toggles ^= SOUND_TTS
+				if("hear_footsteps")
+					hippie_toggles ^= SOUND_FOOTSTEPS
 				if("gear")
 					if(href_list["clear_loadout"])
 						LAZYCLEARLIST(chosen_gear)
@@ -71,6 +73,7 @@
 			. += "<h2>Hippie OOC Settings</h2>"
 
 			. += "<b>Play Text-to-Speech:</b> <a href='?_src_=prefs;preference=hear_tts'>[(hippie_toggles & SOUND_TTS) ? "Enabled":"Disabled"]</a><br>" // let user toggle TTS sounds
+			. += "<b>Play Footsteps:</b> <a href='?_src_=prefs;preference=hear_footsteps'>[(hippie_toggles & SOUND_FOOTSTEPS) ? "Enabled":"Disabled"]</a><br>" // let user toggle footsteps
 
 			. += "</tr></table>"
 		if(3)

--- a/hippiestation/code/modules/client/preferences_toggles.dm
+++ b/hippiestation/code/modules/client/preferences_toggles.dm
@@ -9,5 +9,20 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggletts)()
 	else
 		to_chat(usr, "You will no longer hear text-to-speech sounds.")
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Hearing Text-to-Speech", "[usr.client.prefs.toggles & SOUND_TTS ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/verbs/menu/Settings/Sound/toggletts/Get_checked(client/C)
 	return C.prefs.hippie_toggles & SOUND_TTS
+
+TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggle_footsteps)()
+	set name = "Hear/Silence Footsteps"
+	set category = "Preferences"
+	set desc = "Hear In-game Footsteps"
+	usr.client.prefs.hippie_toggles ^= SOUND_FOOTSTEPS
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.hippie_toggles & SOUND_FOOTSTEPS)
+		to_chat(usr, "You will now hear people's footsteps.")
+	else
+		to_chat(usr, "You will no longer hear people's footsteps.")
+	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Footsteps", "[usr.client.prefs.toggles & SOUND_FOOTSTEPS ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/verbs/menu/Settings/Sound/toggle_footsteps/Get_checked(client/C)
+	return C.prefs.hippie_toggles & SOUND_FOOTSTEPS


### PR DESCRIPTION
#8785 

:cl:
tweak: Added a preference for footsteps. It starts off by default, if you like them and want them, go in OOC preferences and turn them on.
/:cl:

[why]: Agreed by me and flux.