### PR TITLE
Fix: Adding forgotten atmos file for circuits

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3102,6 +3102,7 @@
 #include "hippiestation\code\modules\integrated_electronics\passive\power.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\access.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\arithmetic.dm"
+#include "hippiestation\code\modules\integrated_electronics\subtypes\atmospherics.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\converters.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\data_transfer.dm"
 #include "hippiestation\code\modules\integrated_electronics\subtypes\input.dm"


### PR DESCRIPTION
[Changelogs]: # With all the modularized files, seems like atmos circuits got forgotten for some reason. There you go, folks.

:cl: Shdorsh
fix: Atmos circuits have been brought back in
/:cl:

[why]:  Because I had too many things to take care of