### PR TITLE
Reverts initialize icon_hippie removal

### DIFF
--- a/hippiestation/code/game/atoms.dm
+++ b/hippiestation/code/game/atoms.dm
@@ -1,11 +1,15 @@
 /atom
 	var/icon_hippie
 
-/atom/proc/check_hippie_icon() // Removes safety checks for icon_hippie. If you somehow set this but forget to actually add the icon, you're a retard, and it should be easily viewable ingame.
+/atom/proc/check_hippie_icon()
 	if (!icon || !icon_state || !icon_hippie)
+		return
+	if (length(icon_hippie) <= 0)
+		return
+	if (!is_string_in_list(icon_state, icon_states(icon_hippie)))
 		return
 	icon = icon_hippie
 
 /atom/Initialize()
-    check_hippie_icon()
-    return ..()
+	check_hippie_icon()
+	return ..()


### PR DESCRIPTION

:cl:
refactor: some objects like computers, vending machines and walls aren't invisible anymore.
/:cl:

[why]: I fucked up, turns out it'd need a whole refactor to properly remove this. Atleast i got rid of the useless icon new. Tested.