### PR TITLE
Fixes nanosuit insta-killing other targets

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -812,8 +812,6 @@
 	var/bonus_damage = 10
 	var/quick = FALSE
 	var/obj/item/bodypart/affecting
-	if(check_streak(A,D))
-		return TRUE
 	if(D.IsParalyzed() || D.resting || D.lying)//we can hit ourselves
 		bonus_damage += 5
 		picked_hit_type = "stomps on"
@@ -824,6 +822,8 @@
 			bonus_damage += 5
 			if(D.health <= 40)
 				add_to_streak("S",D)
+				if(check_streak(A,D))
+					return TRUE
 	if(D != A && !D.stat || !D.IsParalyzed() || !D.IsStun()) //and we can't knock ourselves the fuck out/down!
 		if(A.grab_state == GRAB_AGGRESSIVE)
 			A.stop_pulling() //So we don't spam the combo
@@ -854,6 +854,8 @@
 			A.changeNext_move(CLICK_CD_RAPID)
 			.= FALSE
 			add_to_streak("Q",D)
+			if(check_streak(A,D))
+				return TRUE
 	D.visible_message("<span class='danger'>[A] [quick?"quick":""] [picked_hit_type] [D]!</span>", \
 					  "<span class='userdanger'>[A] [quick?"quick":""] [picked_hit_type] you!</span>")
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Nanosuit can no longer insta kill anyone within range after lining up a head stomp combo
/:cl:

[why]: Basically the code was checking the streak and then adding the combo which caused some cases where you would attack someone enough to build a combo, attack someone else and it would insta-kill them. Since you built up a combo but the check was done at the beginning, the next attack you did would just call `check_streak` causing an insta kill on whoever you used it on.