### PR TITLE
Chem piles are now immune to acid and fire

### DIFF
--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_EMPTY(chempiles)
 	icon = 'hippiestation/icons/effects/32x32.dmi'
 	icon_state = "chempile"
 	mergeable_decal = FALSE
+	resistance_flags = ACID_PROOF | FIRE_PROOF
 
 /obj/effect/decal/cleanable/chempile/examine(mob/user)
 	..()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
tweak: Chem piles are now immune to fire and acid
/:cl:

[why]: I actually realized that @Pyko1 made a good point. The whole purpose of this PR was to make my powergame meme grenade in my other PR work properly. The acid and fire were just causing the chem piles to delete which I thought was uncool. So now here we are, I want chem piles immune from having the stuff they contain, I thought it only makes sense right? A reagent container should at least have resistance to acid and fire, but easily be cleaned by soap and explosions? 