### PR TITLE
Buffs cattle-prod stamina force from 80 to 100

### DIFF
--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -77,7 +77,7 @@
 
 /obj/item/melee/baton/cattleprod/hippie_cattleprod
 	stunforce = 7
-	var/stamforce = 80
+	var/stamforce = 100
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/melee/baton/cattleprod/hippie_cattleprod/baton_stun(mob/living/L, mob/user)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
balance: Makeshift cattle-prod stamina damage increase from 80 to 100
/:cl:

[why]: Because we like 2 hit cattle-prods.