### PR TITLE
Another integrated circuits assembly fix

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -593,7 +593,7 @@
 				var/i = 0
 				//Check if there is another component with the same name and append a number for identification
 				for(var/s in input_selection)
-					var/obj/item/integrated_circuit/s_circuit = s
+					var/obj/item/integrated_circuit/s_circuit = input_selection[s] //The for-loop iterates the keys of the associative list.
 					if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
 						i++
 				var/disp_name= "[input.displayed_name] \[[input]\]"


### PR DESCRIPTION
:cl:
fix: Fixes assemblies not showing your choices of input when you use an item on the assembly with more than one circuit in the assembly being able to accept it (such as having more than one weapon firing mechanism circuit in your assembly and you're trying to add a weapon to one of them.)
/:cl:

Apparently the attackby proc had a for-loop for finding similarly named input asking circuits of the same type as well, while also having the same problem with using the keys of the associative list instead of the values. Likewise as before, this just makes it so that the user can't interact with multiples of these kind of circuits when the list isn't shown to them due to a runtime.