### PR TITLE
Removes roundstart clown car

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -16760,7 +16760,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/vehicle/sealed/car/clowncar/roundstart,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "aOA" = (


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
del: The clown car has been cast into oblivion. 
/:cl:

[why]: Because fuck clown car.