### PR TITLE
Adds renamer circuit

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -728,3 +728,20 @@
 				STR.remove_from_storage(target_obj,drop_location())
 			else
 				STR.remove_from_storage(target_obj,container)
+
+// Renamer circuit. Renames the assembly it is in. Useful in cooperation with telecomms-based circuits.
+/obj/item/integrated_circuit/manipulation/renamer
+	name = "renamer"
+	desc = "A small circuit that renames the assembly it is in. Useful paired with speech-based circuits."
+	icon_state = "internalbm"
+	extended_desc = "This circuit accepts a string as input, and can be pulsed to rewrite the current assembly's name with said string. On success, it pulses the default pulse-out wire."
+	inputs = list("name" = IC_PINTYPE_STRING)
+	activators = list("pulse in" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
+	power_draw_per_use = 1
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+obj/item/integrated_circuit/manipulation/renamer/do_work()
+	var/new_name = get_pin_data(IC_INPUT, 1)
+	if(assembly && new_name)
+		assembly.name = new_name
+		activate_pin(2)


### PR DESCRIPTION

:cl:
add: Adds the renamer circuit, feed it a string, pulse it and it'll rename the assembly it is in.
/:cl:

[why]: Useful for tcomms circuits and such.