### PR TITLE
Fixes mentor say F4 not working

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3136,7 +3136,7 @@
 #include "hippiestation\code\modules\jobs\job_types\medical.dm"
 #include "hippiestation\code\modules\jobs\job_types\science.dm"
 #include "hippiestation\code\modules\jobs\job_types\security.dm"
-#include "hippiestation\code\modules\keybindings\bindings_admin.dm"
+#include "hippiestation\code\modules\keybindings\bindings_mentor.dm"
 #include "hippiestation\code\modules\keybindings\bindings_hippie.dm"
 #include "hippiestation\code\modules\library\lib_machines.dm"
 #include "hippiestation\code\modules\lighting\lighting_turf.dm"

--- a/hippiestation/code/modules/keybindings/bindings_mentor.dm
+++ b/hippiestation/code/modules/keybindings/bindings_mentor.dm
@@ -1,6 +1,6 @@
 /datum/mentors/key_down(_key, client/user)
 	switch(_key)
 		if("F4")
-			user.cmd_mentor_say()
+			user.get_mentor_say()
 			return
 	..()

--- a/hippiestation/code/modules/keybindings/bindings_mentor.dm
+++ b/hippiestation/code/modules/keybindings/bindings_mentor.dm
@@ -1,4 +1,4 @@
-/datum/admins/key_down(_key, client/user)
+/datum/mentors/key_down(_key, client/user)
 	switch(_key)
 		if("F4")
 			user.cmd_mentor_say()

--- a/hippiestation/code/modules/mentor/mentorsay.dm
+++ b/hippiestation/code/modules/mentor/mentorsay.dm
@@ -16,3 +16,7 @@
 	else
 		msg = "<b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>"
 	to_chat(GLOB.admins | GLOB.mentors, msg)
+	
+/client/proc/get_mentor_say()
+	var/msg = input(src, null, "asay \"text\"") as text
+	cmd_mentor_say(msg)

--- a/hippiestation/code/modules/mentor/mentorsay.dm
+++ b/hippiestation/code/modules/mentor/mentorsay.dm
@@ -16,9 +16,9 @@
 	else
 		msg = "<b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>"
 	to_chat(GLOB.admins | GLOB.mentors, msg)
-	
+
 	SSblackbox.record_feedback("tally", "mentor_verb", 1, "Msay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	
+
 /client/proc/get_mentor_say()
 	var/msg = input(src, null, "asay \"text\"") as text
 	cmd_mentor_say(msg)

--- a/hippiestation/code/modules/mentor/mentorsay.dm
+++ b/hippiestation/code/modules/mentor/mentorsay.dm
@@ -20,5 +20,5 @@
 	SSblackbox.record_feedback("tally", "mentor_verb", 1, "Msay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/get_mentor_say()
-	var/msg = input(src, null, "asay \"text\"") as text
+	var/msg = input(src, null, "msay \"text\"") as text
 	cmd_mentor_say(msg)

--- a/hippiestation/code/modules/mentor/mentorsay.dm
+++ b/hippiestation/code/modules/mentor/mentorsay.dm
@@ -5,17 +5,19 @@
 	if(!is_mentor())
 		return
 
-	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-	if(!msg)	return
+	msg = emoji_parse(copytext(sanitize(msg), 1, MAX_MESSAGE_LEN))
+	if(!msg)	
+		return
 
-	msg = emoji_parse(msg)
 	log_mentor("MSAY: [key_name(src)] : [msg]")
-
+	msg = keywords_lookup(msg)
 	if(check_rights_for(src, R_ADMIN,0))
 		msg = "<b><font color ='#8A2BE2'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>"
 	else
 		msg = "<b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>"
 	to_chat(GLOB.admins | GLOB.mentors, msg)
+	
+	SSblackbox.record_feedback("tally", "mentor_verb", 1, "Msay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	
 /client/proc/get_mentor_say()
 	var/msg = input(src, null, "asay \"text\"") as text


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
admin: Fixed not being able to use F4 to mentorsay
/:cl:

[why]: This shit was bugging me.