### PR TITLE
Fixes pool hacking not allow temp adjust until update [READY]

### DIFF
--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -245,6 +245,8 @@
 	timer = 10
 	mistoff()
 	icon_state = "poolc_[temperature]"
+	if(temperature == SCALDING)
+		miston()
 	update_icon()
 
 /obj/machinery/poolcontroller/proc/CanUpTemp(mob/user)
@@ -260,19 +262,15 @@
 /obj/machinery/poolcontroller/Topic(href, href_list)
 	if(..())
 		return
-	if(!usr.canUseTopic(src))
-		return
 	if(timer > 0)
 		return
 	if(href_list["IncreaseTemp"])
 		if(CanUpTemp(usr))
 			temperature++
-			. = TRUE
 			handle_temp()
 	if(href_list["DecreaseTemp"])
 		if(CanDownTemp(usr))
 			temperature--
-			. = TRUE
 			handle_temp()
 	if(href_list["beaker"])
 		var/obj/item/reagent_containers/glass/B = beaker
@@ -320,7 +318,6 @@
 		return wires.interact(user)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	user.set_machine(src)
 	var/datum/browser/popup = new(user, "Pool Controller", name, 300, 450)
 	var/dat = ""
 	if(timer)

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -57,7 +57,6 @@
 		obj_flags |= EMAGGED
 		tempunlocked = TRUE
 		drainable = TRUE
-		do_sparks(1, TRUE, src)
 		if(GLOB.adminlog)
 			log_game("[key_name(user)] emagged [src]")
 			message_admins("[key_name_admin(user)] emagged [src]")
@@ -72,7 +71,7 @@
 		if(beaker)
 			to_chat(user, "A beaker is already loaded into the machine.")
 			return
-		if(W.reagents.total_volume >= 100 && W.reagents.reagent_list.len == 1) //check if full and allow one reageant only.
+		if(W.reagents.total_volume >= 100 && W.reagents.reagent_list.len ==1) //check if full and allow one reageant only.
 			for(var/X in W.reagents.reagent_list)
 				var/datum/reagent/R = X
 				if(R.reagent_state == SOLID)
@@ -167,20 +166,20 @@
 			for(var/mob/living/M in W) //Check for mobs in the linked pool-turfs.
 				switch(temperature) //Apply different effects based on what the temperature is set to.
 					if(SCALDING) //Scalding
-						M.bodytemperature = min(500, M.bodytemperature + 50) //heat mob at 35k(elvin) per cycle
+						M.adjust_bodytemperature(M.bodytemperature + 50,0,500)
 
 					if(FRIGID) //Freezing
-						M.bodytemperature = max(0, M.bodytemperature - 60) //cool mob at -35k per cycle, less would not affect the mob enough.
+						M.adjust_bodytemperature(M.bodytemperature - 60) //cool mob at -35k per cycle, less would not affect the mob enough.
 						if(M.bodytemperature <= 50 && !M.stat)
 							M.apply_status_effect(/datum/status_effect/freon)
 
 					if(NORMAL) //Normal temp does nothing, because it's just room temperature water.
 
 					if(WARM) //Warm
-						M.bodytemperature = min(360, M.bodytemperature + 20) //Heats up mobs till the termometer shows up
+						M.adjust_bodytemperature(M.bodytemperature + 20,0,360) //Heats up mobs till the termometer shows up
 
 					else //Cool
-						M.bodytemperature = max(250, M.bodytemperature - 20) //Cools mobs till the termometer shows up
+						M.adjust_bodytemperature(M.bodytemperature - 20,250) //Cools mobs till the termometer shows up
 				var/mob/living/carbon/human/drownee = M
 				if(drownee.stat == DEAD)
 					continue
@@ -269,12 +268,12 @@
 		if(CanUpTemp(usr))
 			temperature++
 			. = TRUE
-		handle_temp()
+			handle_temp()
 	if(href_list["DecreaseTemp"])
 		if(CanDownTemp(usr))
 			temperature--
 			. = TRUE
-		handle_temp()
+			handle_temp()
 	if(href_list["beaker"])
 		var/obj/item/reagent_containers/glass/B = beaker
 		B.forceMove(loc)

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -60,6 +60,9 @@
 		if(GLOB.adminlog)
 			log_game("[key_name(user)] emagged [src]")
 			message_admins("[key_name_admin(user)] emagged [src]")
+	else
+		to_chat(user, "<span class='warning'>The interface on [src] has been damaged.</span>")
+		return
 
 /obj/machinery/poolcontroller/attackby(obj/item/W, mob/user)
 	if(shocked && !(stat & NOPOWER))
@@ -167,19 +170,15 @@
 				switch(temperature) //Apply different effects based on what the temperature is set to.
 					if(SCALDING) //Scalding
 						M.adjust_bodytemperature(M.bodytemperature + 50,0,500)
-
+					if(WARM) //Warm
+						M.adjust_bodytemperature(M.bodytemperature + 20,0,360) //Heats up mobs till the termometer shows up
+					if(NORMAL) //Normal temp does nothing, because it's just room temperature water.
+					if(COOL)
+						M.adjust_bodytemperature(M.bodytemperature - 20,250) //Cools mobs till the termometer shows up
 					if(FRIGID) //Freezing
 						M.adjust_bodytemperature(M.bodytemperature - 60) //cool mob at -35k per cycle, less would not affect the mob enough.
 						if(M.bodytemperature <= 50 && !M.stat)
-							M.apply_status_effect(/datum/status_effect/freon)
-
-					if(NORMAL) //Normal temp does nothing, because it's just room temperature water.
-
-					if(WARM) //Warm
-						M.adjust_bodytemperature(M.bodytemperature + 20,0,360) //Heats up mobs till the termometer shows up
-
-					else //Cool
-						M.adjust_bodytemperature(M.bodytemperature - 20,250) //Cools mobs till the termometer shows up
+							M.apply_status_effect(/datum/status_effect/freon)		
 				var/mob/living/carbon/human/drownee = M
 				if(drownee.stat == DEAD)
 					continue

--- a/hippiestation/code/modules/pool/pool_controller.dm
+++ b/hippiestation/code/modules/pool/pool_controller.dm
@@ -72,7 +72,7 @@
 		if(beaker)
 			to_chat(user, "A beaker is already loaded into the machine.")
 			return
-		if(W.reagents.total_volume >= 100 && W.reagents.reagent_list.len) //check if full and allow one reageant only.
+		if(W.reagents.total_volume >= 100 && W.reagents.reagent_list.len == 1) //check if full and allow one reageant only.
 			for(var/X in W.reagents.reagent_list)
 				var/datum/reagent/R = X
 				if(R.reagent_state == SOLID)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Pool no longer requires an update after having it's thermostat hacked
/:cl:

[why]: Because ugly, non-working code is not allowed.