### PR TITLE
Adds warning message in player panel when player has related accounts

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -43,6 +43,12 @@
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"
+
+		// hippie start -- warning when player has related accounts
+		if (M.client.related_accounts_cid || M.client.related_accounts_ip)
+			body += "<br><b><font color=red>Player has related accounts</font></b>"
+		// hippie end
+
 		var/rep = 0
 		rep += SSpersistence.antag_rep[M.ckey]
 		body += "<br><br>Antagonist reputation: [rep]"


### PR DESCRIPTION
:cl: Bartels
admin: Added a warning in the player panel when a player has related accounts
/:cl:

[why]: 
We have these buttons to check a player's related accounts by CID and IP but you need to actively look for those to see if a player has alternate accounts. This way people who have a ton of notes/bans on another account might be seen as new players and get off with a warning when they shouldn't.

![image](https://user-images.githubusercontent.com/17361436/45264864-87442a00-b443-11e8-9f12-bfc558869a97.png)
