### PR TITLE
Fixes XorEncrypt not working

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/helpers.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/helpers.dm
@@ -138,5 +138,5 @@
 		return
 	var/r
 	for(var/i = 1 to length(string))
-		r += ascii2text(text2ascii(string,i) ^ text2ascii(key,(i-1)%length(string)+1))
+		r += ascii2text(text2ascii(string,i) ^ text2ascii(key,((i-1)%length(string))+1))
   return r


### PR DESCRIPTION
 `(i-1)%length(string)+1` evaluates to 0 on the first iteration of the loop, which breaks everything and returns some random value. Fixed by adding some parentheses, verified to work