### PR TITLE
Fix clothing stat examine message not appearing

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -109,6 +109,7 @@ hippie end */
 
 /obj/item/clothing/examine(mob/user)
 	..()
+	clothing_resistance_flag_examine_message(user)
 	if(damaged_clothes)
 		to_chat(user,  "<span class='warning'>It looks damaged!</span>")
 	GET_COMPONENT(pockets, /datum/component/storage)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Fixed clothing robustness examine message not appearing for clothes
/:cl:

[why]: You can tell that all I do is code dive and check for broken stuff.