### PR TITLE
More Integrated Circuits Fixes

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -108,8 +108,7 @@
 	diag_hud_set_circuitcell()
 
 /obj/item/electronic_assembly/proc/handle_idle_power()
-	if(!battery)
-		return
+
 	// First we generate power.
 	for(var/obj/item/integrated_circuit/passive/power/P in assembly_components)
 		P.make_energy()

--- a/hippiestation/code/modules/integrated_electronics/passive/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/passive/power.dm
@@ -97,7 +97,7 @@
 	activators = list("push ref" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	var/volume = 60
-	var/list/fuel = list("plasma" = 50000, "welding_fuel" = 15000, "carbon" = 10000, "ethanol" = 10000, "nutriment" = 8000)
+	var/list/fuel = list("plasma" = 50000, "slimejelly" = 22500, "welding_fuel" = 15000, "carbon" = 10000, "ethanol" = 10000, "nutriment" = 8000)
 	var/multi = 1
 	var/lfwb =TRUE
 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -842,9 +842,11 @@
 
 
 /obj/item/integrated_circuit/input/beaker_connector/proc/push_vol()
-	if(!current_beaker)
-		set_pin_data(IC_OUTPUT, 1, 0)
-	set_pin_data(IC_OUTPUT, 1, current_beaker.reagents.total_volume)
+	var/beakerVolume = 0
+	if(current_beaker)
+		beakerVolume = current_beaker.reagents.total_volume
+
+	set_pin_data(IC_OUTPUT, 1, beakerVolume)
 	push_data()
 
 


### PR DESCRIPTION
:cl:
fix: Lets idle power using circuits handle power failure again after a battery is removed from the assembly.
fix: Makes starters work again after one has been initially triggered with a charged power cell and then is tried to be triggered again with another charged power cell.
fix: Adds slime jelly as a fuel for fuel cells, as it was stated to be one.
fix: Makes beaker slot circuits stop trying to get volume from a beaker that doesn't exist after a beaker is removed.
/:cl:

The first two were problems caused by an if statement in the handle_idle_power() proc that looks if there is no battery inserted in the assembly, which will never let idle power circuits and passive power circuits handle this situation accordingly, causing, for example, starters to not work properly, because they need to know when a battery is removed to handle triggering their activator pin, and idle power using circuits, such as video camera and light circuits, to still stay on after you've removed the battery from the assembly.

Fuel cells state that slime jelly is a fuel, so it was missing, and therefore was added as one while trying to respect the stated order of efficiency.

The previous implementation for the beaker slot circuit's push_vol() proc allowed it to get the total volume of the beaker after the removal of the beaker, which causes a runtime error, because it is reading null's total volume at that point.