### PR TITLE
A Fix for the Split Body Ability of Slimepeople

### DIFF
--- a/hippiestation/code/datums/dna.dm
+++ b/hippiestation/code/datums/dna.dm
@@ -13,7 +13,7 @@
 	create_random_voice()
 	.=..()
 
-/datum/dna/transfer_identity(mob/living/carbon/destination)
+/datum/dna/transfer_identity(mob/living/carbon/destination, transfer_SE = 0)
 	. = ..()
 	if (!istype(destination))
 		return


### PR DESCRIPTION
:cl:
fix: The split body ability for slimepeople will now not make a randomly named human that the slime person cannot control.
/:cl:

A slime person couldn't use their split body ability properly, because the make_dupe proc that handles this tries to call the transfer_identity proc with the argument transfer_SE, but fails to do so and throws a runtime error for a bad argument (with this error also stopping any other possible processing on the newly made human to actually make it be a controllable clone of the slime person) due to there being no argument transfer_SE for the redefined transfer_identity proc. Fixes #9583.