### PR TITLE
Raise ogg upload limit to 3mb

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1,7 +1,7 @@
 	////////////
 	//SECURITY//
 	////////////
-#define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
+#define UPLOAD_LIMIT		3145728 // hippie -- value raised from 1MB to 3MB (old value: 1048576)	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
 
 GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1407" = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see",


### PR DESCRIPTION
As requested
:cl:
admin: Ogg limit upload was raised from 1mb to 3mb, as requested
/:cl:
