### PR TITLE
Ghetto cattle prod now works + code cleanup [READY]

### DIFF
--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -94,7 +94,7 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.staminaloss += stamforce
+	L.adjustStaminaLoss(stamforce)
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)

--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -1,31 +1,5 @@
 #define MAKESHIFT_BATON_CD 1.5
 
-/obj/item/melee/baton
-	var/stamforce = 80
-	var/selfcharge = 0
-	var/charge_sections = 0
-	var/shaded_charge = 0
-	var/charge_tick = 0
-	var/charge_delay = 4
-	var/cell_type = /obj/item/stock_parts/cell/potato
-
-/obj/item/melee/baton/proc/recharge_newshot()
-	return
-
-/obj/item/melee/baton/attack_self(mob/user)
-	if(cell && cell.charge >= hitcost)
-		status = !status
-		to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
-		playsound(loc, "sparks", 75, 1, -1)
-	else
-		status = 0
-		if(!cell)
-			to_chat(user, "<span class='warning'>[src] does not have a power source!</span>")
-		else
-			to_chat(user, "<span class='warning'>[src] is out of charge.</span>")
-	update_icon()
-	add_fingerprint(user)
-
 /obj/item/melee/baton/stungun
 	name = "stungun"
 	desc = "A powerful, self-charging electric stun gun, courtesy of Nanotrasen's self-defense implements."
@@ -41,27 +15,18 @@
 	hitcost = 100
 	throw_hit_chance = 20
 	attack_verb = list("poked")
-	selfcharge = 1
-	charge_sections = 3
-	shaded_charge = 1
-	charge_tick = 0
-	charge_delay = 10
+	var/selfcharge = 1
+	var/charge_sections = 3
+	var/shaded_charge = 1
+	var/charge_tick = 0
+	var/charge_delay = 10
+	preload_cell_type = /obj/item/stock_parts/cell/potato
 
 /obj/item/melee/baton/stungun/Initialize()
-	if(cell_type)
-		cell = new cell_type(src)
-	else
-		cell = new(src)
-	cell.give(cell.maxcharge)
-	recharge_newshot(1)
+	. = ..()
 	if(selfcharge)
 		START_PROCESSING(SSobj, src)
 	update_icon()
-	. = ..()
-
-/obj/item/melee/baton/stungun/attack_self(mob/user)
-	if(cell && cell.charge >= hitcost)
-		..()
 
 /obj/item/melee/baton/stungun/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/screwdriver))
@@ -89,6 +54,7 @@
 		item_state = itemState
 
 /obj/item/melee/baton/stungun/process()
+	..()
 	if(selfcharge)
 		charge_tick++
 		if(charge_tick < charge_delay)
@@ -106,85 +72,9 @@
 	playsound(loc, 'hippiestation/sound/weapons/stungun.ogg', 75, 1, -1)
 	update_icon()
 
+/obj/item/melee/baton
+	stunforce = 100
+
 /obj/item/melee/baton/cattleprod/hippie_cattleprod
+	stunforce = 40
 	w_class = WEIGHT_CLASS_NORMAL
-	stunforce = 0
-
-
-/obj/item/melee/baton/proc/baton_stun_hippie_makeshift(mob/living/L, mob/user)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
-			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
-			return 0
-	if(iscyborg(loc))
-		var/mob/living/silicon/robot/R = loc
-		if(!R || !R.cell || !R.cell.use(hitcost))
-			return 0
-	else
-		if(!deductcharge(hitcost))
-			return 0
-
-	L.Stun(stunforce)
-	L.staminaloss += stamforce //Not reduced by armour to give it an edge over a taser.
-	L.apply_effect(EFFECT_STUTTER, 7) //Duration of sec baton
-	user.changeNext_move(CLICK_CD_MELEE * MAKESHIFT_BATON_CD)
-	if(user)
-		L.lastattacker = user.real_name
-		L.lastattackerckey = user.ckey
-		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
-								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
-		log_combat(user, L, "stunned")
-
-	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
-
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		H.forcesay(GLOB.hit_appends)
-
-	return 1
-
-/obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
-	if(status && user.has_trait(TRAIT_CLUMSY) && prob(50))
-		user.visible_message("<span class='danger'>[user] accidentally hits themself with [src]!</span>", \
-							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(stamforce)
-		deductcharge(hitcost)
-		return
-
-	if(iscyborg(M))
-		..()
-		return
-
-
-	if(ishuman(M))
-		var/mob/living/carbon/human/L = M
-		if(check_martial_counter(L, user))
-			return
-
-	if(user.a_intent != INTENT_HARM)
-		if(status)
-			if(istype(src, /obj/item/melee/baton/cattleprod/hippie_cattleprod))
-				if(baton_stun_hippie_makeshift(M, user))
-					user.do_attack_animation(M)
-					return
-			else
-				if(baton_stun(M, user))
-					user.do_attack_animation(M)
-					return
-		else
-			M.visible_message("<span class='warning'>[user] has prodded [M] with [src]. Luckily it was off.</span>", \
-							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
-	else
-		if(status)
-			if(istype(src, /obj/item/melee/baton/cattleprod/hippie_cattleprod))
-				baton_stun_hippie_makeshift(M, user)
-			else
-				baton_stun(M, user)
-		..()
-
-
-
-
-
-#undef MAKESHIFT_BATON_CD

--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -76,5 +76,36 @@
 	stunforce = 100
 
 /obj/item/melee/baton/cattleprod/hippie_cattleprod
-	stunforce = 40
+	stunforce = 7
+	var/stamforce = 80
 	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/melee/baton/cattleprod/hippie_cattleprod/baton_stun(mob/living/L, mob/user)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
+			playsound(L, 'sound/weapons/genhit.ogg', 50, 1)
+			return 0
+	if(iscyborg(loc))
+		var/mob/living/silicon/robot/R = loc
+		if(!R || !R.cell || !R.cell.use(hitcost))
+			return 0
+	else
+		if(!deductcharge(hitcost))
+			return 0
+
+	L.staminaloss += stamforce
+	L.apply_effect(EFFECT_STUTTER, stunforce)
+	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
+	if(user)
+		L.lastattacker = user.real_name
+		L.lastattackerckey = user.ckey
+		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
+								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
+		log_combat(user, L, "stunned")
+
+	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
+
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.forcesay(GLOB.hit_appends)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Cattleprod now properly stuns like before
code: Stun baton code is cleaner
/:cl:

[why]: Because it was driving me autistic.