### PR TITLE
[Ready][Tested]Fixed a bug in the join list circuit

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/lists.dm
@@ -4,8 +4,8 @@
 	desc = "This circuit is a huge fan of shipping. It joins 2 lists together."
 	extended_desc = "Elements found in both lists will not be removed and can be found twice in the list."
 	inputs = list(
-		"list to join" = IC_PINTYPE_LIST,
-		"list to join" = IC_PINTYPE_LIST
+		"first list" = IC_PINTYPE_LIST,
+		"second list" = IC_PINTYPE_LIST
 		)
 	outputs = list(
 		"joined list" = IC_PINTYPE_LIST


### PR DESCRIPTION

[Changelogs]: # Naming 2 inputs the same results in having only 1 input, so you can't add lists onto themselves. In other words: it turned the whole circuit useless.

:cl: Shdorsh
fix: Join list circuits now have 2 inputs, as they should
/:cl:

[why]: so late? because no one reported to me.