### PR TITLE
fixes clowns not being able to exit the roundstart clown car.

### DIFF
--- a/hippiestation/code/modules/vehicles/clown_car.dm
+++ b/hippiestation/code/modules/vehicles/clown_car.dm
@@ -11,6 +11,8 @@
 		to_chat(user, "<span class='notice'>You get out of [src].</span>")
 		mob_exit(M, silent)
 		return TRUE
+	else
+		..()
 
 /obj/vehicle/sealed/car/clowncar/roundstart/DumpMobs(randomstep = FALSE)//So people are not stunned on exiting the clowncar
 	for(var/i in occupants)


### PR DESCRIPTION
:cl: GuyonBroadway
fix: Clowns can now exit the roundstart clown car without having to crash into a wall. 
/:cl:


Closes:https://github.com/HippieStation/HippieStation/issues/9193

Whoops. 