### PR TITLE
Fixes pubby's missing tiles and a cleans a few other maps. (#40147)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2348,7 +2348,8 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/deepstorage/power)
 "fe" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -117,12 +117,14 @@
 /area/ruin/space/has_grav/powered/aesthetic)
 "A" = (
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
 "B" = (
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
@@ -131,7 +133,8 @@
 	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
@@ -149,13 +152,15 @@
 /obj/structure/statue/sandstone/venus{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
 "G" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
@@ -207,7 +212,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating{
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1026,7 +1026,8 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard/fore)
 "abu" = (
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "abv" = (
 /turf/closed/wall,
@@ -1265,7 +1266,8 @@
 /area/asteroid/nearstation)
 "abS" = (
 /obj/item/stack/ore/glass,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "abT" = (
 /turf/closed/wall,
@@ -2083,7 +2085,8 @@
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "adw" = (
 /turf/open/floor/plating{
@@ -3348,11 +3351,13 @@
 "afM" = (
 /obj/item/stack/ore/iron,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "afN" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "afP" = (
 /obj/structure/table/wood,
@@ -3826,7 +3831,8 @@
 "agE" = (
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/iron,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "agF" = (
 /turf/closed/wall/r_wall,
@@ -4766,7 +4772,8 @@
 /area/quartermaster/storage)
 "aik" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "aim" = (
 /obj/structure/rack,
@@ -5745,7 +5752,8 @@
 /area/quartermaster/storage)
 "ajQ" = (
 /obj/item/stack/ore/iron,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "ajR" = (
 /obj/structure/rack,
@@ -9850,7 +9858,8 @@
 /area/engine/atmos)
 "aqG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqI" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -10371,7 +10380,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arB" = (
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36383,7 +36393,8 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "bvg" = (
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
 "bvh" = (
 /obj/structure/closet/emcloset{
@@ -39983,7 +39994,8 @@
 "sIA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "sIB" = (
 /turf/closed/wall/rust,
@@ -41277,7 +41289,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNj" = (
 /obj/effect/turf_decal/bot,
@@ -41876,7 +41889,8 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
 "sOK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30996,9 +30996,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "buz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31563,9 +31561,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurplecorners"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31633,9 +31629,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvU" = (
 /obj/machinery/recharger,
@@ -32377,9 +32371,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxD" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -33085,9 +33077,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurplecorners"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33123,9 +33113,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzc" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -33862,9 +33850,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bAF" = (
 /turf/closed/wall,
@@ -34090,13 +34076,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBi" = (
@@ -34264,9 +34250,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBw" = (
 /obj/machinery/computer/security,
@@ -34406,9 +34390,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBK" = (
 /obj/structure/closet/bombcloset,
@@ -35015,9 +34997,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bCJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -35454,9 +35434,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDG" = (
 /obj/structure/table,
@@ -35608,9 +35586,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
@@ -36258,9 +36234,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEW" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -36356,9 +36330,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bFh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36852,9 +36824,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bGm" = (
 /obj/machinery/light_switch{
@@ -43943,13 +43913,13 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/mob/living/simple_animal/parrot/Poly,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVE" = (
@@ -44035,9 +44005,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bVM" = (
 /obj/machinery/power/terminal{
@@ -44382,9 +44350,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWw" = (
 /obj/structure/cable/yellow{
@@ -44732,9 +44698,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXm" = (
 /obj/structure/cable{
@@ -45619,9 +45583,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZg" = (
 /obj/structure/cable{
@@ -45866,9 +45828,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZP" = (
 /obj/structure/cable/yellow{
@@ -46153,9 +46113,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caJ" = (
 /obj/structure/cable/yellow{
@@ -46457,9 +46415,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -46718,9 +46674,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccq" = (
 /obj/structure/chair/office/dark,
@@ -46887,9 +46841,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdh" = (
 /obj/structure/table/glass,
@@ -46913,9 +46865,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkyellow"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdj" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -500,47 +500,12 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 9;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aV" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aW" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aX" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aY" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 5;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -596,25 +561,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 8;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
-/area/shuttle/escape)
-"bh" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bi" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 4;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bj" = (
 /turf/open/floor/mech_bay_recharge_floor,
@@ -625,26 +572,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bl" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 8;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
-/area/shuttle/escape)
-"bm" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
-/area/shuttle/escape)
 "bn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bo" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -666,16 +599,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
-/area/shuttle/escape)
-"br" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -727,41 +651,13 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 10;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bx" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "by" = (
 /obj/structure/table,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/zipties,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bz" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 6;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bA" = (
 /obj/machinery/door/airlock/shuttle{
@@ -1117,9 +1013,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "ch" = (
-/mob/living/simple_animal/bot/medbot{
-	name = "Speedy* Recovery"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1128,6 +1021,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/medbot{
+	name = "Speedy* Recovery"
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -2085,8 +1981,8 @@ aM
 ab
 aU
 bg
-bl
-bl
+be
+be
 bw
 ab
 bG
@@ -2128,10 +2024,10 @@ aI
 aN
 ab
 aV
-bh
-bl
-br
-bx
+be
+be
+be
+bw
 ac
 bH
 bR
@@ -2171,10 +2067,10 @@ aA
 aC
 aC
 ab
-aW
-bh
-bm
-br
+aT
+be
+be
+be
 by
 ac
 bI
@@ -2215,11 +2111,11 @@ aB
 aC
 aC
 ab
-aX
-bh
-bi
-br
-bx
+aS
+be
+be
+be
+bw
 ac
 bJ
 bR
@@ -2259,11 +2155,11 @@ aC
 aC
 aC
 ab
-aY
-bi
-bi
-bi
-bz
+aS
+be
+be
+be
+bw
 ab
 bK
 bR


### PR DESCRIPTION
Closes #9008 

Original PR: https://github.com/tgstation/tgstation/pull/40147
--------------------
Pubby was making use of quite a few icon_state floors in R&D and other parts of the map which no longer existed, so we had purple/black tiles. The other map change are to move asteroid plating into plating with asteroid sand decals since I'm trying to move us in that direction and will be removing those paths shortly.

:cl: WJohn
fix: Fixed pubby's bugged R&D tiles.
/:cl: