### PR TITLE
Fixed assemblies not showing a list of inputs that ask for input

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -632,7 +632,7 @@
 			var/i = 0
 			//Check if there is another component with the same name and append a number for identification
 			for(var/s in input_selection)
-				var/obj/item/integrated_circuit/s_circuit = s
+				var/obj/item/integrated_circuit/s_circuit = input_selection[s] //The for-loop iterates the keys of an associative list.
 				if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
 					i++
 			var/disp_name= "[input.displayed_name] \[[input]\]"


### PR DESCRIPTION
:cl:
fix: Fixed assemblies not letting you use more than one button or any other combination of more than one input circuit that would ask you for input.
/:cl:

The for-loop used to find similarly named input asking input circuits was using the keys of the associative list for the search instead of the values associated with them, which causes a runtime when the name variable of a key is being asked. For the user this meant that he couldn't use more than one input circuit of this kind in an assembly, since the list of choices is never shown to them.