### PR TITLE
Some Integrated Electronics Fixes

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/helpers.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/helpers.dm
@@ -139,4 +139,4 @@
 	var/r
 	for(var/i = 1 to length(string))
 		r += ascii2text(text2ascii(string,i) ^ text2ascii(key,((i-1)%length(string))+1))
-  return r
+	return r

--- a/hippiestation/code/modules/integrated_electronics/core/special_pins/boolean_pin.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/special_pins/boolean_pin.dm
@@ -23,4 +23,4 @@
 /datum/integrated_io/boolean/display_data(var/input)
 	if(data)
 		return "(TRUE)"
-  return "(FALSE)"
+	return "(FALSE)"

--- a/hippiestation/code/modules/integrated_electronics/core/special_pins/color_pin.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/special_pins/color_pin.dm
@@ -46,4 +46,4 @@
 /datum/integrated_io/color/display_data(var/input)
 	if(!isnull(data))
 		return "(<font color='[data]'>[data]</font>)"
-  return ..()
+	return ..()

--- a/hippiestation/code/modules/integrated_electronics/core/special_pins/dir_pin.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/special_pins/dir_pin.dm
@@ -28,4 +28,4 @@
 /datum/integrated_io/dir/display_data(var/input)
 	if(!isnull(data))
 		return "([dir2text(data)])"
-  return ..()
+	return ..()

--- a/hippiestation/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/converters.dm
@@ -191,7 +191,7 @@
 	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+/obj/item/integrated_circuit/converter/rel_to_abs_coords/do_work()
 	var/x1 = get_pin_data(IC_INPUT, 1)
 	var/y1 = get_pin_data(IC_INPUT, 2)
 
@@ -221,7 +221,7 @@
 	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+/obj/item/integrated_circuit/converter/adv_rel_to_abs_coords/do_work()
 	var/turf/T = get_turf(src)
 
 	if(!T)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/text.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/text.dm
@@ -11,6 +11,7 @@
 	icon_state = "lowercase"
 	inputs = list("input" = IC_PINTYPE_STRING)
 	outputs = list("output" = IC_PINTYPE_STRING)
+	activators = list("to lowercase" = IC_PINTYPE_PULSE_IN, "on converted" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/text/lowercase/do_work()
@@ -30,9 +31,10 @@
 	icon_state = "uppercase"
 	inputs = list("input" = IC_PINTYPE_STRING)
 	outputs = list("output" = IC_PINTYPE_STRING)
+	activators = list("to uppercase" = IC_PINTYPE_PULSE_IN, "on converted" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/converter/text/do_work()
+/obj/item/integrated_circuit/text/uppercase/do_work()
 	var/result = null
 	pull_data()
 	var/incoming = get_pin_data(IC_INPUT, 1)


### PR DESCRIPTION
:cl:
fix: Fixes the reference encoder and decoder circuits and the passkey shown for the id card reader.
fix: Fixes the displayed data for the dir, color and boolean pins so that they show a value in each case.
fix: Fixes lowercase and uppercase text circuits.
fix: Fixes the relative to absolute coordinates circuits.
/:cl:

[why]: The first two problems were caused by using spaces rather than tabs, which seems to cause the value to never get returned in their respective return calls. The lowercase and uppercase text circuits didn't have any activator pins to allow their usage, and the uppercase text circuit didn't have a do_work proc set for it. As for the rel-to-abs circuits, their do_work procs were written to be for the abs-to-rel circuit, so they weren't being used by the circuit they were written for.