### PR TITLE
Added clf3 to reagent state change blacklist.

### DIFF
--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -8,7 +8,7 @@
 GLOBAL_LIST_INIT(no_reagent_message_typecache, typecacheof(list(
   /obj/effect/particle_effect,
   /obj/effect/decal/cleanable,
-  /mob/living,
+  /mob,
   /obj/item/reagent_containers/food,
   /turf/open/pool)
 ))
@@ -36,7 +36,8 @@ GLOBAL_LIST_INIT(statechange_reagent_blacklist, typecacheof(list(
 	/datum/reagent/nitrogen,
 	/datum/reagent/nitrous_oxide,
 	/datum/reagent/cryostylane,
-	/datum/reagent/consumable/ethanol/neurotoxin)
+	/datum/reagent/consumable/ethanol/neurotoxin,
+	/datum/reagent/clf3)
 ))
 
 GLOBAL_LIST_INIT(statechange_turf_blacklist, typecacheof(list(

--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -8,7 +8,7 @@
 GLOBAL_LIST_INIT(no_reagent_message_typecache, typecacheof(list(
   /obj/effect/particle_effect,
   /obj/effect/decal/cleanable,
-  /mob,
+  /mob/living,
   /obj/item/reagent_containers/food,
   /turf/open/pool)
 ))


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
balance: Chlorine trifluoride can no longer become solidified bars or turn into vapour. 
/:cl:

[why]: CLF3 is currently one of the most easiest abused chems and it causes havoc in any area it's deployed it. It's well known for vaporizing and catching everything in the room on fire while also creating holes through the hull of the station, even on reinforced floors. When it's solidified it can be turned into clf3 floor tiles and weapons. 'nuff said. A simple solution to this is to blacklist it from reagent state changes.