### PR TITLE
[Ready][Tested] New circuit: Wire connector

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3059,6 +3059,7 @@
 #include "hippiestation\code\modules\integrated_electronics\subtypes\lists.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\manipulation.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\output.dm"
+#include "hippiestation\code\modules\integrated_electronics\subtypes\power.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\reagents.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\smart.dm"
 #include "hippiestation\code\modules\jobs\job_types\captain.dm"

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -1,0 +1,112 @@
+// - wire connector - //
+/obj/item/integrated_circuit/power/transmitter/wire_connector
+	name = "wire connector"
+	desc = "Connects to a wire and allows to read the power, charge it or charge itself from the wire's power."
+	extended_desc = "This circuit will automatically attempt to locate and connect to wires on the floor beneath it when pulsed. \
+						You <b>must</b> set a target before connecting. It can also transfer energy up to 2kJ from the assembly  \
+						to a wire and backwards if negative values are set for energy transfer."
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+	inputs = list(
+			"charge" = IC_PINTYPE_NUMBER
+			)
+	activators = list(
+			"toggle connection" = IC_PINTYPE_PULSE_IN,
+			"transfer power" = IC_PINTYPE_PULSE_IN,
+			"on connected" = IC_PINTYPE_PULSE_OUT,
+			"on connection failed" = IC_PINTYPE_PULSE_OUT,
+			"on disconnected" = IC_PINTYPE_PULSE_OUT
+			)
+	outputs = list(
+			"connected cable" = IC_PINTYPE_REF,
+			"powernet power" = IC_PINTYPE_NUMBER,
+			"powernet load" = IC_PINTYPE_NUMBER
+			)
+	complexity = 35
+	power_draw_per_use = 100
+	amount_to_move = 0
+
+	var/obj/structure/cable/connected_cable
+
+/obj/item/integrated_circuit/power/transmitter/wire_connector/Initialize()
+	START_PROCESSING(SSobj, src)
+	. = ..()
+
+//Does wire things
+/obj/item/integrated_circuit/power/transmitter/wire_connector/process()
+	update_cable()
+	push_data()
+
+//If the assembly containing this is moved from the tile the wire is in, the connection breaks
+/obj/item/integrated_circuit/power/transmitter/wire_connector/ext_moved()
+	if(connected_cable)
+		if(get_dist(get_object(), connected_cable) > 0)
+			// The connected cable is removed
+			connected_cable = null
+			set_pin_data(IC_OUTPUT, 1, null)
+			push_data()
+			activate_pin(5)
+
+
+/obj/item/integrated_circuit/power/transmitter/wire_connector/on_data_written()
+	var/charge_num = get_pin_data(IC_INPUT, 1)
+	//In case someone sets that pin to null
+	if(!charge_num)
+		amount_to_move = 0
+		return
+
+	amount_to_move = CLAMP(charge_num,-2000, 2000)
+
+/obj/item/integrated_circuit/power/transmitter/wire_connector/do_work(var/n)
+	if(n == 1)
+		// If there is a connection, disconnect
+		if(connected_cable)
+			connected_cable = null
+			set_pin_data(IC_OUTPUT, 1, null)
+			push_data()
+			activate_pin(5)
+			return
+	
+		var/obj/structure/cable/foundcable = locate(/obj/structure/cable) in get_turf(src)
+		// If no connector can't connect
+		if(!foundcable || foundcable.invisibility != 0)
+			set_pin_data(IC_OUTPUT, 1, null)
+			push_data()
+			activate_pin(4)
+			return
+		connected_cable = foundcable
+		update_cable()
+		push_data()
+		activate_pin(3)
+		return
+
+
+	if(!connected_cable)
+		return
+
+	if(!assembly)
+		return
+
+	//No charge transfer, no need to syphon tickrates with scripts
+	if(!amount_to_move || amount_to_move == 0)
+		return
+
+	//Second clamp: set the number between what the battery and powernet allows
+	amount_to_move = CLAMP(amount_to_move, -connected_cable.powernet.avail, assembly.battery.charge)
+
+	connected_cable.powernet.avail += amount_to_move
+	assembly.battery.charge -= amount_to_move
+
+/obj/item/integrated_circuit/power/transmitter/wire_connector/proc/update_cable()
+	if(get_dist(get_object(), connected_cable) > 0)
+		connected_cable = null
+
+	if(!connected_cable || connected_cable.invisibility != 0)
+		set_pin_data(IC_OUTPUT, 1, null)
+		set_pin_data(IC_OUTPUT, 2, null)
+		set_pin_data(IC_OUTPUT, 3, null)
+		return
+
+	var/datum/powernet/analyzed_net = connected_cable.powernet
+	set_pin_data(IC_OUTPUT, 1, WEAKREF(connected_cable))
+	set_pin_data(IC_OUTPUT, 2, analyzed_net.viewavail)
+	set_pin_data(IC_OUTPUT, 3, analyzed_net.viewload)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -29,7 +29,7 @@
 
 /obj/item/integrated_circuit/power/transmitter/wire_connector/Destroy()
 	connected_cable = null
-	..()
+	return ..()
 
 /obj/item/integrated_circuit/power/transmitter/wire_connector/Initialize()
 	START_PROCESSING(SSobj, src)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -91,10 +91,11 @@
 		return
 
 	//Second clamp: set the number between what the battery and powernet allows
-	amount_to_move = CLAMP(amount_to_move, -connected_cable.powernet.avail, assembly.battery.charge)
+	var//obj/item/stock_parts/cell/battery = assembly.battery
+	amount_to_move = CLAMP(amount_to_move, -min(connected_cable.powernet.avail,battery.maxcharge - battery.charge), battery.charge)
 
 	connected_cable.powernet.avail += amount_to_move
-	assembly.battery.charge -= amount_to_move
+	battery.charge -= amount_to_move
 
 /obj/item/integrated_circuit/power/transmitter/wire_connector/proc/update_cable()
 	if(get_dist(get_object(), connected_cable) > 0)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -91,7 +91,7 @@
 		return
 
 	//Second clamp: set the number between what the battery and powernet allows
-	var//obj/item/stock_parts/cell/battery = assembly.battery
+	var/obj/item/stock_parts/cell/battery = assembly.battery
 	amount_to_move = CLAMP(amount_to_move, -min(connected_cable.powernet.avail,battery.maxcharge - battery.charge), battery.charge)
 
 	connected_cable.powernet.avail += amount_to_move

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -81,10 +81,10 @@
 		return
 
 
-	if(!connected_cable)
+	if(!connected_cable || !assembly)
 		return
 
-	if(!assembly)
+	if(!assembly.battery)
 		return
 
 	//No charge transfer, no need to syphon tickrates with scripts
@@ -93,10 +93,12 @@
 
 	//Second clamp: set the number between what the battery and powernet allows
 	var/obj/item/stock_parts/cell/battery = assembly.battery
-	amount_to_move = CLAMP(amount_to_move, -min(connected_cable.powernet.avail,battery.maxcharge - battery.charge), battery.charge)
+	amount_to_move = CLAMP(amount_to_move, -connected_cable.powernet.avail, battery.charge)
 
-	connected_cable.powernet.avail += amount_to_move
-	battery.charge -= amount_to_move
+	if(amount_to_move > 0)
+		connected_cable.powernet.avail += battery.use(amount_to_move)
+		return
+	connected_cable.powernet.avail -= battery.give(-amount_to_move)
 
 /obj/item/integrated_circuit/power/transmitter/wire_connector/proc/update_cable()
 	if(get_dist(get_object(), connected_cable) > 0)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -67,7 +67,7 @@
 			activate_pin(5)
 			return
 	
-		var/obj/structure/cable/foundcable = locate(/obj/structure/cable) in get_turf(src)
+		var/obj/structure/cable/foundcable = locate() in get_turf(src)
 		// If no connector can't connect
 		if(!foundcable || foundcable.invisibility != 0)
 			set_pin_data(IC_OUTPUT, 1, null)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -27,6 +27,10 @@
 
 	var/obj/structure/cable/connected_cable
 
+/obj/item/integrated_circuit/power/transmitter/wire_connector/Destroy()
+	connected_cable = null
+	..()
+
 /obj/item/integrated_circuit/power/transmitter/wire_connector/Initialize()
 	START_PROCESSING(SSobj, src)
 	. = ..()

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -33,6 +33,7 @@
 
 //Does wire things
 /obj/item/integrated_circuit/power/transmitter/wire_connector/process()
+	..()
 	update_cable()
 	push_data()
 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/power.dm
@@ -96,7 +96,7 @@
 	amount_to_move = CLAMP(amount_to_move, -connected_cable.powernet.avail, battery.charge)
 
 	if(amount_to_move > 0)
-		connected_cable.powernet.avail += battery.use(amount_to_move)
+		connected_cable.powernet.newavail += battery.use(amount_to_move)
 		return
 	connected_cable.powernet.avail -= battery.give(-amount_to_move)
 


### PR DESCRIPTION
[Changelogs]: # Added a circuit which lets you connect to an exposed wire, read its powernet load and availability as well as either insert a certain amount of energy up to the assembly's batter charge or charge your assembly up to the wire's available power.

:cl: Shdorsh
add: Added a circuit which lets you connect to an exposed wire, read its powernet load and availability as well as either insert a certain amount of energy up to the assembly's batter charge or charge your assembly up to the wire's available power.
/:cl:

[why]: You could do some very shitty solars with assemblies now. Or syphon a near insignificant amount of energy. Or a powernet surveyor. Also, the wires need to be exposed. I thought it would be too unbalanced if this weren't the case. What are your thoughts?