### PR TITLE
Fixes throw impact doing twice the normal damage

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,7 +93,7 @@
 					return 1
 	return ..()
 
-/mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
+/mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	var/hurt = TRUE
 	if(istype(throwingdatum, /datum/thrownthing))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -121,7 +121,7 @@
 			victim.Paralyze(20)
 			Paralyze(20)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>",\
-			"<span class='userdanger'>You violently crash into [victim]!</span>")
+				"<span class='userdanger'>You violently crash into [victim]!</span>")
 		playsound(src,'sound/weapons/punch1.ogg',50,1)
 		if(fist_casted) //hippie edit -- adds fist
 			visible_message("<span class='danger'>[src] slams into [victim] with enough force to level a skyscraper!</span>", "<span class='userdanger'>You crash into [victim] like a thunderbolt!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,9 +93,9 @@
 					return 1
 	return ..()
 
-/mob/living/carbon/proc/reset_fist_casted()//hippie edit -- adds plasma fist
+/mob/living/carbon/proc/reset_fist_casted()//hippie edit -- adds fist
 	if(fist_casted)
-		fist_casted = FALSE //hippie end -- adds plasma fist
+		fist_casted = FALSE //hippie end -- adds fist
 
 /mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
 	. = ..()
@@ -110,11 +110,11 @@
 		if(hurt)
 			Paralyze(20)
 			take_bodypart_damage(10)
-		if(fist_casted)//hippie edit -- adds plasma fist
+		if(fist_casted)//hippie edit -- adds fist
 			var/turf/T = get_turf(src)
 			visible_message("<span class='danger'>[src] slams into [T] with explosive force!</span>", "<span class='userdanger'>You slam into [T] so hard everything nearby feels it!</span>")
 			explosion(T, -1, 1, 4, 0, 0, 0) //No fire and no flash, this is less an explosion and more a shockwave from beign punched THAT hard.
-			fist_casted = FALSE //hippie end -- plasma fist
+			fist_casted = FALSE //hippie end -- fist
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -120,8 +120,9 @@
 			take_bodypart_damage(10)
 			victim.Paralyze(20)
 			Paralyze(20)
-			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
-			playsound(src,'sound/weapons/punch1.ogg',50,1)
+			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>",\
+			"<span class='userdanger'>You violently crash into [victim]!</span>")
+		playsound(src,'sound/weapons/punch1.ogg',50,1)
 		if(fist_casted) //hippie edit -- adds fist
 			visible_message("<span class='danger'>[src] slams into [victim] with enough force to level a skyscraper!</span>", "<span class='userdanger'>You crash into [victim] like a thunderbolt!</span>")
 			var/turf/T = get_turf(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -108,7 +108,7 @@
 				hurt = FALSE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Knockdown(20)
+			Paralyze(20)
 			take_bodypart_damage(10)
 		if(fist_casted)//hippie edit -- adds plasma fist
 			var/turf/T = get_turf(src)
@@ -122,8 +122,8 @@
 		if(hurt)
 			victim.take_bodypart_damage(10)
 			take_bodypart_damage(10)
-			victim.Knockdown(20)
-			Knockdown(20)
+			victim.Paralyze(20)
+			Paralyze(20)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
 			playsound(src,'sound/weapons/punch1.ogg',50,1)
 		if(fist_casted) //hippie edit -- adds plasma fist

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -126,10 +126,10 @@
 			Paralyze(20)
 			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
 			playsound(src,'sound/weapons/punch1.ogg',50,1)
-		if(fist_casted) //hippie edit -- adds plasma fist
+		if(fist_casted) //hippie edit -- adds fist
 			visible_message("<span class='danger'>[src] slams into [victim] with enough force to level a skyscraper!</span>", "<span class='userdanger'>You crash into [victim] like a thunderbolt!</span>")
 			var/turf/T = get_turf(src)
-			explosion(T, -1, 3, 5, 0, 0, 0) //The reward for lining the spell up to hit another person is a bigger boom! //hippie end -- plasma fist
+			explosion(T, -1, 3, 5, 0, 0, 0) //The reward for lining the spell up to hit another person is a bigger boom! //hippie end -- fist
 			
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,7 +93,11 @@
 					return 1
 	return ..()
 
-/mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+/mob/living/carbon/proc/reset_fist_casted()//hippie edit -- adds plasma fist
+	if(fist_casted)
+		fist_casted = FALSE //hippie end -- adds plasma fist
+
+/mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
 	. = ..()
 	var/hurt = TRUE
 	if(istype(throwingdatum, /datum/thrownthing))
@@ -104,8 +108,13 @@
 				hurt = FALSE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
+			Knockdown(20)
 			take_bodypart_damage(10)
+		if(fist_casted)//hippie edit -- adds plasma fist
+			var/turf/T = get_turf(src)
+			visible_message("<span class='danger'>[src] slams into [T] with explosive force!</span>", "<span class='userdanger'>You slam into [T] so hard everything nearby feels it!</span>")
+			explosion(T, -1, 1, 4, 0, 0, 0) //No fire and no flash, this is less an explosion and more a shockwave from beign punched THAT hard.
+			fist_casted = FALSE //hippie end -- plasma fist
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)
@@ -113,11 +122,15 @@
 		if(hurt)
 			victim.take_bodypart_damage(10)
 			take_bodypart_damage(10)
-			victim.Paralyze(20)
-			Paralyze(20)
-			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>",\
-				"<span class='userdanger'>You violently crash into [victim]!</span>")
-		playsound(src,'sound/weapons/punch1.ogg',50,1)
+			victim.Knockdown(20)
+			Knockdown(20)
+			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
+			playsound(src,'sound/weapons/punch1.ogg',50,1)
+		if(fist_casted) //hippie edit -- adds plasma fist
+			visible_message("<span class='danger'>[src] slams into [victim] with enough force to level a skyscraper!</span>", "<span class='userdanger'>You crash into [victim] like a thunderbolt!</span>")
+			var/turf/T = get_turf(src)
+			explosion(T, -1, 3, 5, 0, 0, 0) //The reward for lining the spell up to hit another person is a bigger boom! //hippie end -- plasma fist
+			
 
 
 //Throwing stuff

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,10 +93,6 @@
 					return 1
 	return ..()
 
-/mob/living/carbon/proc/reset_fist_casted()//hippie edit -- adds fist
-	if(fist_casted)
-		fist_casted = FALSE //hippie end -- adds fist
-
 /mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
 	. = ..()
 	var/hurt = TRUE

--- a/hippiestation/code/modules/mob/living/carbon/carbon.dm
+++ b/hippiestation/code/modules/mob/living/carbon/carbon.dm
@@ -1,45 +1,6 @@
 /mob/living/carbon
 	var/fist_casted = FALSE
 
-/mob/living/carbon/proc/reset_fist_casted()
-	if(fist_casted)
-		fist_casted = FALSE
-
-/mob/living/carbon/throw_impact(atom/hit_atom, throwingdatum)
-	. = ..()
-	var/hurt = TRUE
-	if(istype(throwingdatum, /datum/thrownthing))
-		var/datum/thrownthing/D = throwingdatum
-		if(iscyborg(D.thrower))
-			var/mob/living/silicon/robot/R = D.thrower
-			if(!R.emagged)
-				hurt = FALSE
-	if(hit_atom.density && isturf(hit_atom))
-		if(hurt)
-			Knockdown(20)
-			take_bodypart_damage(10)
-		if(fist_casted)
-			var/turf/T = get_turf(src)
-			visible_message("<span class='danger'>[src] slams into [T] with explosive force!</span>", "<span class='userdanger'>You slam into [T] so hard everything nearby feels it!</span>")
-			explosion(T, -1, 1, 4, 0, 0, 0) //No fire and no flash, this is less an explosion and more a shockwave from beign punched THAT hard.
-			fist_casted = FALSE
-	if(iscarbon(hit_atom) && hit_atom != src)
-		var/mob/living/carbon/victim = hit_atom
-		if(victim.movement_type & FLYING)
-			return
-		if(hurt)
-			victim.take_bodypart_damage(10)
-			take_bodypart_damage(10)
-			victim.Knockdown(20)
-			Knockdown(20)
-			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [victim]!</span>")
-			playsound(src,'sound/weapons/punch1.ogg',50,1)
-		if(fist_casted)
-			visible_message("<span class='danger'>[src] slams into [victim] with enough force to level a skyscraper!</span>", "<span class='userdanger'>You crash into [victim] like a thunderbolt!</span>")
-			var/turf/T = get_turf(src)
-			explosion(T, -1, 3, 5, 0, 0, 0) //The reward for lining the spell up to hit another person is a bigger boom!
-
-
 /mob/living/carbon/update_sight()
 	. = ..()
 	if(mind)

--- a/hippiestation/code/modules/mob/living/carbon/carbon.dm
+++ b/hippiestation/code/modules/mob/living/carbon/carbon.dm
@@ -1,6 +1,10 @@
 /mob/living/carbon
 	var/fist_casted = FALSE
 
+/mob/living/carbon/proc/reset_fist_casted()	
+	if(fist_casted)	
+		fist_casted = FALSE	
+
 /mob/living/carbon/update_sight()
 	. = ..()
 	if(mind)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
fix: Impacting a wall no longer does 20 damage
/:cl:

[why]: Big fucking oof coders.