### PR TITLE
K-K-Karma annihilates HideAndSeekLOGIC with facts and good coding practises

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -50,29 +50,7 @@
 		Die()
 
 /obj/item/clothing/mask/facehugger/attackby(obj/item/O, mob/user, params)
-	/* hippie start -- moved into type check
 	return O.attack_obj(src, user)
-	hippie end*/
-	// hippie start -- special effects when hit by genderchange potion
-	if(!istype(O, /obj/item/slimepotion/genderchange))
-		return O.attack_obj(src, user)
-
-	if(stat == DEAD)
-		to_chat(user, "<span class='warning'>The potion can only be used if the creature is alive!</span>")
-		return
-
-	if(sterile)
-		visible_message("<span class='danger'>[src] grows a proboscis!</span>")
-		sterile = 0
-	else
-		visible_message("<span class='danger'>[src]'s proboscis shrivels up and drops off!</span>")
-		sterile = 1
-
-	qdel(O)
-	// hippie end
-	
-	return
-
 
 /obj/item/clothing/mask/facehugger/attack_alien(mob/user) //can be picked up by aliens
 	return attack_hand(user)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -46,8 +46,10 @@
 
 		if(!Target || client)
 			break
-
+		/* hippie start
 		if(Target.health <= -70 || Target.stat == DEAD)
+		hippie end*/
+		if(Target.health <= -70 || Target.stat != CONSCIOUS) //hippie -- nerf slimes a bit and make xenobio faster
 			Target = null
 			AIproc = 0
 			break

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3201,6 +3201,7 @@
 #include "hippiestation\code\modules\mob\living\carbon\life.dm"
 #include "hippiestation\code\modules\mob\living\carbon\reindex_screams.dm"
 #include "hippiestation\code\modules\mob\living\carbon\alien\alien.dm"
+#include "hippiestation\code\modules\mob\living\carbon\alien\facehugger.dm"
 #include "hippiestation\code\modules\mob\living\carbon\human\damage_procs.dm"
 #include "hippiestation\code\modules\mob\living\carbon\human\emote.dm"
 #include "hippiestation\code\modules\mob\living\carbon\human\human.dm"

--- a/hippiestation/code/modules/mob/living/carbon/alien/facehugger.dm
+++ b/hippiestation/code/modules/mob/living/carbon/alien/facehugger.dm
@@ -1,0 +1,19 @@
+/obj/item/clothing/mask/facehugger/attackby(obj/item/O, mob/user, params)
+	if(!istype(O, /obj/item/slimepotion/genderchange))
+		return O.attack_obj(src, user)
+
+	if(stat == DEAD)
+		to_chat(user, "<span class='warning'>The potion can only be used if the creature is alive!</span>")
+		return
+
+	if(sterile)
+		user.visible_message("<span class='danger'>[src] grows a proboscis!</span>", "<span class='danger'>[src] grows a proboscis!</span>")
+		sterile = 0
+	else
+		user.visible_message("<span class='danger'>[src]'s proboscis shrivels up and drops off!</span>", "<span class='danger'>[src]'s proboscis shrivels up and drops off!</span>")
+		sterile = 1
+
+		qdel(O)
+		log_admin("[key_name(user)] used a gender change potion on a facehugger at [get_turf(user)]")
+
+		return


### PR DESCRIPTION
:cl: HideAndSeekLOGIC
balance: NPC slimes can't eat anything that isn't conscious anymore
fix: fixed slimes eating half-eaten monkeys instead of healthy monkeys
code: modularised the most intense form of xenobiology
admin: added logs for the most intense form of xenobiology to show when and where a facehugger was genderchanged and by whom
/:cl:

[why]: 

Last two things are kind of a must. @k-k-karma was quite adamant about me doing the modularisation, I decided to chuck in the logs as a bonus since I'd assume admins would want to know when Denark released xenos again.

First two things are the result of my xenobiology buff - slimes couldn't kill monkeys fast enough with the sped up evolving so they ended up eating half-eaten ones, slowing the whole thing down. Instead of buffing the slimes, I decided to give them a little nerf; they already deal clone damage, have stuns, are almost immune to melee, etc., so making them generally not put people below softcrit should be a welcome nerf.