### PR TITLE
[READY] Making pAI connectors and mmi tanks work easier

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
@@ -24,6 +24,8 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 150
 	can_be_asked_input = TRUE
+	demands_object_input = TRUE
+
 	var/obj/item/mmi/installed_brain
 
 /obj/item/integrated_circuit/input/mmi_tank/attackby(var/obj/item/mmi/O, var/mob/user)
@@ -152,6 +154,8 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 150
 	can_be_asked_input = TRUE
+	demands_object_input = TRUE
+
 	var/obj/item/paicard/installed_pai
 
 /obj/item/integrated_circuit/input/pAI_connector/attackby(var/obj/item/paicard/O, var/mob/user)


### PR DESCRIPTION
This one's for you, Carbonhell.

[Changelogs]: # Makes it so that mmi tanks and pAI connectors can have their items loaded into after being put in assembly. That way, there is no need to do all the complicated wiring again.

:cl: Shdorsh
tweak: made brain tanks and pAI connectors accept items once while in assembly.
/:cl:

[why]: That's how I always wanted them to work.