### PR TITLE
Fixed tasers and projectiles not using new paralyze vars

### DIFF
--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -2,7 +2,7 @@
 	damage = 60
 
 /obj/item/projectile/bullet/c38 // Detectives .38 revolver
-	knockdown = 0
+	paralyze = 0
 	stun = 0
 	damage = 15
 	stamina = 45 //Plus the 15 base damage means two shots will down a perp
@@ -17,9 +17,9 @@
 
 /obj/item/projectile/bullet/shotgun_stunslug // Syndie bulldog shotgun stunslugs
 	stun = 0
-	knockdown = 0
+	paralyze = 0
 	stamina = 80 //Stunshot can stay potent to give nukies an edge.
 
 /obj/item/projectile/bullet/p50 // Sniper rifles
 	stun = 10
-	knockdown = 10
+	paralyze = 10

--- a/hippiestation/code/modules/projectiles/projectile/energy.dm
+++ b/hippiestation/code/modules/projectiles/projectile/energy.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile/energy/electrode
 	stun = 0
-	knockdown = 0
+	paralyze = 0
 	stamina = 60
 
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixed tasers insta-stunning.
fix: Fixes various projectiles not using the new paralyze variable.
/:cl:

[why]: When the combat refactor got implemented, this particular variable got changed from knockdown to paralyze, but our moduralized code didn't resulting in OP tasers.