### PR TITLE
Removes roundstart clown car

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -16760,7 +16760,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/vehicle/sealed/car/clowncar/roundstart,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "aOA" = (

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -253,7 +253,7 @@
 			canminus = FALSE
 			canplus = TRUE
 		if(2)
-			if(issilicon(user) || IsAdminGhost(user) || tempunlocked)
+			if(tempunlocked)
 				canminus = TRUE
 				canplus = TRUE
 			else
@@ -263,7 +263,7 @@
 			canminus = TRUE
 			canplus = TRUE
 		if(4)
-			if(issilicon(user) || IsAdminGhost(user) || tempunlocked)
+			if(tempunlocked)
 				canminus = TRUE
 				canplus = TRUE
 			else
@@ -348,8 +348,8 @@
 		<h3>Temperature</h3>
 		<div class='statusDisplay'>
 		<B>Current temperature:</B> [temp2text()]<BR>
-		[(canplus && !timer && !drained) ? "<a href='?src=\ref[src];IncreaseTemp=1'>Increase Temperature</a><br>" : "<span class='linkOff'>Increase Temperature</span><br>"]
-		[(canminus && !timer && !drained) ? "<a href='?src=\ref[src];DecreaseTemp=1'>Decrease Temperature</a><br>" : "<span class='linkOff'>Decrease Temperature</span><br>"]
+		[((issilicon(user) || IsAdminGhost(user) || canplus) && !timer && !drained) ? "<a href='?src=\ref[src];IncreaseTemp=1'>Increase Temperature</a><br>" : "<span class='linkOff'>Increase Temperature</span><br>"]
+		[((issilicon(user) || IsAdminGhost(user) || canminus) && !timer && !drained) ? "<a href='?src=\ref[src];DecreaseTemp=1'>Decrease Temperature</a><br>" : "<span class='linkOff'>Decrease Temperature</span><br>"]
 		</div>
 		<h3>Drain</h3>
 		<div class='statusDisplay'>

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -51,13 +51,13 @@
 	if(!(obj_flags & EMAGGED)) //If it is not already emagged, emag it.
 		to_chat(user, "<span class='warning'>You disable the [src]'s safety features.</span>")
 		do_sparks(5, TRUE, src)
-		set_obj_flags = "EMAGGED"
+		obj_flags |= EMAGGED
 		tempunlocked = TRUE
 		drainable = TRUE
 		do_sparks(1, 1)
 		if(GLOB.adminlog)
-			log_say("[key_name(user)] emagged the poolcontroller")
-			message_admins("[key_name_admin(user)] emagged the poolcontroller")
+			log_game("[key_name(user)] emagged [src]")
+			message_admins("[key_name_admin(user)] emagged [src]")
 
 /obj/machinery/poolcontroller/attackby(obj/item/W, mob/user)
 	if(shocked && !(stat & NOPOWER))
@@ -120,16 +120,16 @@
 //procs
 /obj/machinery/poolcontroller/proc/shock(mob/user, prb)
 	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
-		return 0
+		return FALSE
 	if(!prob(prb))
-		return 0
+		return FALSE
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()
 	if(electrocute_mob(user, get_area(src), src, 0.7))
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /obj/machinery/poolcontroller/proc/poolreagent()
 	for(var/X in linkedturfs)
@@ -160,7 +160,7 @@
 		reagenttimer--
 	if(stat & (NOPOWER|BROKEN))
 		return PROCESS_KILL
-	else if(reagenttimer == 0 && !drained)
+	else if(!reagenttimer && !drained)
 		poolreagent()
 
 /obj/machinery/poolcontroller/proc/updatePool()
@@ -253,7 +253,7 @@
 			canminus = FALSE
 			canplus = TRUE
 		if(2)
-			if(tempunlocked)
+			if(issilicon(user) || IsAdminGhost(user) || tempunlocked)
 				canminus = TRUE
 				canplus = TRUE
 			else
@@ -263,7 +263,7 @@
 			canminus = TRUE
 			canplus = TRUE
 		if(4)
-			if(tempunlocked)
+			if(issilicon(user) || IsAdminGhost(user) || tempunlocked)
 				canminus = TRUE
 				canplus = TRUE
 			else
@@ -286,12 +286,12 @@
 		return
 	if(href_list["IncreaseTemp"])
 		if(canplus)
-			temperature += 1
+			temperature++
 			. = TRUE
 		handle_temp()
 	if(href_list["DecreaseTemp"])
 		if(canminus)
-			temperature -= 1
+			temperature--
 		handle_temp()
 	if(href_list["beaker"])
 		var/obj/item/reagent_containers/glass/B = beaker
@@ -348,12 +348,12 @@
 		<h3>Temperature</h3>
 		<div class='statusDisplay'>
 		<B>Current temperature:</B> [temp2text()]<BR>
-		[(canplus && timer == 0 && !drained) ? "<a href='?src=\ref[src];IncreaseTemp=1'>Increase Temperature</a><br>" : "<span class='linkOff'>Increase Temperature</span><br>"]
-		[(canminus && timer == 0 && !drained) ? "<a href='?src=\ref[src];DecreaseTemp=1'>Decrease Temperature</a><br>" : "<span class='linkOff'>Decrease Temperature</span><br>"]
+		[(canplus && !timer && !drained) ? "<a href='?src=\ref[src];IncreaseTemp=1'>Increase Temperature</a><br>" : "<span class='linkOff'>Increase Temperature</span><br>"]
+		[(canminus && !timer && !drained) ? "<a href='?src=\ref[src];DecreaseTemp=1'>Decrease Temperature</a><br>" : "<span class='linkOff'>Decrease Temperature</span><br>"]
 		</div>
 		<h3>Drain</h3>
 		<div class='statusDisplay'>
-		<B>Drain status:</B> [drainable ? "<span class='bad'>Enabled</span>" : "<span class='good'>Disabled</span>"]
+		<B>Drain status:</B> [(issilicon(user) || IsAdminGhost(user) || drainable) ? "<span class='bad'>Enabled</span>" : "<span class='good'>Disabled</span>"]
 		<br><b>Pool status:</b> "})
 	if(timer < 45)
 		if(!drained)
@@ -362,7 +362,7 @@
 			dat += "<span class='bad'>Drained</span><BR>"
 	else
 		dat += "<span class='bad'>[drained ? "Filling" : "Draining"]<BR></span>"
-	if(drainable && !timer)
+	if( (issilicon(user) || IsAdminGhost(user) || drainable) && !timer)
 		if(drained)
 			dat += "<a href='?src=\ref[src];Activate Drain=1'>Fill Pool</a><br>"
 		else

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -54,7 +54,7 @@
 		obj_flags |= EMAGGED
 		tempunlocked = TRUE
 		drainable = TRUE
-		do_sparks(1, 1)
+		do_sparks(1, TRUE, src)
 		if(GLOB.adminlog)
 			log_game("[key_name(user)] emagged [src]")
 			message_admins("[key_name_admin(user)] emagged [src]")

--- a/hippiestation/code/modules/pool/pool_wires.dm
+++ b/hippiestation/code/modules/pool/pool_wires.dm
@@ -4,6 +4,7 @@
 
 /datum/wires/poolcontroller
 	holder_type = /obj/machinery/poolcontroller
+	proper_name = "Pool"
 
 /datum/wires/poolcontroller/New(atom/holder)
 	wires = list(


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
del: Honkmobile has been cast into a deep chasm.
/:cl:

[why]: Because reeeeeeee!!