### PR TITLE
Increase Captain's sabre hit speed by 25%

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2887,6 +2887,7 @@
 #include "hippiestation\code\game\objects\items\implants\implantcase.dm"
 #include "hippiestation\code\game\objects\items\implants\implanter.dm"
 #include "hippiestation\code\game\objects\items\melee\energy.dm"
+#include "hippiestation\code\game\objects\items\melee\misc.dm"
 #include "hippiestation\code\game\objects\items\stacks\medical.dm"
 #include "hippiestation\code\game\objects\items\stacks\rods.dm"
 #include "hippiestation\code\game\objects\items\stacks\stack.dm"

--- a/hippiestation/code/game/objects/items/melee/misc.dm
+++ b/hippiestation/code/game/objects/items/melee/misc.dm
@@ -1,0 +1,3 @@
+/obj/item/melee/sabre/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	..()
+	user.changeNext_move(CLICK_CD_CLICK_ABILITY)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
balance: Captain's sabre hit delay reduced from 8 to 6 ticks.
/:cl:

[why]: It feels too weak at the moment, and since tg nerfed delimbing, it has been made redundant by almost any other sharp weapon.