### PR TITLE
Gang-wide messages now show the name of who sends them

### DIFF
--- a/hippiestation/code/game/gamemodes/gangs/gangtool.dm
+++ b/hippiestation/code/game/gamemodes/gangs/gangtool.dm
@@ -138,7 +138,7 @@
 		to_chat(user, "<span class='info'>[icon2html(src, user)]Error: Station out of range.</span>")
 		return
 	if(gang.members.len)
-		var/ping = "<span class='danger'><B><i>[gang.name] [(user.mind in gang.leaders) ? "Leader" : "Gangster"]</i>: [message]</B></span>"
+		var/ping = "<span class='danger'><B><i>[gang.name] [(user.mind in gang.leaders) ? "Leader" : "Gangster"] [user.real_name]</i>: [message]</B></span>"
 		for(var/datum/mind/ganger in gang.members)
 			if(ganger.current && is_station_level(ganger.current.z) && (ganger.current.stat == CONSCIOUS))
 				to_chat(ganger.current, ping)

--- a/hippiestation/code/game/gamemodes/gangs/gangtool.dm
+++ b/hippiestation/code/game/gamemodes/gangs/gangtool.dm
@@ -138,7 +138,10 @@
 		to_chat(user, "<span class='info'>[icon2html(src, user)]Error: Station out of range.</span>")
 		return
 	if(gang.members.len)
-		var/ping = "<span class='danger'><B><i>[gang.name] [(user.mind in gang.leaders) ? "Leader" : "Gangster"] [user.real_name]</i>: [message]</B></span>"
+		var/datum/antagonist/gang/G = user.mind.has_antag_datum(/datum/antagonist/gang)
+		if(!G)
+			return
+		var/ping = "<span class='danger'><B><i>[gang.name] [G.message_name] [user.real_name]</i>: [message]</B></span>"
 		for(var/datum/mind/ganger in gang.members)
 			if(ganger.current && is_station_level(ganger.current.z) && (ganger.current.stat == CONSCIOUS))
 				to_chat(ganger.current, ping)

--- a/hippiestation/code/modules/antagonists/gang/gang.dm
+++ b/hippiestation/code/modules/antagonists/gang/gang.dm
@@ -5,6 +5,7 @@
 	job_rank = ROLE_GANG
 	antagpanel_category = "Gang"
 	var/hud_type = "gangster"
+	var/message_name = "Gangster"
 	var/datum/team/gang/gang
 
 /datum/antagonist/gang/can_be_owned(datum/mind/new_owner)
@@ -89,7 +90,7 @@
 	var/datum/team/gang/old_gang = gang
 	var/datum/mind/old_owner = owner
 	owner.remove_antag_datum(/datum/antagonist/gang)
-	var/datum/antagonist/gang/boss/new_boss = new
+	var/datum/antagonist/gang/boss/lieutenant/new_boss = new
 	new_boss.silent = TRUE
 	old_owner.add_antag_datum(new_boss,old_gang)
 	new_boss.silent = FALSE
@@ -165,6 +166,7 @@
 /datum/antagonist/gang/boss
 	name = "Gang boss"
 	hud_type = "gang_boss"
+	message_name = "Leader"
 
 /datum/antagonist/gang/boss/on_gain()
 	..()
@@ -271,6 +273,9 @@
 	log_admin("[key_name(user)] has demoted [owner.current] from gang boss.")
 	admin_take_gangtool(user)
 	demote()
+
+/datum/antagonist/gang/boss/lieutenant
+	message_name = "Lieutenant"
 
 #define MAXIMUM_RECALLS 3
 #define INFLUENCE_INTERVAL 1800
@@ -463,6 +468,7 @@
 /datum/team/gang/proc/domination_time_remaining() // retrieves the value from world.time based deciseconds to seconds
 	var/diff = domination_time - world.time
 	return round(diff * 0.1)
+
 
 #undef MAXIMUM_RECALLS
 #undef INFLUENCE_INTERVAL

--- a/hippiestation/code/modules/antagonists/gang/gang.dm
+++ b/hippiestation/code/modules/antagonists/gang/gang.dm
@@ -275,6 +275,7 @@
 	demote()
 
 /datum/antagonist/gang/boss/lieutenant
+	name = "Gang Lieutenant"
 	message_name = "Lieutenant"
 
 #define MAXIMUM_RECALLS 3


### PR DESCRIPTION
> _Penis Gang Leader_: dom in cargo
> _Penis Gang Leader_: no let's dom in viro
> _Penis Gang Leader_: ur mom gay
> _Penis Gang Leader_: fuck you eat shit
> _Penis Gang Leader_: i'll blow you up you mofo

:cl: steamp0rt
tweak: Gang-wide messages now show the name of who sends them
tweak: Lieutenants can now be distinguished from the leader when sending gang messages
/:cl:
