### PR TITLE
[READY] Fix: adding a tg file that wasn't included in hippie

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -1729,6 +1729,7 @@
 #include "code\modules\integrated_electronics\subtypes\power.dm"
 #include "code\modules\integrated_electronics\subtypes\reagents.dm"
 #include "code\modules\integrated_electronics\subtypes\smart.dm"
+#include "code\modules\integrated_electronics\subtypes\text.dm"
 #include "code\modules\integrated_electronics\subtypes\time.dm"
 #include "code\modules\integrated_electronics\subtypes\trig.dm"
 #include "code\modules\jobs\access.dm"


### PR DESCRIPTION
[Changelogs]: # Adding a file that was in the tg dme but not inside the hippie one. Took about a few months to notice.

:cl: Shdorsh
add: text replacer circuit
fix: Integrated a tg file correctly
/:cl:

[why]: Should have been here for months. Something was clearly not checked on upstream merge PR.