### PR TITLE
A Code Change for the New Proc of Pins and a Few Integrated Circuit Fixes

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/pins.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/pins.dm
@@ -22,7 +22,7 @@ D [1]/  ||
 
 /datum/integrated_io/New(loc, _name, _data, _pin_type,_ord)
 	name = _name
-	if(_data)
+	if(!isnull(_data))
 		data = _data
 	if(_pin_type)
 		pin_type = _pin_type

--- a/hippiestation/code/modules/integrated_electronics/passive/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/passive/power.dm
@@ -120,14 +120,6 @@
 	if(assembly)
 		if(assembly.battery)
 			var/bp = 5000
-			/*
-				This value is rounded, because for the greater than or equal check, the equal case won't necessarily
-				be true for all of the fuels if the compared value isn't rounded due to the division,
-				since it can introduce a small difference, which is in the interval (-0.05; 0.05) with the current fuel values and cell rate of 0.002,
-				in the calculated value, so that the value from the division we were expecting to be equal with one of the fuel values on the list won't
-				necessarily be equal without rounding.
-			*/
-			var/comparedValue = round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1)
 			if(reagents.get_reagent_amount("blood")) //only blood is powerful enough to power the station(c)
 				var/datum/reagent/blood/B = locate() in reagents.reagent_list
 				if(lfwb)
@@ -135,11 +127,11 @@
 						var/mob/M = B.data["donor"]
 						if(M && (M.stat != DEAD) && (M.client))
 							bp = 500000
-				if(comparedValue >= bp)
+				if(round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1) >= bp)
 					if(reagents.remove_reagent("blood", 1))
 						assembly.give_power(bp)
 			for(var/I in fuel)
-				if(comparedValue >= fuel[I])
+				if(round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1) >= fuel[I])
 					if(reagents.remove_reagent(I, 1))
 						assembly.give_power(fuel[I]*multi)
 

--- a/hippiestation/code/modules/integrated_electronics/passive/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/passive/power.dm
@@ -127,11 +127,11 @@
 						var/mob/M = B.data["donor"]
 						if(M && (M.stat != DEAD) && (M.client))
 							bp = 500000
-				if(round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1) >= bp)
+				if((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE > bp)
 					if(reagents.remove_reagent("blood", 1))
 						assembly.give_power(bp)
 			for(var/I in fuel)
-				if(round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1) >= fuel[I])
+				if((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE > fuel[I])
 					if(reagents.remove_reagent(I, 1))
 						assembly.give_power(fuel[I]*multi)
 

--- a/hippiestation/code/modules/integrated_electronics/passive/power.dm
+++ b/hippiestation/code/modules/integrated_electronics/passive/power.dm
@@ -120,6 +120,14 @@
 	if(assembly)
 		if(assembly.battery)
 			var/bp = 5000
+			/*
+				This value is rounded, because for the greater than or equal check, the equal case won't necessarily
+				be true for all of the fuels if the compared value isn't rounded due to the division,
+				since it can introduce a small difference, which is in the interval (-0.05; 0.05) with the current fuel values and cell rate of 0.002,
+				in the calculated value, so that the value from the division we were expecting to be equal with one of the fuel values on the list won't
+				necessarily be equal without rounding.
+			*/
+			var/comparedValue = round((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE, 0.1)
 			if(reagents.get_reagent_amount("blood")) //only blood is powerful enough to power the station(c)
 				var/datum/reagent/blood/B = locate() in reagents.reagent_list
 				if(lfwb)
@@ -127,11 +135,11 @@
 						var/mob/M = B.data["donor"]
 						if(M && (M.stat != DEAD) && (M.client))
 							bp = 500000
-				if((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE > bp)
+				if(comparedValue >= bp)
 					if(reagents.remove_reagent("blood", 1))
 						assembly.give_power(bp)
 			for(var/I in fuel)
-				if((assembly.battery.maxcharge-assembly.battery.charge) / GLOB.CELLRATE > fuel[I])
+				if(comparedValue >= fuel[I])
 					if(reagents.remove_reagent(I, 1))
 						assembly.give_power(fuel[I]*multi)
 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
@@ -798,7 +798,7 @@
 		"target NTNet addresses"= IC_PINTYPE_STRING,
 		"data to send"			= IC_PINTYPE_STRING,
 		"secondary text"		= IC_PINTYPE_STRING,
-		"passkey"				= IC_PINTYPE_STRING /* hippie -- adds hackable passkey back in */
+		"passkey"				= IC_PINTYPE_STRING
 		)
 	outputs = list(
 		"address received"			= IC_PINTYPE_STRING,

--- a/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
@@ -797,8 +797,8 @@
 	inputs = list(
 		"target NTNet addresses"= IC_PINTYPE_STRING,
 		"data to send"			= IC_PINTYPE_STRING,
-		"passkey"				= IC_PINTYPE_STRING, /* hippie -- adds hackable passkey back in */
-		"secondary text"		= IC_PINTYPE_STRING
+		"secondary text"		= IC_PINTYPE_STRING,
+		"passkey"				= IC_PINTYPE_STRING /* hippie -- adds hackable passkey back in */
 		)
 	outputs = list(
 		"address received"			= IC_PINTYPE_STRING,

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -287,7 +287,7 @@
 				for(var/i in 1 to length(harvest_output))
 					harvest_output[i] = WEAKREF(harvest_output[i])
 
-				if(harvest_output.len)
+				if(length(harvest_output))
 					set_pin_data(IC_OUTPUT, 1, harvest_output)
 					push_data()
 			if(1)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -631,7 +631,7 @@
 /obj/item/integrated_circuit/reagent/extinguisher/do_work()
 	//Check if enough volume
 	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
-	if(!reagents || (reagents.total_volume < IC_SMOKE_REAGENTS_MINIMUM_UNITS) || busy)
+	if(!reagents || reagents.total_volume < 5 || busy)
 		push_data()
 		activate_pin(3)
 		return

--- a/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
@@ -340,6 +340,9 @@
 	paiholder.set_pin_data(IC_OUTPUT, 3, A)
 	var/list/modifiers = params2list(params)
 
+	if(modifiers["shift"] && modifiers["ctrl"])
+		paiholder.do_work(10)
+		return
 	if(modifiers["shift"])
 		paiholder.do_work(7)
 		return
@@ -349,10 +352,6 @@
 	if(modifiers["ctrl"])
 		paiholder.do_work(9)
 		return
-	if(modifiers["shift"] && modifiers["ctrl"])
-		paiholder.do_work(10)
-		return
-
 
 	if(istype(A,/obj/item/electronic_assembly))
 		var/obj/item/electronic_assembly/CheckedAssembly = A


### PR DESCRIPTION
:cl:
code: Makes the New proc for pins allow you to set 0 as data.
fix: NTNet receiver circuits now output received passkeys to the passkey output pin instead of the text received pin.
fix: Integrated extinguisher circuits will now shoot the last remaining 5 units they might have in them.
fix: Fixes the plant manipulation module circuit causing a runtime error when you try to harvest a tray with no harvest.
fix: pAIs can now pulse the shift+ctrl pin when they are inside a pAI connector circuit.
/:cl:

Since New was using the if-statement

    if(_data)
        data = _data

to determine whether or not to set _data as data, you couldn't have _data = 0 to set zero as data, since if(_data) is false when _data = 0 or _data = null. So, to allow using zero, I replaced it with if(!isnull(_data)) to make it only check that you aren't trying to assign null. As a result of this, at least, new join text circuits can now have their default value for end be 0 instead of null, which is what they currently are trying to do.

Previously every NTNet receiver circuit would set the passkey on the text received output pin, because the passkey was being put as text in the circuit's do_work proc due to the passkey input pin being the third input pin instead of the fourth input pin.

Integrated extinguisher circuits were using IC_SMOKE_REAGENTS_MINIMUM_UNITS, which is 10 units at the moment, to determine whether or not the integrated extinguisher could be used. What this meant was that you could have 5 units be stuck inside the extinguisher, even if you should be able to use those 5 units.

The plant manipulation module circuit on harvest mode would try to look at the len of 0 when there was no harvest, which causes a runtime error, because 0 is not a list. Replacing harvest_output.len with length(harvest_output) seems to handle this situation properly.

pAIs couldn't pulse the shift+ctrl click pin on the pAI connector circuit, because it was being considered last instead of being considered before the modifiers it is a combination of, so now shift+ctrl click is being considered before all of the other possibilities.