### PR TITLE
[READY] Fixing the weakref on tank slots

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/atmospherics.dm
@@ -740,7 +740,7 @@ obj/item/integrated_circuit/atmospherics/connector/portableConnectorReturnAir()
 	do_work(2)
 
 /obj/item/integrated_circuit/input/tank_slot/do_work()
-	set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
+	set_pin_data(IC_OUTPUT, 2, WEAKREF(current_tank))
 	push_data()
 
 /obj/item/integrated_circuit/input/tank_slot/proc/push_pressure()


### PR DESCRIPTION
[Changelogs]: # Makes the tank slot's pin reference the tank as it was supposed to, and not the tank slot itself.

:cl: Shdorsh
fix: tank slot now correctly reference their inserted tank
/:cl:

[why]: Bcuz I dumm lawl

Besides; it's tested and working.