### PR TITLE
[URGENT] Nerfing atmos circuits

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
@@ -119,7 +119,7 @@
 
 /obj/item/integrated_circuit/atmospherics/pump/proc/move_gas(datum/gas_mixture/source_air, datum/gas_mixture/target_air)
 	// No moles = nothing to pump
-	if(source_air.total_moles() <= 0 || target_air.return_pressure() <=750)
+	if(source_air.total_moles() <= 0 || target_air.return_pressure() >=750)
 		return
 
 	// Negative Kelvin temperatures should never happen and if they do, normalize them 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
@@ -119,7 +119,7 @@
 
 /obj/item/integrated_circuit/atmospherics/pump/proc/move_gas(datum/gas_mixture/source_air, datum/gas_mixture/target_air)
 	// No moles = nothing to pump
-	if(source_air.total_moles() <= 0)
+	if(source_air.total_moles() <= 0 || target_air.return_pressure() <=750)
 		return
 
 	// Negative Kelvin temperatures should never happen and if they do, normalize them 
@@ -137,7 +137,7 @@
 /obj/item/integrated_circuit/atmospherics/pump/volume
 	name = "volume pump"
 	desc = "Moves gases between two tanks, canisters, and other gas containers by using their volume, up to 200 L/s."
-	extended_desc = " Use negative volume to move air from target to source. Note that only part of the gas is moved on each transfer. Unlike the gas pump, this one keeps pumping even further to pressures of 9000 pKa and it is not advised to use it on tank circuits."
+	extended_desc = " Use negative volume to move air from target to source. Note that only part of the gas is moved on each transfer. Its maximum pumping volume is capped at 1000kPa."
 
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	complexity = 5
@@ -174,7 +174,7 @@
 	if(source_air.temperature < TCMB)
 		source_air.temperature = TCMB
 
-	if((source_air.return_pressure() < 0.01) || (target_air.return_pressure() > 9000))
+	if((source_air.return_pressure() < 0.01) || (target_air.return_pressure() > 1000))
 		return
 
 	var/transfer_ratio = transfer_rate/source_air.volume

--- a/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
@@ -345,6 +345,10 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 	if(!contaminated_air)
 		contaminated_air = air_contents
 
+	//Courtesy of atmos circuit bomb nerf. You brought it upon yourselves.
+	if(contaminated_air.return_pressure() >=750 || filtered_air.return_pressure() >= 750)
+		return
+
 	var/pressure_delta = target_pressure - contaminated_air.return_pressure()
 	var/transfer_moles
 
@@ -430,6 +434,9 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 	var/datum/gas_mixture/output_gases = gas_output.return_air()
 
 	if(!source_1_gases || !source_2_gases || !output_gases)
+		return
+
+	if(output_gases.return_pressure() >= 750)
 		return
 
 	if(source_1_gases.return_pressure() <=0 || source_2_gases.return_pressure() <=0)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
@@ -7,6 +7,8 @@
 /obj/item/integrated_circuit/atmospherics
 	category_text = "Atmospherics"
 	cooldown_per_use = 2 SECONDS
+	complexity = 10
+	size = 7
 	outputs = list(
 		"self reference" = IC_PINTYPE_SELFREF,
 		"pressure" = IC_PINTYPE_NUMBER
@@ -41,8 +43,6 @@
 	name = "gas pump"
 	desc = "Somehow moves gases between two tanks, canisters, and other gas containers."
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	complexity = 5
-	size = 3
 	inputs = list(
 			"source" = IC_PINTYPE_REF,
 			"target" = IC_PINTYPE_REF,
@@ -140,8 +140,6 @@
 	extended_desc = " Use negative volume to move air from target to source. Note that only part of the gas is moved on each transfer. Its maximum pumping volume is capped at 1000kPa."
 
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	complexity = 5
-	size = 3
 	inputs = list(
 			"source" = IC_PINTYPE_REF,
 			"target" = IC_PINTYPE_REF,
@@ -230,8 +228,6 @@
 	extended_desc = "This circuit will automatically attempt to locate and connect to ports on the floor beneath it when activated. \
 					You <b>must</b> set a target before connecting."
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	complexity = 2
-	size = 6
 	inputs = list(
 			"target" = IC_PINTYPE_REF
 			)
@@ -296,7 +292,7 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 	name = "gas filter"
 	desc = "Filters one gas out of a mixture."
 	complexity = 20
-	size = 5
+	size = 8
 	spawn_flags = IC_SPAWN_RESEARCH
 	inputs = list(
 			"source" = IC_PINTYPE_REF,
@@ -401,7 +397,7 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 	name = "gas mixer"
 	desc = "Mixes 2 different types of gases."
 	complexity = 20
-	size = 5
+	size = 8
 	spawn_flags = IC_SPAWN_RESEARCH
 	inputs = list(
 			"first source" = IC_PINTYPE_REF,
@@ -668,7 +664,8 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 
 	container_type = OPENCONTAINER
 
-	complexity = 4
+	complexity = 20
+	size = 25
 	inputs = list()
 	outputs = list(
 		"pressure used" = IC_PINTYPE_NUMBER,


### PR DESCRIPTION
[Changelogs]: # Capped max pressurization through atmos pump circuits to prevent maxcaps in < 3 minutes ingame and hopefully strongly nerf explosions 

:cl: Shdorsh
balance: rebalanced atmos circuits
/:cl:

[why]: I told you folks I'll nerf it into oblivion if you act like shitlords using it. Consider this nerf "minor", more to follow if I see or hear of some more maxcap autism.