### PR TITLE
Fixes ss13 logo and pipe causing runtimes

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -17117,30 +17117,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQa" = (
-/turf/open/floor/plating/logo/l1,
+/turf/open/floor/plasteel/logo/l1,
 /area/hallway/primary/central)
 "aQb" = (
-/turf/open/floor/plating/logo/l3,
+/turf/open/floor/plasteel/logo/l3,
 /area/hallway/primary/central)
 "aQc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 1
 	},
-/turf/open/floor/plating/logo/l5,
+/turf/open/floor/plasteel/logo/l5,
 /area/hallway/primary/central)
 "aQd" = (
-/turf/open/floor/plating/logo/l7,
+/turf/open/floor/plasteel/logo/l7,
 /area/hallway/primary/central)
 "aQe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/logo/l9,
+/turf/open/floor/plasteel/logo/l9,
 /area/hallway/primary/central)
 "aQf" = (
-/turf/open/floor/plating/logo/l11,
+/turf/open/floor/plasteel/logo/l11,
 /area/hallway/primary/central)
 "aQg" = (
-/turf/open/floor/plating/logo/l13,
+/turf/open/floor/plasteel/logo/l13,
 /area/hallway/primary/central)
 "aQh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -17631,10 +17631,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRC" = (
-/turf/open/floor/plating/logo/l2,
+/turf/open/floor/plasteel/logo/l2,
 /area/hallway/primary/central)
 "aRD" = (
-/turf/open/floor/plating/logo/l4,
+/turf/open/floor/plasteel/logo/l4,
 /area/hallway/primary/central)
 "aRE" = (
 /obj/machinery/navbeacon{
@@ -17645,11 +17645,11 @@
 	icon_state = "pipe11-1";
 	dir = 1
 	},
-/turf/open/floor/plating/logo/l6,
+/turf/open/floor/plasteel/logo/l6,
 /area/hallway/primary/central)
 "aRF" = (
 /obj/effect/landmark/observer_start,
-/turf/open/floor/plating/logo/l8,
+/turf/open/floor/plasteel/logo/l8,
 /area/hallway/primary/central)
 "aRG" = (
 /obj/machinery/navbeacon{
@@ -17657,13 +17657,13 @@
 	location = "EVA2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/logo/l10,
+/turf/open/floor/plasteel/logo/l10,
 /area/hallway/primary/central)
 "aRH" = (
-/turf/open/floor/plating/logo/l12,
+/turf/open/floor/plasteel/logo/l12,
 /area/hallway/primary/central)
 "aRI" = (
-/turf/open/floor/plating/logo/l14,
+/turf/open/floor/plasteel/logo/l14,
 /area/hallway/primary/central)
 "aRJ" = (
 /obj/effect/landmark/event_spawn,

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -17117,52 +17117,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQa" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L1"
-	},
+/turf/open/floor/plating/logo/l1,
 /area/hallway/primary/central)
 "aQb" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L3"
-	},
+/turf/open/floor/plating/logo/l3,
 /area/hallway/primary/central)
 "aQc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L5"
-	},
+/turf/open/floor/plating/logo/l5,
 /area/hallway/primary/central)
 "aQd" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L7"
-	},
+/turf/open/floor/plating/logo/l7,
 /area/hallway/primary/central)
 "aQe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L9"
-	},
+/turf/open/floor/plating/logo/l9,
 /area/hallway/primary/central)
 "aQf" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L11"
-	},
+/turf/open/floor/plating/logo/l11,
 /area/hallway/primary/central)
 "aQg" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L13";
-	name = "floor"
-	},
+/turf/open/floor/plating/logo/l13,
 /area/hallway/primary/central)
 "aQh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -17653,16 +17631,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRC" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L2"
-	},
+/turf/open/floor/plating/logo/l2,
 /area/hallway/primary/central)
 "aRD" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L4"
-	},
+/turf/open/floor/plating/logo/l4,
 /area/hallway/primary/central)
 "aRE" = (
 /obj/machinery/navbeacon{
@@ -17673,17 +17645,11 @@
 	icon_state = "pipe11-1";
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L6"
-	},
+/turf/open/floor/plating/logo/l6,
 /area/hallway/primary/central)
 "aRF" = (
 /obj/effect/landmark/observer_start,
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L8"
-	},
+/turf/open/floor/plating/logo/l8,
 /area/hallway/primary/central)
 "aRG" = (
 /obj/machinery/navbeacon{
@@ -17691,22 +17657,13 @@
 	location = "EVA2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L10"
-	},
+/turf/open/floor/plating/logo/l10,
 /area/hallway/primary/central)
 "aRH" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L12"
-	},
+/turf/open/floor/plating/logo/l12,
 /area/hallway/primary/central)
 "aRI" = (
-/turf/open/floor/plasteel{
-	icon = 'hippiestation/icons/turf/floors.dmi';
-	icon_state = "L14"
-	},
+/turf/open/floor/plating/logo/l14,
 /area/hallway/primary/central)
 "aRJ" = (
 /obj/effect/landmark/event_spawn,
@@ -50489,7 +50446,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "czA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},

--- a/hippiestation/code/game/turfs/simulated/floor.dm
+++ b/hippiestation/code/game/turfs/simulated/floor.dm
@@ -18,47 +18,47 @@
 			return
 	..()
 
-/turf/open/floor/plating/logo
+/turf/open/floor/plasteel/logo
 	icon = 'hippiestation/icons/turf/floors.dmi'
 
-/turf/open/floor/plating/logo/l1
+/turf/open/floor/plasteel/logo/l1
 	icon_state = "L1"
 
-/turf/open/floor/plating/logo/l2
+/turf/open/floor/plasteel/logo/l2
 	icon_state = "L2"
 
-/turf/open/floor/plating/logo/l3
+/turf/open/floor/plasteel/logo/l3
 	icon_state = "L3"
 
-/turf/open/floor/plating/logo/l4
+/turf/open/floor/plasteel/logo/l4
 	icon_state = "L4"
 
-/turf/open/floor/plating/logo/l5
+/turf/open/floor/plasteel/logo/l5
 	icon_state = "L5"
 
-/turf/open/floor/plating/logo/l6
+/turf/open/floor/plasteel/logo/l6
 	icon_state = "L6"
 
-/turf/open/floor/plating/logo/l7
+/turf/open/floor/plasteel/logo/l7
 	icon_state = "L7"
 
-/turf/open/floor/plating/logo/l8
+/turf/open/floor/plasteel/logo/l8
 	icon_state = "L8"
 
-/turf/open/floor/plating/logo/l9
+/turf/open/floor/plasteel/logo/l9
 	icon_state = "L9"
 
-/turf/open/floor/plating/logo/l10
+/turf/open/floor/plasteel/logo/l10
 	icon_state = "L10"
 
-/turf/open/floor/plating/logo/l11
+/turf/open/floor/plasteel/logo/l11
 	icon_state = "L11"
 
-/turf/open/floor/plating/logo/l12
+/turf/open/floor/plasteel/logo/l12
 	icon_state = "L12"
 
-/turf/open/floor/plating/logo/l13
+/turf/open/floor/plasteel/logo/l13
 	icon_state = "L13"
 
-/turf/open/floor/plating/logo/l14
+/turf/open/floor/plasteel/logo/l14
 	icon_state = "L14"

--- a/hippiestation/code/game/turfs/simulated/floor.dm
+++ b/hippiestation/code/game/turfs/simulated/floor.dm
@@ -17,3 +17,48 @@
 		if(!F.use(1))
 			return
 	..()
+
+/turf/open/floor/plating/logo
+	icon = 'hippiestation/icons/turf/floors.dmi'
+
+/turf/open/floor/plating/logo/l1
+	icon_state = "L1"
+
+/turf/open/floor/plating/logo/l2
+	icon_state = "L2"
+
+/turf/open/floor/plating/logo/l3
+	icon_state = "L3"
+
+/turf/open/floor/plating/logo/l4
+	icon_state = "L4"
+
+/turf/open/floor/plating/logo/l5
+	icon_state = "L5"
+
+/turf/open/floor/plating/logo/l6
+	icon_state = "L6"
+
+/turf/open/floor/plating/logo/l7
+	icon_state = "L7"
+
+/turf/open/floor/plating/logo/l8
+	icon_state = "L8"
+
+/turf/open/floor/plating/logo/l9
+	icon_state = "L9"
+
+/turf/open/floor/plating/logo/l10
+	icon_state = "L10"
+
+/turf/open/floor/plating/logo/l11
+	icon_state = "L11"
+
+/turf/open/floor/plating/logo/l12
+	icon_state = "L12"
+
+/turf/open/floor/plating/logo/l13
+	icon_state = "L13"
+
+/turf/open/floor/plating/logo/l14
+	icon_state = "L14"


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixed a roundstart runtime in the map and the hippiestation 13 logo
/:cl:

[why]: Holy oof.

![image](https://user-images.githubusercontent.com/32651551/50624694-a7b35b00-0ef0-11e9-889a-11d48f38a90e.png)
 
If you need proof, here it is.