### PR TITLE
Fixes double examine message

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -94,8 +94,6 @@
 
 	msg += common_trait_examine()
 
-	msg += common_trait_examine()
-
 	GET_COMPONENT_FROM(mood, /datum/component/mood, src)
 	if(mood)
 		switch(mood.shown_mood)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -286,8 +286,6 @@
 
 	msg += common_trait_examine()
 
-	msg += common_trait_examine()
-
 	var/traitstring = get_trait_string()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixed humans having a double examine message
/:cl:

[why]: 
![image](https://user-images.githubusercontent.com/32651551/50731161-c3ef0c00-112b-11e9-9962-cc401cbb23ab.png)
