### PR TITLE
[Ready] Adding Selfchanging Assemblies

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -759,7 +759,7 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 
 
 // - redescribing circuit - //
-/obj/item/integrated_circuit/output/redescribe
+/obj/item/integrated_circuit/manipulation/redescribe
 	name = "redescriber"
 	desc = "Takes any string as an input and will set it as the assembly's description."
 	extended_desc = "Strings should can be of any length."
@@ -771,7 +771,7 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 	activators = list("redescribe" = IC_PINTYPE_PULSE_IN,"get description" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/output/redescribe/do_work(var/n)
+/obj/item/integrated_circuit/manipulation/redescribe/do_work(var/n)
 	if(!assembly)
 		return
 
@@ -786,8 +786,8 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 	activate_pin(3)
 
 // - repainting circuit - //
-/obj/item/integrated_circuit/output/repaint
-	name = "self-repainting circuit"
+/obj/item/integrated_circuit/manipulation/repaint
+	name = "auto-repainter"
 	desc = "There's an oddly high amount of spraying cans fitted right inside this circuit."
 	extended_desc = "Takes a value in hexadecimal and uses it to repaint the assembly it is in."
 	cooldown_per_use = 10
@@ -797,7 +797,7 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 	activators = list("repaint" = IC_PINTYPE_PULSE_IN,"get color" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/output/repaint/do_work(var/n)
+/obj/item/integrated_circuit/manipulation/repaint/do_work(var/n)
 	if(!assembly)
 		return
 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -742,12 +742,72 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
+	if(!assembly)
+		return
 	switch(n)
 		if(1)
 			var/new_name = get_pin_data(IC_INPUT, 1)
-			if(assembly && new_name)
+			if(new_name)
 				assembly.name = new_name
-				activate_pin(2)
+
 		else
 			set_pin_data(IC_OUTPUT, 1, assembly.name)
+			push_data()
 
+	activate_pin(3)
+
+
+
+// - redescribing circuit - //
+/obj/item/integrated_circuit/output/redescribe
+	name = "redescriber"
+	desc = "Takes any string as an input and will set it as the assembly's description."
+	extended_desc = "Strings should can be of any length."
+	icon_state = "speaker"
+	cooldown_per_use = 10
+	complexity = 3
+	inputs = list("text" = IC_PINTYPE_STRING)
+	outputs = list("description" = IC_PINTYPE_STRING)
+	activators = list("redescribe" = IC_PINTYPE_PULSE_IN,"get description" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/output/redescribe/do_work(var/n)
+	if(!assembly)
+		return
+
+	switch(n)
+		if(1)
+			assembly.desc = get_pin_data(IC_INPUT, 1)
+
+		else
+			set_pin_data(IC_OUTPUT, assembly.desc)
+			push_data()
+
+	activate_pin(3)
+
+// - repainting circuit - //
+/obj/item/integrated_circuit/output/repaint
+	name = "self-repainting circuit"
+	desc = "There's an oddly high amount of spraying cans fitted right inside this circuit."
+	extended_desc = "Takes a value in hexadecimal and uses it to repaint the assembly it is in."
+	cooldown_per_use = 10
+	complexity = 3
+	inputs = list("color" = IC_PINTYPE_COLOR)
+	outputs = list("current color" = IC_PINTYPE_COLOR)
+	activators = list("repaint" = IC_PINTYPE_PULSE_IN,"get color" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/output/repaint/do_work(var/n)
+	if(!assembly)
+		return
+
+	switch(var/n)
+		if(1)
+			assembly.detail_color = get_pin_data(IC_INPUT, 1)
+			assembly.update_icon()
+
+		else
+			set_pin_data(IC_OUTPUT, 1, assembly.detail_color)
+			push_data()
+
+	activate_pin(3)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -736,12 +736,18 @@
 	icon_state = "internalbm"
 	extended_desc = "This circuit accepts a string as input, and can be pulsed to rewrite the current assembly's name with said string. On success, it pulses the default pulse-out wire."
 	inputs = list("name" = IC_PINTYPE_STRING)
-	activators = list("pulse in" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
+	outputs = list("current name" = IC_PINTYPE_STRING)
+	activators = list("rename" = IC_PINTYPE_PULSE_IN,"get name" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
 	power_draw_per_use = 1
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-obj/item/integrated_circuit/manipulation/renamer/do_work()
-	var/new_name = get_pin_data(IC_INPUT, 1)
-	if(assembly && new_name)
-		assembly.name = new_name
-		activate_pin(2)
+obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
+	switch(n)
+		if(1)
+			var/new_name = get_pin_data(IC_INPUT, 1)
+			if(assembly && new_name)
+				assembly.name = new_name
+				activate_pin(2)
+		else
+			set_pin_data(IC_OUTPUT, 1, assembly.name)
+

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -801,7 +801,7 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 	if(!assembly)
 		return
 
-	switch(var/n)
+	switch(n)
 		if(1)
 			assembly.detail_color = get_pin_data(IC_INPUT, 1)
 			assembly.update_icon()

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -780,7 +780,7 @@ obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 			assembly.desc = get_pin_data(IC_INPUT, 1)
 
 		else
-			set_pin_data(IC_OUTPUT, assembly.desc)
+			set_pin_data(IC_OUTPUT, 1, assembly.desc)
 			push_data()
 
 	activate_pin(3)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -741,7 +741,7 @@
 	power_draw_per_use = 1
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
+/obj/item/integrated_circuit/manipulation/renamer/do_work(var/n)
 	if(!assembly)
 		return
 	switch(n)


### PR DESCRIPTION
[Changelogs]: # It's done. It's the continuation of #9561, only post-modularization and with a few slightly added functions: you can now get the name, description and color of the assembly aswell.
:cl: Shdorsh
add: redescriber and repainter circuit
tweak: renamer circuit can read assembly name
/:cl:

[why]: It was planned and many people sobbed since I had to focus on studying and this didn't get implemented.

Edit: Tested and working.