### PR TITLE
reagents are now transferred to target turf then reacting

### DIFF
--- a/hippiestation/code/modules/hydroponics/plant_genes.dm
+++ b/hippiestation/code/modules/hydroponics/plant_genes.dm
@@ -1,0 +1,3 @@
+/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	G.reagents.set_reacting(FALSE)
+	G.reagents.handle_reactions()


### PR DESCRIPTION

:cl:  fruits with liquid contents and separated chemicals now react on target turf when throw
/:cl:

[why]:  fruit bomb were useless because it did not reacted on target turf and if you threw it at someone the dude felt nothing https://imgur.com/AIavPzt