### PR TITLE
Adds a cool boot sequence to nanosuit and rids morphine injection

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -239,7 +239,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/examine(mob/user)
 	..()
-	if(mode != NONE)
+	if(mode != NANO_NONE)
 		to_chat(user, "The suit appears to be in [mode] mode.")
 	else
 		to_chat(user, "The suit appears to be offline.")
@@ -483,7 +483,7 @@
 	U.Paralyze(300)
 	U.AdjustStun(300)
 	U.Jitter(120)
-	toggle_mode(NONE, TRUE)
+	toggle_mode(NANO_NONE, TRUE)
 	shutdown = TRUE
 	addtimer(CALLBACK(src, .proc/emp_assaulttwo), 25)
 
@@ -492,13 +492,16 @@
 	sleep(35)
 	helmet.display_visor_message("Warning. EMP shutdown, all systems impaired.")
 	sleep(25)
-	helmet.display_visor_message("Switching to core function mode.")
+	helmet.display_visor_message("Switching to: core function mode.")
 	sleep(25)
 	helmet.display_visor_message("Life support priority. Warning!")
 	addtimer(CALLBACK(src, .proc/emp_assaultthree), 35)
 
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/emp_assaultthree()
+	helmet.display_visor_message("CMOS reset sequence begin, standby...")
+	sleep(20)
+	playsound(src, 'sound/machines/beep.ogg', 50, FALSE)
 	helmet.display_visor_message("4672482//-82544111.0//WRXT _YWD")
 	sleep(5)
 	helmet.display_visor_message("KPO- -86801780.768//1228.")
@@ -516,12 +519,18 @@
 	helmet.display_visor_message("MED//8189")
 	sleep(10)
 	helmet.display_visor_message("LOADING//...")
-	sleep(60)
+	sleep(30)
+	helmet.display_visor_message("Cardiac dysrhythmias treatment in progress, standby...")
+	playsound(src, 'sound/machines/defib_charge.ogg', 75, 0)
+	sleep(30)
+	playsound(src, 'sound/machines/defib_zap.ogg', 50, 0)
 	U.AdjustStun(-100)
 	U.AdjustParalyzed(-100)
 	U.adjustStaminaLoss(-55)
 	U.adjustOxyLoss(-55)
 	helmet.display_visor_message("Cleared to proceed.")
+	sleep(10)
+	playsound(src, 'sound/machines/defib_success.ogg', 75, 0)
 	shutdown = FALSE
 
 /datum/action/item_action/nanosuit

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -188,7 +188,7 @@
 	permeability_coefficient = 0.01
 	var/mob/living/carbon/human/U = null
 	var/criticalpower = FALSE
-	var/mode = NONE
+	var/mode = NANO_NONE
 	var/datum/martial_art/nano/style = new
 	var/shutdown = TRUE
 	var/current_charges = 3
@@ -467,7 +467,7 @@
 	if(!severity || shutdown)
 		return
 	set_nano_energy(max(0,cell.charge-(cell.charge/severity)),40)
-	if((mode == armor && cell.charge == 0) || (mode != armor))
+	if((mode == NANO_ARMOR && !cell.charge) || (mode != NANO_ARMOR))
 		if(prob(5/severity))
 			emp_assault()
 		else if(prob(10/severity))
@@ -1043,7 +1043,6 @@
 	to_chat(usr, "<span class='notice'>MMA Master</span>: Harm intents deals more damage, occasionally trigger series of fast hits and you can leg sweep while lying down.")
 	to_chat(usr, "<span class='notice'>Highschool Bully</span>: Grab someone and harm intent them to deliver a deadly knock down punch.")
 	to_chat(usr, "<span class='notice'>Knock out master</span>: Tighten your grip and harm intent to deliver a very deadly knock out punch.")
-
 	to_chat(usr, "<b><i>User warning: The suit is equipped with an implant which vaporizes the suit and user upon request or death.</i></b>")
 
 /obj/item/stock_parts/cell/nano

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -190,7 +190,7 @@
 	var/criticalpower = FALSE
 	var/mode = NONE
 	var/datum/martial_art/nano/style = new
-	var/shutdown = FALSE
+	var/shutdown = TRUE
 	var/current_charges = 3
 	var/max_charges = 3 //How many charges total the shielding has
 	var/medical_delay = 200 //How long after we've been shot before we can start recharging. 20 seconds here
@@ -216,6 +216,10 @@
 	var/stealth_cloak_in = 2 //transition time back into cloak
 	rad_flags = RAD_PROTECT_CONTENTS|RAD_NO_CONTAMINATE
 	rad_insulation = RAD_NO_INSULATION
+	var/healthon = FALSE
+	var/atmoson = FALSE
+	var/radon = FALSE
+	var/cellon = FALSE
 
 /obj/item/clothing/suit/space/hardsuit/nano/Initialize()
 	. = ..()
@@ -330,12 +334,11 @@
 		if(msg_time_react == 0)
 			if(BP.body_zone == BODY_ZONE_L_LEG || BP.body_zone == BODY_ZONE_R_LEG || BP.body_zone == BODY_ZONE_L_ARM || BP.body_zone == BODY_ZONE_R_ARM)
 				if(BP.brute_dam > trauma_threshold)
-					helmet.display_visor_message("Extensive blunt force detected in [BP.name]! Administering local anesthetic.")
+					helmet.display_visor_message("Extensive blunt force detected in [BP.name]!")
 					msg_time_react = 200
 				if(BP.burn_dam > trauma_threshold)
-					helmet.display_visor_message("Heat shield failure detected in [BP.name]! Administering local anesthetic.")
+					helmet.display_visor_message("Heat shield failure detected in [BP.name]!")
 					msg_time_react = 200
-				user.reagents.add_reagent("morphine", 0.5)
 			if(BP.body_zone == BODY_ZONE_HEAD)
 				if(BP.brute_dam > trauma_threshold)
 					helmet.display_visor_message("Cranial trauma detected!")
@@ -647,7 +650,40 @@
 		U.add_trait(TRAIT_NODISMEMBER, "Nanosuit")
 		if(help_verb)
 			U.verbs += help_verb
+		bootSequence()
 	..()
+
+/obj/item/clothing/suit/space/hardsuit/nano/proc/bootSequence()
+	helmet.display_visor_message("Crynet - BIOS v1.32 Syndicate Systems")
+	sleep(10)
+	helmet.display_visor_message("P.O.S.T. Commencing...")
+	sleep(30)
+	playsound(src, 'sound/machines/beep.ogg', 50, FALSE)
+	helmet.display_visor_message("Memory test: 6144PB OK(Installed Memory: 6144PB)")
+	sleep(10)
+	helmet.display_visor_message("Onboard equipment test: OK")
+	sleep(10)
+	helmet.display_visor_message("Telecommunications systems: OK")
+	sleep(10)
+	helmet.display_visor_message("Checking environment sensors, standby...")
+	sleep(20)
+	healthon = TRUE
+	helmet.display_visor_message("Life signs systems: OK")
+	sleep(5)
+	atmoson = TRUE
+	helmet.display_visor_message("Atmospheric sensors: OK")
+	sleep(5)
+	cellon = TRUE
+	helmet.display_visor_message("Power sensor: OK")
+	sleep(5)
+	radon = TRUE
+	helmet.display_visor_message("Geiger counter: OK")
+	sleep(5)
+	helmet.display_visor_message("Loading default configuration, standby...")
+	sleep(25)
+	helmet.display_visor_message("Successful. Have a safe and secure day.")
+	shutdown = FALSE
+
 
 /datum/outfit/nanosuit
 	name = "Nanosuit"
@@ -672,20 +708,20 @@
 	if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit/nano)) //Only display if actually wearing the suit.
 		var/obj/item/clothing/suit/space/hardsuit/nano/NS = wear_suit
 		if(statpanel("Crynet Nanosuit"))
-			stat("Crynet Protocols : [NS.mode != NONE?"Engaged":"Disengaged"]")
-			stat("Energy Charge:", "[round(NS.cell.percent())]%")
+			stat("Crynet Protocols : [!NS.shutdown?"Engaged":"Disengaged"]")
+			stat("Energy Charge:", "[NS.cellon?"[round(NS.cell.percent())]%":"offline"]")
 			stat("Mode:", "[NS.mode]")
-			stat("Overall Status:", "[health]% healthy")
-			stat("Nutrition Status:", "[nutrition]")
-			stat("Oxygen Loss:", "[getOxyLoss()]")
-			stat("Toxin Levels:", "[getToxLoss()]")
-			stat("Burn Severity:", "[getFireLoss()]")
-			stat("Brute Trauma:", "[getBruteLoss()]")
-			stat("Radiation Levels:","[radiation] rad")
-			stat("Body Temperature:","[bodytemperature-T0C] degrees C ([bodytemperature*1.8-459.67] degrees F)")
-			stat("Atmospheric Pressure:","[pressure] kPa")
-			stat("Atmoshperic Temperature:","<span class='[environment.temperature > FIRE_IMMUNITY_MAX_TEMP_PROTECT?"alert":"info"]'>[round(environment.temperature-T0C, 0.01)] &deg;C ([round(environment.temperature, 0.01)] K)</span>")
-			stat("Atmospheric Thermal Energy:","[THERMAL_ENERGY(environment)/1000] kJ")
+			stat("Overall Status:", "[NS.healthon?"[health]% healthy":"offline"]")
+			stat("Nutrition Status:", "[NS.healthon?"[nutrition]":"offline"]")
+			stat("Oxygen Loss:", "[NS.healthon?"[getOxyLoss()]":"offline"]")
+			stat("Toxin Levels:", "[NS.healthon?"[getToxLoss()]":"offline"]")
+			stat("Burn Severity:", "[NS.healthon?"[getFireLoss()]":"offline"]")
+			stat("Brute Trauma:", "[NS.healthon?"[getBruteLoss()]":"offline"]")
+			stat("Radiation Levels:","[NS.radon?"[radiation] rads":"offline"]")
+			stat("Body Temperature:","[NS.healthon?"["[bodytemperature-T0C] degrees C ([bodytemperature*1.8-459.67] degrees F)"]":"offline"]")
+			stat("Atmospheric Pressure:","[NS.atmoson?"[pressure] kPa":"offline"]")
+			stat("Atmoshperic Temperature:","[NS.atmoson?"<span class='[environment.temperature > FIRE_IMMUNITY_MAX_TEMP_PROTECT?"alert":"info"]'>[round(environment.temperature-T0C, 0.01)] &deg;C ([round(environment.temperature, 0.01)] K)</span>":"offline"]")
+			stat("Atmospheric Thermal Energy:","[NS.atmoson?"[THERMAL_ENERGY(environment)/1000] kJ":"offline"]")
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -289,7 +289,7 @@
 		amount = 0 //set our energy to 0
 		if(mode == NANO_CLOAK) //are we in cloak?
 			recharge_cooldown = 15 //then wait 3 seconds(1 value per 2 ticks = 15*2=30/10 = 3 seconds) to recharge again
-		if(mode != NANO_ARMOR) //we're not in cloak
+		if(mode != NANO_ARMOR && mode != NANO_NONE) //we're not in cloak
 			toggle_mode(NANO_ARMOR, TRUE) //go into it, forced
 	cell.charge = amount
 	return TRUE
@@ -522,16 +522,17 @@
 	sleep(30)
 	helmet.display_visor_message("Cardiac dysrhythmias treatment in progress, standby...")
 	playsound(src, 'sound/machines/defib_charge.ogg', 75, 0)
-	sleep(30)
+	sleep(25)
 	playsound(src, 'sound/machines/defib_zap.ogg', 50, 0)
 	U.AdjustStun(-100)
 	U.AdjustParalyzed(-100)
 	U.adjustStaminaLoss(-55)
 	U.adjustOxyLoss(-55)
 	helmet.display_visor_message("Cleared to proceed.")
-	sleep(10)
+	sleep(3)
 	playsound(src, 'sound/machines/defib_success.ogg', 75, 0)
 	shutdown = FALSE
+	toggle_mode(NANO_ARMOR)
 
 /datum/action/item_action/nanosuit
 	check_flags = AB_CHECK_STUN|AB_CHECK_CONSCIOUS
@@ -692,6 +693,7 @@
 	sleep(25)
 	helmet.display_visor_message("Successful. Have a safe and secure day.")
 	shutdown = FALSE
+	toggle_mode(NANO_ARMOR)
 
 
 /datum/outfit/nanosuit


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
add: Nanosuit has a bootup sequence, sensors come online as it loads in.
add: Nanosuit has a "revive" sequence in emp shutdown.
del: Removed nanosuit morphine injection from limb damage reaction.
fix: Var refs in nanosuit were inconsistent in some cases.
fix: Nanosuit code has strange behaviour that has now been fixed.

/:cl:

[why]: So apparently morphine was making users fall asleep whenever they had any sort of limb trauma or whatever, it was too much of a hassle to fix and caused a temporary speed boost which made the nanosuit a bit more powerful than it needed to be while at the same time fucking over the user. Long story short, I removed the injection.
The dank ass boot sequence is inspired by old computers, you will notice that all the sensors appear offline and will actually come on, section by section as the messages appear. I think that's pretty cool. Let me know what you think.

https://imgur.com/a/1iBHlOg