### PR TITLE
Allows deconstruction of reagent refinery

### DIFF
--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -50,7 +50,7 @@
 			addtimer(CALLBACK(src, /obj/machinery/reagent_sheet/proc/create_sheets, chem_material), work_time)
 			to_chat(user, "<span class='notice'>You add [working] to [src]</span>")
 			visible_message("<span class='notice'>[src] activates!</span>")
-		if(!in_range(src, S) || !user.Adjacent(src))
+		if(!in_range(src, working) || !user.Adjacent(src))
 			return
 	else
 		if(!working && default_deconstruction_screwdriver(user, icon_state, icon_state, I))

--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -10,7 +10,6 @@
 	light_range = 2
 	light_color = LIGHT_COLOR_FLARE
 	var/obj/item/reagent_containers/food/snacks/solid_reagent/working = null
-	var/obj/item/stock_parts/cell/charging = null
 	var/work_time = 300
 	var/end_volume = 100
 	circuit = /obj/item/circuitboard/machine/reagent_sheet

--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -9,7 +9,8 @@
 	light_power = 0.5
 	light_range = 2
 	light_color = LIGHT_COLOR_FLARE
-	var/working = FALSE
+	var/obj/item/reagent_containers/food/snacks/solid_reagent/working = null
+	var/obj/item/stock_parts/cell/charging = null
 	var/work_time = 300
 	var/end_volume = 100
 	circuit = /obj/item/circuitboard/machine/reagent_sheet
@@ -26,45 +27,57 @@
 		to_chat(user, "<span class='notice'>The status display reads: Outputting <b>[end_volume/20]</b> ingot(s) after <b>[work_time*0.1]</b> seconds of processing.<span>")
 
 /obj/machinery/reagent_sheet/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/reagent_containers/food/snacks/solid_reagent))
-		var/obj/item/reagent_containers/food/snacks/solid_reagent/S = I
+	if(istype(I, /obj/item/reagent_containers/food/snacks/solid_reagent) && !panel_open)
+		if(stat & BROKEN)
+			to_chat(user, "<span class='warning'>[src] is broken!</span>")
+			return
 		if(working)
 			to_chat(user, "<span class='warning'>[src] is busy!</span>")
 			return
-		if(panel_open)
-			to_chat(user, "<span class='warning'>You can't load the [I] while it's opened!</span>")
-			return
+		else
+			var/area/a = loc.loc // Gets our locations location, like a dream within a dream
+			if(!isarea(a))
+				return
+			if(a.power_equip == 0) // There's no APC in this area, don't try to cheat power!
+				to_chat(user, "<span class='warning'>[src] seems to be powered off!</span>")
+				return
+			if(!user.transferItemToLoc(I,src) && !I.reagents)
+				to_chat(user, "<span class='alert'>[src] rejects [I]</span>")
+				return
+			working = I
+			var/chem_material = working.reagents.total_volume * end_volume
+			use_power = working.reagents.total_volume
+			updateUsrDialog()
+			addtimer(CALLBACK(src, /obj/machinery/reagent_sheet/proc/create_sheets, chem_material), work_time)
+			to_chat(user, "<span class='notice'>You add [working] to [src]</span>")
+			visible_message("<span class='notice'>[src] activates!</span>")
 		if(!in_range(src, S) || !user.Adjacent(src))
 			return
-		if(S.reagents)
-			var/chem_material = S.reagents.total_volume * end_volume
-			use_power = S.reagents.total_volume
-			updateUsrDialog()
-			addtimer(CALLBACK(src, /obj/machinery/reagent_sheet/proc/create_sheets, chem_material, S.reagent_type), work_time)
-			working = TRUE
-			to_chat(user, "<span class='notice'>You add [S] to [src]</span>")
-			visible_message("<span class='notice'>[src] activates!</span>")
-			qdel(S)
-		else
-			to_chat(user, "<span class='alert'>[src] rejects the [S]</span>")
 	else
-		if(!working && default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+		if(!working && default_deconstruction_screwdriver(user, icon_state, icon_state, I))
 			return
-		if(default_deconstruction_crowbar(W))
+		if(default_deconstruction_crowbar(I))
 			return
 		return ..()
+		
+/obj/machinery/reagent_sheet/deconstruct()
+	if(working)
+		working.forceMove(drop_location())
+	return ..()
+	
+/obj/machinery/reagent_sheet/Destroy()
+	QDEL_NULL(working)
+	return ..()
 
-/obj/machinery/reagent_sheet/proc/create_sheets(amount, R)
-	visible_message("<span class='notice'>[src] finishes processing</span>")
-	playsound(src, 'sound/machines/ping.ogg', 50, 0)
-	working = FALSE
+/obj/machinery/reagent_sheet/proc/create_sheets(amount)
 	var/sheet_amount = max(round(amount / MINERAL_MATERIAL_AMOUNT), 1)
 	var/obj/item/stack/sheet/mineral/reagent/RS = new(get_turf(src))
+	visible_message("<span class='notice'>[src] finishes processing</span>")
+	playsound(src, 'sound/machines/ping.ogg', 50, 0)
 	RS.amount = sheet_amount
-	var/paths = subtypesof(/datum/reagent)//one reference per stack
-	for(var/path in paths)
+	for(var/path in subtypesof(/datum/reagent))
 		var/datum/reagent/RR = new path
-		if(RR.id == R)
+		if(RR.id == working.reagent_type)
 			RS.reagent_type = RR
 			RS.name = "[RR.name] ingots"
 			RS.singular_name = "[RR.name] ingot"

--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -28,18 +28,14 @@
 /obj/machinery/reagent_sheet/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/solid_reagent))
 		var/obj/item/reagent_containers/food/snacks/solid_reagent/S = I
-
 		if(working)
 			to_chat(user, "<span class='warning'>[src] is busy!</span>")
 			return
-
 		if(panel_open)
 			to_chat(user, "<span class='warning'>You can't load the [I] while it's opened!</span>")
 			return
-
 		if(!in_range(src, S) || !user.Adjacent(src))
 			return
-
 		if(S.reagents)
 			var/chem_material = S.reagents.total_volume * end_volume
 			use_power = S.reagents.total_volume
@@ -52,7 +48,11 @@
 		else
 			to_chat(user, "<span class='alert'>[src] rejects the [S]</span>")
 	else
-		..()
+		if(!working && default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+			return
+		if(default_deconstruction_crowbar(W))
+			return
+		return ..()
 
 /obj/machinery/reagent_sheet/proc/create_sheets(amount, R)
 	visible_message("<span class='notice'>[src] finishes processing</span>")
@@ -72,7 +72,6 @@
 			break
 		else
 			qdel(RR)
-
 	return
 
 /obj/item/circuitboard/machine/reagent_sheet


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
tweak: Gave reagent refinery the option to be deconstructed
/:cl:

[why]: This also allows non-bluespace rped's to upgrade them. Also modernizes and decancerfies the code to act like a more modern and maintainable machine.