### PR TITLE
Fixes custom emotes saying you're banned

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -413,7 +413,7 @@
 		. = FALSE
 
 /datum/emote/living/custom/run_emote(mob/user, params, type_override = null)
-	if(!is_banned_from(user.ckey, "emote"))
+	if(is_banned_from(user.ckey, "emote"))
 		to_chat(user, "You cannot send custom emotes (banned).")
 		return FALSE
 	else if(QDELETED(user))


### PR DESCRIPTION

:cl: 
fix: Custom emotes can be used again, without displaying the banned message.
/:cl:

[why]: ree.