### PR TITLE
Nanosuit armor slowdown removed, quick cuff breaking, bug fixes and code cleanup.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -647,7 +647,7 @@
 			to_chat(C, "<span class='unconscious'>You feel a breath of fresh air... which is a sensation you don't recognise...</span>")
 
 /mob/living/carbon/human/cuff_resist(obj/item/I)
-	if(dna && dna.check_mutation(HULK))
+	if(dna && dna.check_mutation(HULK) || istype(mind.martial_art, /datum/martial_art/nanosuit)) //Hippie edit -- Allows nanosuit strength mode to break cuffs fast
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		if(..(I, cuff_break = FAST_CUFFBREAK))
 			dropItemToGround(I)

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -1010,8 +1010,9 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/kill_cloak()
 	if(mode == NANO_CLOAK)
-		var/obj/item/gun/G
-		if(G && G == U.get_active_held_item())
+		var/obj/item/W = U.get_active_held_item()
+		if(istype(W, /obj/item/gun))
+			var/obj/item/gun/G = W
 			if(G.suppressed && G.can_shoot())
 				set_nano_energy(CLAMP(cell.charge-15,0,cell.charge))
 				U.filters = null
@@ -1098,23 +1099,25 @@
 	set desc = "You read through the manual..."
 	set category = "Nanosuit help"
 
-	to_chat(usr, "<b><i>Welcome to CryNet Systems user manual 1.22 rev. 6618. Today we will learn about what your new piece of hardware has to offer.</i></b>")
-	to_chat(usr, "<b><i>If you are reading this, you've probably alerted the entire sector about the purchase of an illegal syndicate item banned in a radius of 50 megaparsecs!</i></b>")
-	to_chat(usr, "<b><i>Fortunately the syndicate equipped this bad boy with high tech sensing equipment,the downside is the whole crew knows you're here.</i></b>")
-	to_chat(usr, "<b>Sensors</b>: Reagent scanner, bomb radar, medical, security and diagnostic huds, user life signs monitor and bluespace communication relay.")
-	to_chat(usr, "<b>Passive equipment</b>: Binoculars, night vision, anti-slips, shock and heat proof gloves, self refilling mini o2 tank, emergency medical systems and body temperature defroster.")
-	to_chat(usr, "<b>Press C to toggle quick mode selection.</b>")
-	to_chat(usr, "<b>Active modes</b>: Armor, strength, speed and cloak.")
-	to_chat(usr, "<span class='notice'>Armor</span>: Resist damage that would normally kill or seriously injure you. Blocks 50% of attacks at a cost of suit energy drain.")
-	to_chat(usr, "<span class='notice'>Cloak</span>: Become a ninja. Cloaking technology alters the outer layers to refract light through and around the suit, making the user appear almost completely invisible. Simple tasks such as attacking in any way, being hit or throwing objects cancels cloak.")
-	to_chat(usr, "<span class='notice'>Speed</span>: Run like a madman. Use conservatively as suit energy drains fairly quickly.")
-	to_chat(usr, "<span class='notice'>Strength</span>: Beat the shit out of objects  or people with your fists. Jump across small gabs and structures. You hit and throw harder with brute objects. You can't be grabbed aggressively or pushed. Deflect attacks and ranged hits occasionally. ")
-	to_chat(usr, "<span class='notice'>Aggressive Grab</span>: Your grabs start aggressive.")
-	to_chat(usr, "<span class='notice'>Robust push</span>: Your disarms have a 70% chance of knocking an opponent down for 4 seconds.")
-	to_chat(usr, "<span class='notice'>MMA Master</span>: Harm intents deals more damage, occasionally trigger series of fast hits and you can leg sweep while lying down.")
-	to_chat(usr, "<span class='notice'>Highschool Bully</span>: Grab someone and harm intent them to deliver a deadly knock down punch.")
-	to_chat(usr, "<span class='notice'>Knock out master</span>: Tighten your grip and harm intent to deliver a very deadly knock out punch.")
-	to_chat(usr, "<b><i>User warning: The suit is equipped with an implant which vaporizes the suit and user upon request or death.</i></b>")
+	to_chat(src, "<b><i>Welcome to CryNet Systems user manual 1.22 rev. 6618. Today we will learn about what your new piece of hardware has to offer.</i></b>")
+	to_chat(src, "<b><i>If you are reading this, you've probably alerted the entire sector about the purchase of an illegal syndicate item banned in a radius of 50 megaparsecs!</i></b>")
+	to_chat(src, "<b><i>Fortunately the syndicate equipped this bad boy with high tech sensing equipment,the downside is the whole crew knows you're here.</i></b>")
+	to_chat(src, "<b>Sensors</b>: Reagent scanner, bomb radar, medical, security and diagnostic huds, user life signs monitor and bluespace communication relay.")
+	to_chat(src, "<b>Passive equipment</b>: Binoculars, night vision, anti-slips, shock and heat proof gloves, self refilling mini o2 tank, emergency medical systems and body temperature defroster.")
+	to_chat(src, "<b>Press C to toggle quick mode selection.</b>")
+	to_chat(src, "<b>Active modes</b>: Armor, strength, speed and cloak.")
+	to_chat(src, "<span class='notice'>Armor</span>: Resist damage that would normally kill or seriously injure you. Blocks 50% of attacks at a cost of suit energy drain.")
+	to_chat(src, "<span class='notice'>Cloak</span>: Become a ninja. Cloaking technology alters the outer layers to refract light through and around the suit, making the user appear almost completely invisible. Simple tasks such as attacking in any way, being hit or throwing objects cancels cloak.")
+	to_chat(src, "<span class='notice'>Speed</span>: Run like a madman. Use conservatively as suit energy drains fairly quickly.")
+	to_chat(src, "<span class='notice'>Strength</span>: Beat the shit out of objects  or people with your fists. Jump across small gabs and structures. You hit and throw harder with brute objects. You can't be grabbed aggressively or pushed. Deflect attacks and ranged hits occasionally. ")
+	to_chat(src, "<span class='notice'>Aggressive grab</span>: Your grabs start aggressive.")
+	to_chat(src, "<span class='notice'>Robust push</span>: Your disarms have a 70% chance of knocking an opponent down for 4 seconds.")
+	to_chat(src, "<span class='notice'>MMA master</span>: Harm intents deals more damage, occasionally trigger series of fast hits and you can leg sweep while lying down.")
+	to_chat(src, "<span class='notice'>Highschool bully</span>: Grab someone and harm intent them to deliver a deadly knock down punch.")
+	to_chat(src, "<span class='notice'>Knockout master</span>: Tighten your grip and harm intent to deliver a very deadly knock out punch.")
+	to_chat(src, "<span class='notice'>Mike Tyson</span>: 2 quick punches to build confidence then land a hard right hook, sending your victim flying back.")
+	to_chat(src, "<span class='notice'>Head stomp special</span>: Target victims head while they're knocked down, stomp until their brain explodes.")
+	to_chat(src, "<b><i>User warning: The suit is equipped with an implant which vaporizes the suit and user upon request or death.</i></b>")
 
 /obj/item/stock_parts/cell/nano
 	name = "nanosuit self charging battery"

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -1056,7 +1056,7 @@
 	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(T)], with cause of [cause].")
 	playsound(loc, 'sound/effects/fuse.ogg', 30, FALSE)
 	imp_in.dust(TRUE,TRUE)
-	qdel()
+	qdel(src)
 
 /obj/item/tank/internals/emergency_oxygen/recharge
 	name = "self-filling miniature oxygen tank"

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -1054,12 +1054,9 @@
 	imp_in.visible_message("<span class='warning'>[imp_in] burns up in a flash!</span>")
 	var/turf/T = get_turf(imp_in)
 	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(T)], with cause of [cause].")
-	for(var/obj/item/I in imp_in.contents)
-		if(I == src || I == imp_in)
-			continue
-		 qdel(I)
 	playsound(loc, 'sound/effects/fuse.ogg', 30, FALSE)
 	imp_in.dust(TRUE,TRUE)
+	qdel()
 
 /obj/item/tank/internals/emergency_oxygen/recharge
 	name = "self-filling miniature oxygen tank"

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -213,7 +213,6 @@
 	var/obj/item/stock_parts/cell/nano/cell //What type of power cell this uses
 	block_chance = 0
 	var/menu_open = FALSE
-	var/datum/radial_menu/menu = null
 	//variables for cloak pausing when shooting a suppressed gun
 	var/stealth_cloak_out = 1 //transition time out of cloak
 	var/stealth_cloak_in = 2 //transition time back into cloak
@@ -237,7 +236,6 @@
 	U = null
 	QDEL_NULL(style)
 	QDEL_NULL(cell)
-	QDEL_NULL(menu)
 	return ..()
 
 /obj/item/clothing/suit/space/hardsuit/nano/examine(mob/user)
@@ -1141,7 +1139,7 @@ mob/living/carbon/human/key_up(_key, client/user)
 		return FALSE
 	return TRUE
 
-/obj/item/clothing/suit/space/hardsuit/nano/proc/open_mode_menu(mob/living/user, close = FALSE)
+/obj/item/clothing/suit/space/hardsuit/nano/proc/open_mode_menu(mob/living/user, close)
 	if(close)
 		return
 	var/list/choices = list(

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -1038,26 +1038,28 @@
 	name = "disintegration implant"
 	desc = "Ashes to ashes."
 	icon_state = "explosive"
+	actions_types = list(/datum/action/item_action/dusting_implant)
 
 /obj/item/implant/explosive/disintegrate/activate(cause)
-	if(!cause || !imp_in || active)
-		return FALSE
-	if(!src.loc) //Do we have a host?
+	if(!cause || !imp_in || cause == "emp" || active)
 		return FALSE
 	if(cause == "action_button" && !popup)
 		popup = TRUE
-		var/response = alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to vapourize!", "[name] Confirmation", "Yes", "No")
+		var/response = alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to disintergrate!", "[name] Confirmation", "Yes", "No")
 		popup = FALSE
 		if(response == "No")
 			return FALSE
-	to_chat(imp_in, "<span class='notice'>You activate your [name].</span>")
-	active = TRUE
-	var/turf/dustturf = get_turf(imp_in)
-	var/area/A = get_area(dustturf)
-	message_admins("[name] in [ADMIN_LOOKUPFLW(imp_in)] was activated at [A.name] [ADMIN_JMP(dustturf)], by cause of [cause].")
+	active = TRUE //to avoid it triggering multiple times due to dying
+	to_chat(imp_in, "<span class='notice'>Your dusting implant activates!</span>")
+	imp_in.visible_message("<span class='warning'>[imp_in] burns up in a flash!</span>")
+	var/turf/T = get_turf(imp_in)
+	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(T)], with cause of [cause].")
+	for(var/obj/item/I in imp_in.contents)
+		if(I == src || I == imp_in)
+			continue
+		 qdel(I)
 	playsound(loc, 'sound/effects/fuse.ogg', 30, FALSE)
 	imp_in.dust(TRUE,TRUE)
-	qdel(src)
 
 /obj/item/tank/internals/emergency_oxygen/recharge
 	name = "self-filling miniature oxygen tank"
@@ -1076,7 +1078,9 @@
 		var/mob/living/carbon/human/H = loc
 		var/moles_val = (ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 		var/In_Use = H.Move()
-		if(!In_Use)
+		if(In_Use)
+			return
+		else
 			sleep(10)
 			if(air_contents.gases[/datum/gas/oxygen][MOLES] < (10*moles_val))
 				air_contents.assert_gas(/datum/gas/oxygen)

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -820,7 +820,7 @@
 		bonus_damage += 5
 		picked_hit_type = "stomps on"
 		affecting = D.get_bodypart(ran_zone(A.zone_selected))
-		if(affecting.body_zone == BODY_ZONE_HEAD)
+		if(affecting.body_zone == BODY_ZONE_HEAD && !A.resting || !A.lying)
 			D.add_splatter_floor(D.loc)
 			D.adjustBrainLoss(15)
 			bonus_damage += 5
@@ -901,7 +901,7 @@
 /mob/living/carbon/monkey/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	if(user.a_intent == INTENT_HARM)
 		..(user, TRUE)
-		adjustBruteLoss(15)
+		adjustBruteLoss(20)
 		var/hitverb = "punched"
 		if(mob_size < MOB_SIZE_LARGE)
 			step_away(src,user,15)
@@ -914,7 +914,7 @@
 /mob/living/simple_animal/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	if(user.a_intent == INTENT_HARM)
 		..(user, TRUE)
-		adjustBruteLoss(15)
+		adjustBruteLoss(20)
 		var/hitverb = "punched"
 		if(mob_size < MOB_SIZE_LARGE)
 			step_away(src,user,15)
@@ -927,7 +927,8 @@
 /mob/living/carbon/alien/humanoid/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	if(user.a_intent == INTENT_HARM)
 		..(user, TRUE)
-		adjustBruteLoss(15)
+		adjustBruteLoss(25)
+		adjustStaminaLoss(35)
 		var/hitverb = "punched"
 		playsound(loc, "punch", 25, TRUE, -1)
 		visible_message("<span class='danger'>[user] has [hitverb] [src]!</span>", \
@@ -1129,20 +1130,20 @@ mob/living/carbon/human/key_up(_key, client/user)
 		if("C")
 			if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
 				var/obj/item/clothing/suit/space/hardsuit/nano/NS = wear_suit
-				NS.check_menu(TRUE)
+				NS.open_mode_menu(src, TRUE)
 				return
 	..()
 
-/obj/item/clothing/suit/space/hardsuit/nano/proc/check_menu(mob/living/user, forced = FALSE)
+/obj/item/clothing/suit/space/hardsuit/nano/proc/check_menu(mob/living/user, forced)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated() || !user.Adjacent(src))
 		return FALSE
-	if(forced)
-		return FALSE
 	return TRUE
 
-/obj/item/clothing/suit/space/hardsuit/nano/proc/open_mode_menu(mob/living/user)
+/obj/item/clothing/suit/space/hardsuit/nano/proc/open_mode_menu(mob/living/user, close = FALSE)
+	if(close)
+		return
 	var/list/choices = list(
 	"armor" = image(icon = 'hippiestation/icons/mob/actions/actions_nanosuit.dmi', icon_state = "armor_menu"),
 	"speed" = image(icon = 'hippiestation/icons/mob/actions/actions_nanosuit.dmi', icon_state = "speed_menu"),


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
add: Nanosuit can now quickly break cuffs in strength mode 
balance: Armor mode in nanosuit no longer slows you down
balance: Increased nanosuit damage to simple mobs and monkeys, aliens also take a bit of stamina damage
fix: You can no longer use the nanosuit's head stomp while laying down
fix: Attacking simple mob's in nanosuit's cloak now properly disables it
/:cl:

[why]: I feel like the slowdown penalty for the nanosuit punishes the user for no reason while strength mode felt inconsistent being able to beat up everyone and increase damage with melee objects but not let you burst out of cuffs like the hulk. Also the melee damage on simple mobs was weak. Code improvements were done to make the file more sane to read for reviewers. There were also some pretty dumb things going on like using `usr` instead of `user`, hard-coded radial menus (ew) and low end procs such as `Move()` and `Stat()` having pretty gross overrides on them. 