### PR TITLE
Fixes holotool sticking to your suit storage

### DIFF
--- a/hippiestation/code/game/objects/items/holotool/holotool.dm
+++ b/hippiestation/code/game/objects/items/holotool/holotool.dm
@@ -3,7 +3,7 @@
 	desc = "A highly experimental holographic tool projector."
 	icon = 'hippiestation/icons/obj/holotool.dmi'
 	icon_state = "holotool"
-	slot_flags = SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT
 	usesound = 'sound/items/pshoom.ogg'
 	lefthand_file = 'hippiestation/icons/mob/inhands/lefthand.dmi'
 	righthand_file = 'hippiestation/icons/mob/inhands/righthand.dmi'


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Holotool will now properly go onto the belt slot.
/:cl:

[why]: Because hecking flag updates.