### PR TITLE
adds blood bucket back to slime processor

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -189,7 +189,7 @@
 	visible_message("[picked_slime] is sucked into [src].")
 	picked_slime.forceMove(src)
 
-/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
+/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)//HIPPIE CODE- This is modularized in the corresponding file in the hippie folder
 	var/mob/living/simple_animal/slime/S = what
 	if (istype(S))
 		var/C = S.cores

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -48,3 +48,8 @@
 	input = /mob/living/simple_animal/slime
 	output = null
 	required_machine = /obj/machinery/processor/slime
+
+/datum/food_processor_process/mob/living/carbon/monkey
+	input = /mob/living/carbon/monkey
+	output = null
+	required_machine = /obj/machinery/processor/slime

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -48,8 +48,3 @@
 	input = /mob/living/simple_animal/slime
 	output = null
 	required_machine = /obj/machinery/processor/slime
-
-/datum/food_processor_process/mob/living/carbon/monkey
-	input = /mob/living/carbon/monkey
-	output = null
-	required_machine = /obj/machinery/processor/slime

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3065,6 +3065,7 @@
 #include "hippiestation\code\modules\food_and_drinks\food\snacks_sandwichtoast.dm"
 #include "hippiestation\code\modules\food_and_drinks\food\snacks_soup.dm"
 #include "hippiestation\code\modules\food_and_drinks\kitchen_machinery\microwave.dm"
+#include "hippiestation\code\modules\food_and_drinks\kitchen_machinery\processor.dm"
 #include "hippiestation\code\modules\food_and_drinks\kitchen_machinery\smartfridge.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\food.dm"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3068,6 +3068,7 @@
 #include "hippiestation\code\modules\food_and_drinks\kitchen_machinery\smartfridge.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\food.dm"
+#include "hippiestation\code\modules\food_and_drinks\recipes\processor_recipes.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\tablecraft\recipes_bread.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\tablecraft\recipes_burger.dm"
 #include "hippiestation\code\modules\food_and_drinks\recipes\tablecraft\recipes_meat.dm"

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,6 +1,6 @@
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/carbon/monkey/M = what
-	var/mob/simple_animal/slime/S = wut
+	var/mob/simple_animal/slime/S = what
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -22,14 +22,14 @@
 		B.holder = bucket
 		B.volume = 70
 		//set reagent data
-		B.data["donor"] = O
-		for(var/datum/disease/D in O.viruses)
+		B.data["donor"] = M
+		for(var/datum/disease/D in M.viruses)
 			if(!(D.spread_flags & SPECIAL))
 				B.data["viruses"] += D.Copy()
-		if(O.has_dna())
-			B.data["blood_DNA"] = O.dna.unique_enzymes
-		if(O.resistances&&O.resistances.len)
-			B.data["resistances"] = O.resistances.Copy()
+		if(M.has_dna())
+			B.data["blood_DNA"] = M.dna.unique_enzymes
+		if(O.resistances&&M.resistances.len)
+			B.data["resistances"] = M.resistances.Copy()
 		bucket.reagents.reagent_list += B
 		bucket.reagents.update_total()
 		bucket.on_reagent_change()

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,5 +1,5 @@
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
-	var/mob/simple_animal/slime/S = what
+	var/mob/living/simple_animal/slime/S = what
 	var/mob/living/carbon/monkey/M = what
 	if (istype(S))
 		var/C = S.cores

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -23,13 +23,8 @@
 		B.volume = 70
 		//set reagent data
 		B.data["donor"] = M
-		for(var/datum/disease/D in M.viruses)
-			if(!(D.spread_flags & SPECIAL))
-				B.data["viruses"] += D.Copy()
 		if(M.has_dna())
 			B.data["blood_DNA"] = M.dna.unique_enzymes
-		if(M.resistances&&M.resistances.len)
-			B.data["resistances"] = M.resistances.Copy()
 		bucket.reagents.reagent_list += B
 		bucket.reagents.update_total()
 		bucket.on_reagent_change()

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,6 +1,6 @@
-/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what, atom/movable/wut)
+/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
+	var/mob/simple_animal/slime/S = what
 	var/mob/living/carbon/monkey/M = what
-	var/mob/simple_animal/slime/S = wut
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -17,7 +17,7 @@
 			M.forceMove(drop_location())
 			M.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
 			return
-		var/obj/bucket = new /obj/item/weapon/reagent_containers/glass/bucket(loc)
+		var/obj/bucket = new /obj/item/reagent_containers/glass/bucket(loc)
 		var/datum/reagent/blood/B = new()
 		B.holder = bucket
 		B.volume = 70

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,0 +1,36 @@
+/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
+	var/mob/living/carbom/monkey/M = what
+ 	var/mob/simple_animal/slime/S = what
+	if (istype(S))
+		var/C = S.cores
+		if(S.stat != DEAD)
+			S.forceMove(drop_location())
+			S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
+			return
+		for(var/i in 1 to (C+rating_amount-1))
+			var/atom/movable/item = new S.coretype(drop_location())
+			adjust_item_drop_location(item)
+			SSblackbox.record_feedback("tally", "slime_core_harvested", 1, S.colour)
+	else if (istype(M))
+		if(M.stat != DEAD)
+			M.forceMove(drop_location())
+			M.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
+			return
+		var/obj/bucket = new /obj/item/weapon/reagent_containers/glass/bucket(loc)
+		var/datum/reagent/blood/B = new()
+		B.holder = bucket
+		B.volume = 70
+		//set reagent data
+		B.data["donor"] = O
+		for(var/datum/disease/D in O.viruses)
+			if(!(D.spread_flags & SPECIAL))
+				B.data["viruses"] += D.Copy()
+		if(O.has_dna())
+			B.data["blood_DNA"] = O.dna.unique_enzymes
+		if(O.resistances&&O.resistances.len)
+			B.data["resistances"] = O.resistances.Copy()
+		bucket.reagents.reagent_list += B
+		bucket.reagents.update_total()
+		bucket.on_reagent_change()
+		//bucket_of_blood.reagents.handle_reactions() //blood doesn't react
+	..()

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -12,6 +12,7 @@
 			adjust_item_drop_location(item)
 			SSblackbox.record_feedback("tally", "slime_core_harvested", 1, S.colour)
 	else if (istype(M))
+		var/C = M
 		if(M.stat != DEAD)
 			M.forceMove(drop_location())
 			M.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,6 +1,6 @@
-/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
+/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what, atom/movable/wut)
 	var/mob/living/carbon/monkey/M = what
-	var/mob/simple_animal/slime/S = what
+	var/mob/simple_animal/slime/S = wut
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,6 +1,6 @@
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
-	var/mob/living/carbom/monkey/M = what
-	var/mob/simple_animal/slime/S = what
+	var/mob/living/carbon/monkey/M = what
+	var/mob/simple_animal/slime/S = wut
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -1,6 +1,6 @@
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/carbom/monkey/M = what
- 	var/mob/simple_animal/slime/S = what
+	var/mob/simple_animal/slime/S = what
 	if (istype(S))
 		var/C = S.cores
 		if(S.stat != DEAD)

--- a/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/hippiestation/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -28,7 +28,7 @@
 				B.data["viruses"] += D.Copy()
 		if(M.has_dna())
 			B.data["blood_DNA"] = M.dna.unique_enzymes
-		if(O.resistances&&M.resistances.len)
+		if(M.resistances&&M.resistances.len)
 			B.data["resistances"] = M.resistances.Copy()
 		bucket.reagents.reagent_list += B
 		bucket.reagents.update_total()

--- a/hippiestation/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/hippiestation/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,0 +1,4 @@
+/datum/food_processor_process/mob/monkey
+	input = /mob/living/carbon/monkey
+	output = null
+required_machine = /obj/machinery/processor/slime

--- a/hippiestation/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/hippiestation/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,4 +1,4 @@
 /datum/food_processor_process/mob/monkey
 	input = /mob/living/carbon/monkey
 	output = null
-required_machine = /obj/machinery/processor/slime
+	required_machine = /obj/machinery/processor/slime


### PR DESCRIPTION

:cl: xTrainx
fix: readds blood bucket back to the slime processor
/:cl:

[why]: turning monkeys into chucky salsa seems to have been lost some time ago after the processor recipes came to their own file, so im adding it back. It's real useful if you dont want to use your own blood, or if you dont have blood for being a slimeboi/skeleboi/golemboi and less of a hassle for everyone