### PR TITLE
Fixes cat brains not changing target mobs species

### DIFF
--- a/hippiestation/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/hippiestation/code/modules/surgery/bodyparts/dismemberment.dm
@@ -3,3 +3,14 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.checknoosedrop()
+		
+/obj/item/organ/brain/transfer_to_limb(obj/item/bodypart/head/LB, mob/living/carbon/human/C)
+	Remove(C)	//Changeling brain concerns are now handled in Remove
+	forceMove(LB)
+	LB.brain = src
+	if(brainmob)
+		LB.brainmob = brainmob
+		brainmob = null
+		LB.brainmob.forceMove(LB)
+		LB.brainmob.stat = DEAD
+		C.set_species()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixes moving catbeast brains into humans leaving them as humans
/:cl:

[why]: Oof.