### PR TITLE
Fixes mummy clothing requiring non modularized null rod

### DIFF
--- a/hippiestation/code/modules/crafting/recipies.dm
+++ b/hippiestation/code/modules/crafting/recipies.dm
@@ -149,3 +149,6 @@
 	time = 40
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/mummy
+	tools = list(/obj/item/nullrod/hippie/egyptian)


### PR DESCRIPTION
:cl: Bartels
fix: Fixed mummy clothing being impossible to craft
/:cl:

Recipe of mummy clothing requires a nullrod as a tool but the recipe was not updated after nullrods were modularized.