### PR TITLE
Fixes reagent refinery not removing working reagent causing it to always be busy

### DIFF
--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -73,7 +73,7 @@
 	var/obj/item/stack/sheet/mineral/reagent/RS = new(get_turf(src))
 	visible_message("<span class='notice'>[src] finishes processing</span>")
 	playsound(src, 'sound/machines/ping.ogg', 50, 0)
-	qdel(working)
+	QDEL_NULL(working)
 	RS.amount = sheet_amount
 	for(var/path in subtypesof(/datum/reagent))
 		var/datum/reagent/RR = new path

--- a/hippiestation/code/game/machinery/reagent_sheet.dm
+++ b/hippiestation/code/game/machinery/reagent_sheet.dm
@@ -73,7 +73,6 @@
 	var/obj/item/stack/sheet/mineral/reagent/RS = new(get_turf(src))
 	visible_message("<span class='notice'>[src] finishes processing</span>")
 	playsound(src, 'sound/machines/ping.ogg', 50, 0)
-	QDEL_NULL(working)
 	RS.amount = sheet_amount
 	for(var/path in subtypesof(/datum/reagent))
 		var/datum/reagent/RR = new path
@@ -85,6 +84,7 @@
 			break
 		else
 			qdel(RR)
+	QDEL_NULL(working)
 	return
 
 /obj/item/circuitboard/machine/reagent_sheet


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Deleting the working reagent in the reagent refinery wasn't working and has been fixed.
/:cl:

[why]: Remember kids, always test shit.