### PR TITLE
Standardizes Singletank Bombs

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3030,6 +3030,7 @@
 #include "hippiestation\code\modules\antagonists\traitor\equipment\Malf_Modules.dm"
 #include "hippiestation\code\modules\antagonists\wizard\equipment\spellbook.dm"
 #include "hippiestation\code\modules\antagonists\wizard\equipment\spellbook_darkness.dm"
+#include "hippiestation\code\modules\assembly\bomb.dm"
 #include "hippiestation\code\modules\assembly\flash.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
 #include "hippiestation\code\modules\atmospherics\unary_devices\vent_pump.dm"

--- a/hippiestation/code/modules/assembly/bomb.dm
+++ b/hippiestation/code/modules/assembly/bomb.dm
@@ -1,0 +1,2 @@
+/obj/item/tank/ignite()
+	air_contents.temperature += 10


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl:
tweak: Singletank bombs now work by heating their contents.
/:cl:

[why]: Singletank bombs are a long-standing component in the code, and they've been a snowflake interaction that ignores most of the gases in the game for quite some time. What's more, the igniter in the assembly never actually affected the temperature of the gases in the mixture.