### PR TITLE
Blacklists mime's cats from pictures

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -169,8 +169,6 @@
 		if((ai_user && GLOB.cameranet.checkTurfVis(T)) || (T in seen))
 			turfs += T
 			for(var/mob/M in T)
-				if(istype(M, /mob/living/simple_animal/pet/cat/mime)) //hippie start -- black lists mime's cat
-					continue //hippie end -- black lists mime's cat
 				mobs += M
 			if(locate(/obj/item/areaeditor/blueprints) in T)
 				blueprints = TRUE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -169,7 +169,7 @@
 		if((ai_user && GLOB.cameranet.checkTurfVis(T)) || (T in seen))
 			turfs += T
 			for(var/mob/M in T)
-				if(istype(M, mob/living/simple_animal/pet/cat/mime)) //hippie start -- black lists mime's cat
+				if(istype(M, /mob/living/simple_animal/pet/cat/mime)) //hippie start -- black lists mime's cat
 					continue //hippie end -- black lists mime's cat
 				mobs += M
 			if(locate(/obj/item/areaeditor/blueprints) in T)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -169,6 +169,8 @@
 		if((ai_user && GLOB.cameranet.checkTurfVis(T)) || (T in seen))
 			turfs += T
 			for(var/mob/M in T)
+				if(istype(M, mob/living/simple_animal/pet/cat/mime)) //hippie start -- black lists mime's cat
+					continue //hippie end -- black lists mime's cat
 				mobs += M
 			if(locate(/obj/item/areaeditor/blueprints) in T)
 				blueprints = TRUE

--- a/hippiestation/code/modules/paperwork/photography.dm
+++ b/hippiestation/code/modules/paperwork/photography.dm
@@ -30,6 +30,8 @@
 				continue
 			if(is_vampire(C))
 				continue
+			if(istype(C, /mob/living/simple_animal/pet/cat/mime))
+				continue
 			if(C.invisibility)
 				continue
 			var/datum/photo_disguise/D = new()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Mime's cat has been blacklisted from pictures, preventing players from using them as invisible box disguises
/:cl:

[why]: Big oof