### PR TITLE
Updates dummies to ignore muting flags.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1375,14 +1375,14 @@
 
 /obj/item/toy/dummy
 	name = "ventriloquist dummy"
-	desc = "It's a dummy, dummy. Altclick to change the dummy's name"  //hippie -- clarifying changing the dummy's name
+	desc = "It's a dummy, dummy."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "assistant"
 	item_state = "doll"
 	var/doll_name = "Dummy"
 
 //Add changing looks when i feel suicidal about making 20 inhands for these.
-/obj/item/toy/dummy/AltClick(mob/user) //hippie -- freeing up attack_self for speaking into the dummy
+/obj/item/toy/dummy/attack_self(mob/user)
 	var/new_name = stripped_input(usr,"What would you like to name the dummy?","Input a name",doll_name,MAX_NAME_LEN)
 	if(!new_name)
 		return
@@ -1397,11 +1397,6 @@
 
 	say(message, language)
 	return NOPASS
-//hippie start -- Allows mobs like the mime (and possibly xenos i guess) to use the dummy despite being muted (inb4 changelings cry)
-/obj/item/toy/dummy/attack_self(mob/user)
-	var/msg = stripped_input("What is [src.doll_name] saying", "Doll ass play")
-	if(user.is_holding_item_of_type(src))
-		src.talk_into(user, msg)
-	else to_chat(user,"You lost your dummy dummy") //hippie end
+
 /obj/item/toy/dummy/GetVoice()
 	return doll_name

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1375,14 +1375,14 @@
 
 /obj/item/toy/dummy
 	name = "ventriloquist dummy"
-	desc = "It's a dummy, dummy."
+	desc = "It's a dummy, dummy. Altclick to change the dummy's name"  //hippie -- clarifying changing the dummy's name
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "assistant"
 	item_state = "doll"
 	var/doll_name = "Dummy"
 
 //Add changing looks when i feel suicidal about making 20 inhands for these.
-/obj/item/toy/dummy/AltClick(mob/user)
+/obj/item/toy/dummy/AltClick(mob/user) //hippie -- freeing up attack_self for speaking into the dummy
 	var/new_name = stripped_input(usr,"What would you like to name the dummy?","Input a name",doll_name,MAX_NAME_LEN)
 	if(!new_name)
 		return
@@ -1397,10 +1397,11 @@
 
 	say(message, language)
 	return NOPASS
+//hippie start -- Allows mobs like the mime (and possibly xenos i guess) to use the dummy despite being muted (inb4 changelings cry)
 /obj/item/toy/dummy/attack_self(mob/user)
 	var/msg = stripped_input("What is [src.doll_name] saying", "Doll ass play")
 	if(user.is_holding_item_of_type(src))
 		src.talk_into(user, msg)
-	else to_chat(user,"You lost your dummy dummy")
+	else to_chat(user,"You lost your dummy dummy") //hippie end
 /obj/item/toy/dummy/GetVoice()
 	return doll_name

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1382,7 +1382,7 @@
 	var/doll_name = "Dummy"
 
 //Add changing looks when i feel suicidal about making 20 inhands for these.
-/obj/item/toy/dummy/attack_self(mob/user)
+/obj/item/toy/dummy/AltClick(mob/user)
 	var/new_name = stripped_input(usr,"What would you like to name the dummy?","Input a name",doll_name,MAX_NAME_LEN)
 	if(!new_name)
 		return
@@ -1397,6 +1397,10 @@
 
 	say(message, language)
 	return NOPASS
-
+/obj/item/toy/dummy/attack_self(mob/user)
+	var/msg = stripped_input("What is [src.doll_name] saying", "Doll ass play")
+	if(user.is_holding_item_of_type(src))
+		src.talk_into(user, msg)
+	else to_chat(user,"You lost your dummy dummy")
 /obj/item/toy/dummy/GetVoice()
 	return doll_name

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2896,6 +2896,7 @@
 #include "hippiestation\code\game\objects\items\staples.dm"
 #include "hippiestation\code\game\objects\items\stunbaton.dm"
 #include "hippiestation\code\game\objects\items\tools.dm"
+#include "hippiestation\code\game\objects\items\toy.dm"
 #include "hippiestation\code\game\objects\items\twohanded.dm"
 #include "hippiestation\code\game\objects\items\vending_items.dm"
 #include "hippiestation\code\game\objects\items\weaponry.dm"

--- a/hippiestation/code/game/objects/items/toy.dm
+++ b/hippiestation/code/game/objects/items/toy.dm
@@ -1,0 +1,14 @@
+/obj/item/toy/dummy
+	desc = "It's a dummy, dummy. Altclick to change the dummy's name"
+
+/obj/item/toy/dummy/AltClick(mob/user)
+	var/new_name = stripped_input(usr,"What would you like to name the dummy?","Input a name",doll_name,MAX_NAME_LEN)
+	if(!new_name) return
+	doll_name = new_name
+	to_chat(user, "You name the dummy as \"[doll_name]\"")
+	name = "[initial(name)] - [doll_name]"
+
+/obj/item/toy/dummy/attack_self(mob/user)
+	var/msg = stripped_input("What is [doll_name] saying", "Doll ass play")
+	if(user.is_holding_item_of_type(src)) talk_into(user, msg)
+	else to_chat(user,"You lost your dummy dummy")


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # Allows anyone without the ability to speak to be able to use the dummies ventriloquism ability. Changing the mimes name is handled by alt clicks. Updates description to note name changing effect moving places. You can still talk into the dummy with :l or :r.

Credits to @Tranquill6 for the original idea and @k-k-karma for playtesting it and code input

[why]: mostly gimmicks