### PR TITLE
Makes nanosuit use cell.use() proc

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -267,8 +267,8 @@
 			defrosted = FALSE
 			detecting = FALSE
 	var/energy = cell.charge //store current energy here
-	if(mode == NANO_CLOAK && !U.Move()) //are we in cloak, not moving?
-		energy -= cloak_use_rate * 0.1 //take away the cloak discharge rate at 1/10th since we're not moving
+	if(mode == NANO_CLOAK) //are we in cloak, not moving?
+		energy -= cloak_use_rate //take away the cloak discharge rate at 1/10th since we're not moving
 	if((energy < cell.maxcharge) && mode != NANO_CLOAK && !recharge_cooldown) //if our energy is less than 100, we're not in cloak and don't have a recharge delay timer
 		var/energy2 = regen_rate //store our regen rate here
 		energy2+=energy //add our current energy to it
@@ -293,7 +293,7 @@
 			recharge_cooldown = 15 //then wait 3 seconds(1 value per 2 ticks = 15*2=30/10 = 3 seconds) to recharge again
 		if(mode != NANO_ARMOR && mode != NANO_NONE) //we're not in cloak
 			toggle_mode(NANO_ARMOR, TRUE) //go into it, forced
-	cell.use(amount)
+	cell.use(round(amount))
 	return TRUE
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/addmedicalcharge()

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -278,7 +278,7 @@
 	if(msg_time_react)
 		msg_time_react -= 1
 	if(cell.charge != energy)
-		set_nano_energy(energy) //now set our current energy to the variable we modified
+		set_nano_energy(cell.charge - energy) //now set our current energy to the variable we modified
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/set_nano_energy(var/amount, var/delay = 0)
 	if(delay > recharge_cooldown)
@@ -288,8 +288,7 @@
 		criticalpower = TRUE
 	else if(amount > crit_energy) //did our energy go higher than the crit level
 		criticalpower = FALSE //turn it off
-	if(amount <= 0) //did we lose energy?
-		amount = 0 //set our energy to 0
+	if(!cell.charge) //did we lose energy?
 		if(mode == NANO_CLOAK) //are we in cloak?
 			recharge_cooldown = 15 //then wait 3 seconds(1 value per 2 ticks = 15*2=30/10 = 3 seconds) to recharge again
 		if(mode != NANO_ARMOR && mode != NANO_NONE) //we're not in cloak


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
code: Nanosuit cell charge is handled by proper procs within cells.
/:cl:

[why]: This is mainly so I can track the cell use on the blackbox tally but hey, code improvements never hurt.