### PR TITLE
Multitool Functionality on Circuits Fix

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -220,7 +220,7 @@
 						io = circuit_pins.get_pin_ref(IC_INPUT, i)
 						if(io)
 							words += "<b><a href='?src=[REF(circuit_pins)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							[io.display_data(io.data)]</b><br>"
+							<a href='?src=[REF(circuit_pins)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
 							if(io.linked.len)
 								words += "<ul>"
 								for(var/k in io.linked)
@@ -241,7 +241,7 @@
 						io = circuit_pins.get_pin_ref(IC_OUTPUT, i)
 						if(io)
 							words += "<b><a href='?src=[REF(circuit_pins)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							[io.display_data(io.data)]</b><br>"
+							<a href='?src=[REF(circuit_pins)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
 							if(io.linked.len)
 								words += "<ul>"
 								for(var/k in io.linked)

--- a/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -176,7 +176,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					io = get_pin_ref(IC_INPUT, i)
 					if(io)
 						words += "<b><a href='?src=[REF(src)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							[io.display_data(io.data)]</b><br>"
+							<a href='?src=[REF(src)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
 						if(io.linked.len)
 							words += "<ul>"
 							for(var/k in io.linked)
@@ -197,7 +197,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					io = get_pin_ref(IC_OUTPUT, i)
 					if(io)
 						words += "<b><a href='?src=[REF(src)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							[io.display_data(io.data)]</b><br>"
+							<a href='?src=[REF(src)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
 						if(io.linked.len)
 							words += "<ul>"
 							for(var/k in io.linked)


### PR DESCRIPTION
:cl: 
fix: Lets you use multitools to write data on pins again.
/:cl:

With the current implementation of the assembly/circuit user interface there were no links, which are added in this pull request, to allow multitools to modify data on the pins of a circuit by itself or in an assembly even if the code for handling this does exist. Fixes #9907. (Hoping this does the job as suggested.)