### PR TITLE
Fixes catbans and cluwnebans once and for all fucking damn it

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -80,6 +80,8 @@ SUBSYSTEM_DEF(job)
 			return FALSE
 		if(jobban_isbanned(player, rank) || QDELETED(player))
 			return FALSE
+		if((jobban_isbanned(player, CLUWNEBAN) || jobban_isbanned(player, CATBAN)) && !istype(job, GetJob(SSjob.overflow_role))) // hippie start -- fixes catbans
+			return FALSE // hippie end
 		if(!job.player_old_enough(player.client))
 			return FALSE
 		if(job.required_playtime_remaining(player.client))
@@ -103,6 +105,9 @@ SUBSYSTEM_DEF(job)
 		if(jobban_isbanned(player, job.title) || QDELETED(player))
 			JobDebug("FOC isbanned failed, Player: [player]")
 			continue
+		if((jobban_isbanned(player, CLUWNEBAN) || jobban_isbanned(player, CATBAN)) && job.title != SSjob.overflow_role) // hippie start -- fixes catbans
+			JobDebug("FOC isbanned failed (cat/clown ban), Player: [player]")
+			continue // hippie end
 		if(!job.player_old_enough(player.client))
 			JobDebug("FOC player not old enough, Player: [player]")
 			continue
@@ -123,6 +128,11 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/GiveRandomJob(mob/dead/new_player/player)
 	JobDebug("GRJ Giving random job, Player: [player]")
 	. = FALSE
+	if(jobban_isbanned(player, CLUWNEBAN) || jobban_isbanned(player, CATBAN)) // hippie start -- fixes catbans
+		JobDebug("GRJ player is cat/clown banned")
+		if(AssignRole(player, SSjob.overflow_role))
+			return TRUE
+		return FALSE // hippie end
 	for(var/datum/job/job in shuffle(occupations))
 		if(!job)
 			continue
@@ -275,6 +285,8 @@ SUBSYSTEM_DEF(job)
 		AssignRole(player, SSjob.overflow_role)
 		overflow_candidates -= player
 	JobDebug("DO, AC1 end")
+
+	HippieFillBannedPosition() // hippie -- cat/clowns can only play as the overflow role, assistant by default.
 
 	//Select one head
 	JobDebug("DO, Running Head Check")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -653,9 +653,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			HTML += "<tr bgcolor='[job.selection_color]'><td width='60%' align='right'>"
 			var/rank = job.title
 			lastJob = job
-			if(jobban_isbanned(user, rank) || jobban_isbanned(user, CLUWNEBAN) || jobban_isbanned(user, CATBAN)) // hippie -- adds our jobban checks
+			if(jobban_isbanned(user, rank))
 				HTML += "<font color=red>[rank]</font></td><td><a href='?_src_=prefs;jobbancheck=[rank]'> BANNED</a></td></tr>"
 				continue
+			if((jobban_isbanned(user, CLUWNEBAN) || jobban_isbanned(user, CATBAN)) && rank != SSjob.overflow_role) // hippie start -- adds our jobban checks
+				HTML += "<font color=red>[rank]</font></td><td><a href='?_src_=prefs;jobbancheck=[rank]'> BANNED</a></td></tr>"
+				continue // hippie end
 			var/required_playtime_remaining = job.required_playtime_remaining(user.client)
 			if(required_playtime_remaining)
 				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[ [get_exp_format(required_playtime_remaining)] as [job.get_exp_req_type()] \] </font></td></tr>"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3089,6 +3089,7 @@
 #include "hippiestation\code\modules\mob\mob_defines.dm"
 #include "hippiestation\code\modules\mob\mob_helpers.dm"
 #include "hippiestation\code\modules\mob\mob_movement.dm"
+#include "hippiestation\code\modules\mob\dead\new_player\new_player.dm"
 #include "hippiestation\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "hippiestation\code\modules\mob\dead\observer\say.dm"
 #include "hippiestation\code\modules\mob\living\emote.dm"

--- a/hippiestation/code/controllers/subsystem/job.dm
+++ b/hippiestation/code/controllers/subsystem/job.dm
@@ -19,3 +19,9 @@
 			if(!M.equip_to_slot_if_possible(I, G.category, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) // Try to put it in its slot, first
 				if(!M.equip_to_slot_if_possible(I, SLOT_IN_BACKPACK, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) // If it fails, try to put it in the backpack
 					I.forceMove(get_turf(M)) // If everything fails, just put it on the floor under the mob.
+
+/datum/controller/subsystem/job/proc/HippieFillBannedPosition()
+	for(var/p in unassigned)
+		var/mob/dead/new_player/player = p
+		if(jobban_isbanned(player, CLUWNEBAN) || jobban_isbanned(player, CATBAN))
+			AssignRole(player, overflow_role)

--- a/hippiestation/code/datums/dna.dm
+++ b/hippiestation/code/datums/dna.dm
@@ -38,10 +38,3 @@
 	..()
 	if(jobban_isbanned(holder, CLUWNEBAN) && !check_mutation(CLUWNEMUT))
 		add_mutation(CLUWNEMUT) // you can't escape hell
-
-/mob/living/carbon/human/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
-	if(jobban_isbanned(src, CATBAN))
-		if(mrace != /datum/species/tarajan)
-			set_species(/datum/species/tarajan)
-			return
-	..()

--- a/hippiestation/code/modules/mob/dead/new_player/new_player.dm
+++ b/hippiestation/code/modules/mob/dead/new_player/new_player.dm
@@ -1,0 +1,5 @@
+/mob/dead/new_player/IsJobUnavailable(rank, latejoin = FALSE)
+	. = ..()
+	if(. == JOB_AVAILABLE)
+		if(jobban_isbanned(src, CLUWNEBAN) || jobban_isbanned(src, CATBAN) && rank != SSjob.overflow_role)
+			return JOB_UNAVAILABLE_BANNED


### PR DESCRIPTION

:cl:
fix: Cat/cluwn banned people cannot join as a role different from Assistant anymore.
/:cl:

We can also make all cat/cluwnes be able to join only as any role we specify through config now. Memes.