### PR TITLE
[WIP] Adding pathtype pins

### DIFF
--- a/code/__DEFINES/~hippie_defines/integrated_electronics.dm
+++ b/code/__DEFINES/~hippie_defines/integrated_electronics.dm
@@ -26,6 +26,7 @@
 #define IC_FORMAT_REF			"\<REF\>"
 #define IC_FORMAT_LIST			"\<LIST\>"
 #define IC_FORMAT_INDEX			"\<INDEX\>"
+#define IC_FORMAT_PATHTYPE		"\<TYPE\>"
 
 #define IC_FORMAT_PULSE			"\<PULSE\>"
 
@@ -41,6 +42,7 @@
 #define IC_PINTYPE_LIST				/datum/integrated_io/lists
 #define IC_PINTYPE_INDEX			/datum/integrated_io/index
 #define IC_PINTYPE_SELFREF			/datum/integrated_io/selfref
+#define IC_PINTYPE_PATHTYPE			/datum/integrated_io/pathtype
 
 #define IC_PINTYPE_PULSE_IN			/datum/integrated_io/activate
 #define IC_PINTYPE_PULSE_OUT		/datum/integrated_io/activate/out

--- a/hippiestation/code/modules/integrated_electronics/core/special_pins/pathtype_pin.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/special_pins/pathtype_pin.dm
@@ -1,0 +1,14 @@
+// These pins only contain the path of an atom. Helps for future type locators.
+/datum/integrated_io/pathtype
+	name = "path type pin"
+
+/datum/integrated_io/pathtype/ask_for_pin_data(mob/user) // This clears the pin.
+	write_data_to_pin(null)
+
+/datum/integrated_io/pathtype/write_data_to_pin(var/new_data)
+	if(isnull(new_data) || ispath(new_data))
+		data = new_data
+		holder.on_data_written()
+
+/datum/integrated_io/pathtype/display_pin_type()
+	return IC_FORMAT_PATHTYPE


### PR DESCRIPTION
[Changelogs]: # Added pathtype pins and soon split between type locators and exact atom locators.

:cl: Shdorsh
add: New pathtype pins for new circuits.
/:cl:

[why]:  My aim is to branch the locators in 2 types: type locator and exact atom locator. I'll be using weakrefs possibly for the exact mob one and the new pathtype will be used for the more generalized atom type locator, which locates any atom of the same type. Only 3 more exams to go, until friday and I'm back to overhaul circuitry. I saw your work and bugfixes, folks, I'm proud of you.