### PR TITLE
wasnt overwriting code/modules/hydroponics/plant_genes.dm

### DIFF
--- a/hippiestation/code/modules/hydroponics/plant_genes.dm
+++ b/hippiestation/code/modules/hydroponics/plant_genes.dm
@@ -1,3 +1,11 @@
+/datum/plant_gene/trait/noreact
+	// Makes plant reagents not react until squashed.
+	name = "Separated Chemicals"
+
+/datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	G.reagents.set_reacting(FALSE)
+
 /datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	G.reagents.set_reacting(FALSE)
 	G.reagents.handle_reactions()


### PR DESCRIPTION
@yoyobatty merge this, found that the hippiestation/code/modules/hydroponics/plant_genes.dm was not overwriting code/modules/hydroponics/plant_genes.dm from RR-1 because didnt put all /no_react