### PR TITLE
[READY]Circuitry Copyright Agreement Of 2018 (make circuits id-lockable and sealable)

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/analyzer.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/analyzer.dm
@@ -9,6 +9,10 @@
 /obj/item/integrated_electronics/analyzer/afterattack(var/atom/A, var/mob/living/user)
 	. = ..()
 	if(istype(A, /obj/item/electronic_assembly))
+		var/obj/item/electronic_assembly/EA = A
+		if(EA.idlock)
+			to_chat(user, "<span class='notice'>[A] is currently identity-locked and can't be analyzed.</span>")
+
 		var/saved = "[A.name] analyzed! On circuit printers with cloning enabled, you may use the code below to clone the circuit:<br><br><code>[SScircuit.save_electronic_assembly(A)]</code>"
 		if(saved)
 			to_chat(user, "<span class='notice'>You scan [A].</span>")

--- a/hippiestation/code/modules/integrated_electronics/core/analyzer.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/analyzer.dm
@@ -12,6 +12,7 @@
 		var/obj/item/electronic_assembly/EA = A
 		if(EA.idlock)
 			to_chat(user, "<span class='notice'>[A] is currently identity-locked and can't be analyzed.</span>")
+			return FALSE
 
 		var/saved = "[A.name] analyzed! On circuit printers with cloning enabled, you may use the code below to clone the circuit:<br><br><code>[SScircuit.save_electronic_assembly(A)]</code>"
 		if(saved)

--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -579,6 +579,28 @@
 /obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
 	if(can_anchor && default_unfasten_wrench(user, I, 20))
 		return
+
+	// ID-Lock part: check if we have an id-lock and only lock if we're not trying to get values from it, to prevent accidents
+	if(istype(I, /obj/item/integrated_electronics/debugger))
+		var/obj/item/integrated_electronics/debugger/debugger = I
+		if(debugger.idlock)
+			// check if unlocked to lock
+			if(!idlock)
+				idlock = debugger.idlock
+				to_chat(user,"<span class='notice'>You lock \the [src].</span>")
+
+			//if locked, unlock if ids match
+			else
+				if(idlock == debugger.idlock)
+					idlock = null
+					to_chat(user,"<span class='notice'>You unlock \the [src].</span>")
+
+				else
+					to_chat(user,"<span class='notice'>The scanned ID doesn't match with \the [src]'s lock.</span>")
+
+			debugger.idlock = null
+			return
+
 	if(istype(I, /obj/item/integrated_circuit))
 		if(!user.canUnEquip(I))
 			return FALSE
@@ -588,6 +610,7 @@
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
+
 	else if(I.tool_behaviour == TOOL_MULTITOOL || istype(I, /obj/item/integrated_electronics/wirer) || istype(I, /obj/item/integrated_electronics/debugger))
 		if(opened)
 			interact(user)
@@ -597,6 +620,7 @@
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
+
 	else if(istype(I, /obj/item/stock_parts/cell))
 		if(!opened)
 			to_chat(user, "<span class='warning'>[src]'s hatch is closed, so you can't access \the [src]'s power supplier.</span>")
@@ -614,10 +638,12 @@
 		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>You slot the [I] inside \the [src]'s power supplier.</span>")
 		return TRUE
+
 	else if(istype(I, /obj/item/integrated_electronics/detailer))
 		var/obj/item/integrated_electronics/detailer/D = I
 		detail_color = D.detail_color
 		update_icon()
+
 	else
 		if(user.a_intent != INTENT_HELP)
 			return ..()

--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -547,7 +547,7 @@
 	update_icon()
 	return TRUE
 
-/obj/item/electronic_assembly/welder_act(obj/item/I, mob/living/user)
+/obj/item/electronic_assembly/welder_act(mob/living/user, obj/item/I)
 	var/type_to_use
 
 	if(!sealed)

--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -34,7 +34,7 @@
 	var/creator // circuit creator if any
 	var/static/next_assembly_id = 0
 	var/sealed = FALSE
-	var/obj/item/card/id/idlock = null
+	var/datum/weakref/idlock = null
 
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_TRACK_HUD, DIAG_CIRCUIT_HUD) //diagnostic hud overlays
 	max_integrity = 50
@@ -606,7 +606,7 @@
 
 			//if locked, unlock if ids match
 			else
-				if(idlock == debugger.idlock)
+				if(idlock.resolve() == debugger.idlock.resolve())
 					idlock = null
 					to_chat(user,"<span class='notice'>You unlock \the [src].</span>")
 

--- a/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/assemblies.dm
@@ -553,13 +553,16 @@
 	if(!sealed)
 		type_to_use = input("What would you like to do?","[src] type setting") as null|anything in list("repair", "seal")
 	else
-		type_to_use = "repair"
+		type_to_use = input("What would you like to do?","[src] type setting") as null|anything in list("repair", "unseal")
 
 	switch(type_to_use)
 		if("repair")
+			to_chat(world,"Integrity: [obj_integrity] / [max_integrity]")
 			if(obj_integrity < max_integrity)
 				obj_integrity = min(obj_integrity + 20,max_integrity)
+				to_chat(world,"Integrity: [obj_integrity] / [max_integrity]")
 				to_chat(user,"<span class='notice'>You fix the dents and scratches of the assembly.</span>")
+				to_chat(world,user)
 				return TRUE
 
 			else
@@ -569,12 +572,24 @@
 		if("seal")
 			if(!opened)
 				sealed = TRUE
-				to_chat(user,"<span class='notice'>You seal the assembly, making it impossible to be opened.</span>")
-				return TRUE
+				if(I.use_tool(src, user, 50, volume=100, amount=3))
+					to_chat(user,"<span class='notice'>You seal the assembly, making it impossible to be opened.</span>")
+					return TRUE
 
 			else
 				to_chat(user,"<span class='notice'>You need to close the assembly first before sealing it indefinitely!</span>")
 				return FALSE
+
+		if("unseal")
+			to_chat(user,"<span class='notice'>You start unsealing the assembly carefully...</span>")
+			if(I.use_tool(src, user, 50, volume=250, amount=3))
+				for(var/obj/item/integrated_circuit/IC in assembly_components)
+					if(prob(50))
+						IC.disconnect_all()
+
+				to_chat(user,"<span class='notice'>You unsealed the assembly.</span>")
+				sealed = FALSE
+				return TRUE
 
 /obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
 	if(can_anchor && default_unfasten_wrench(user, I, 20))

--- a/hippiestation/code/modules/integrated_electronics/core/debugger.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/debugger.dm
@@ -10,6 +10,8 @@
 	var/data_to_write = null
 	var/accepting_refs = FALSE
 	var/copy_values = FALSE
+	var/copy_id = FALSE
+	var/obj/item/card/id/idlock = null
 
 /obj/item/integrated_electronics/debugger/attack_self(mob/user)
 	var/type_to_use = input("Please choose a type to use.","[src] type setting") as null|anything in list("string","number","ref","copy","null")
@@ -21,6 +23,7 @@
 		if("string")
 			accepting_refs = FALSE
 			copy_values = FALSE
+			copy_id = FALSE
 			new_data = stripped_input(user, "Now type in a string.","[src] string writing", no_trim = TRUE)
 			if(istext(new_data) && user.IsAdvancedToolUser())
 				data_to_write = new_data
@@ -28,6 +31,7 @@
 		if("number")
 			accepting_refs = FALSE
 			copy_values = FALSE
+			copy_id = FALSE
 			new_data = input(user, "Now type in a number.","[src] number writing") as null|num
 			if(isnum(new_data) && user.IsAdvancedToolUser())
 				data_to_write = new_data
@@ -35,17 +39,25 @@
 		if("ref")
 			accepting_refs = TRUE
 			copy_values = FALSE
+			copy_id = FALSE
 			to_chat(user, "<span class='notice'>You turn \the [src]'s ref scanner on.  Slide it across \
 			an object for a ref of that object to save it in memory.</span>")
 		if("copy")
 			accepting_refs = FALSE
 			copy_values = TRUE
+			copy_id = FALSE
 			to_chat(user, "<span class='notice'>You turn \the [src]'s value copier on.  Use it on a pin \
 			to save its current value in memory.</span>")
 		if("null")
 			data_to_write = null
 			copy_values = FALSE
 			to_chat(user, "<span class='notice'>You set \the [src]'s memory to absolutely nothing.</span>")
+		if("id lock")
+			accepting_refs = FALSE
+			copy_values = FALSE
+			copy_id = TRUE
+			to_chat(user, "<span class='notice'>You turn \the [src]'s id card scanner on. Use your own card \
+			to store the identity and id-lock an assembly.</span>")
 
 /obj/item/integrated_electronics/debugger/afterattack(atom/target, mob/living/user, proximity)
 	. = ..()
@@ -55,6 +67,18 @@
 		to_chat(user, "<span class='notice'>You set \the [src]'s memory to a reference to [target.name] \[Ref\].  The ref scanner is \
 		now off.</span>")
 		accepting_refs = FALSE
+
+	else if(copy_id && proximity)
+		if(istype(target,/obj/item/card/id))
+			idlock = target
+			to_chat(user, "<span class='notice'>You set \the [src]'s card memory to [target.name].  The id card scanner is \
+			now off.</span>")
+
+		else
+			to_chat(user, "<span class='notice'>You turn the id card scanner is off.</span>")
+
+		copy_id = FALSE
+		return
 
 /obj/item/integrated_electronics/debugger/proc/write_data(var/datum/integrated_io/io, mob/user)
 	//If the pin can take data:

--- a/hippiestation/code/modules/integrated_electronics/core/debugger.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/debugger.dm
@@ -11,7 +11,7 @@
 	var/accepting_refs = FALSE
 	var/copy_values = FALSE
 	var/copy_id = FALSE
-	var/obj/item/card/id/idlock = null
+	var/datum/weakref/idlock = null
 
 /obj/item/integrated_electronics/debugger/attack_self(mob/user)
 	var/type_to_use = input("Please choose a type to use.","[src] type setting") as null|anything in list("string","number","ref","copy","null")
@@ -70,7 +70,7 @@
 
 	else if(copy_id && proximity)
 		if(istype(target,/obj/item/card/id))
-			idlock = target
+			idlock = WEAKREF(target)
 			to_chat(user, "<span class='notice'>You set \the [src]'s card memory to [target.name].  The id card scanner is \
 			now off.</span>")
 

--- a/hippiestation/code/modules/integrated_electronics/core/printer.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/printer.dm
@@ -43,6 +43,8 @@
 	visible_message("<span class='notice'>[src] has finished printing its assembly!</span>")
 	playsound(src, 'sound/items/poster_being_created.ogg', 50, TRUE)
 	var/obj/item/electronic_assembly/assembly = SScircuit.load_electronic_assembly(get_turf(src), program)
+	if(idlock)
+		assembly.idlock = idlock
 	assembly.creator = key_name(user)
 	assembly.investigate_log("was printed by [assembly.creator].", INVESTIGATE_CIRCUIT)
 	cloning = FALSE
@@ -151,7 +153,7 @@
 	if((can_clone && CONFIG_GET(flag/ic_printing)) || debug)
 		HTML += "Here you can load script for your assembly.<br>"
 		if(!cloning)
-			HTML += " <A href='?src=[REF(src)];print=load'>{Load Program}</a> "
+			HTML += " <A href='?src=[REF(src)];print=load'>Load Program</a> "
 		else
 			HTML += " Load Program"
 		if(!program)
@@ -165,9 +167,9 @@
 	HTML += "Categories:"
 	for(var/category in SScircuit.circuit_fabricator_recipe_list)
 		if(category != current_category)
-			HTML += " <a href='?src=[REF(src)];category=[category]'>\[[category]\]</a> "
+			HTML += " <a href='?src=[REF(src)];category=[category]'>[category]</a> "
 		else // Bold the button if it's already selected.
-			HTML += " <b>\[[category]\]</b> "
+			HTML += " <b>[category]</b> "
 	HTML += "<hr>"
 	HTML += "<center><h4>[current_category]</h4></center>"
 


### PR DESCRIPTION
[Changelogs]: # Chuckster Corp and Nanotrasen have come to an agreement that the user of their products should have the ability to protect their designs as their own intellectual property. As such, the new printers were fitted with blueprints of permanently sealable assemblies in order to prevent tampering and theft of design. Due to a collaboration, the id-card system has been expanded to be used for locking an assembly's identity and preventing the use of analyzers on them. The use of third party analyzers and modified analyzers who can break this encryption are against the terms of service.

:cl: Shdorsh
tweak: circuits can be sealed so no one can tamper with their insides directly. Unsealing has a 50% probability to remove circuit connections.
tweak: debuggers have a special id lock setting now, that can be used to prevent analyzing assemblies.
tweak: making printers id lockable so they only print out id locked circuits. also, making the printers look slightly better.
/:cl:

[why]: Make it so that greyshits don't steal other people's design and have to come up with their own. Also, make circuits more secure to use so people can show off their best without the constant fear of the circuit analyzer.