### PR TITLE
Fixes mob's eyes becoming bloody after revive

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -517,7 +517,7 @@
 	set_eye_damage(0)
 	cure_nearsighted()
 	cure_blind()
-	heal_overall_damage(INFINITY, INFINITY, INFINITY, null, TRUE) //heal brute and burn dmg on both organic and robotic limbs, and update health right away.
+	cure_husk()
 	hallucination = 0
 	heal_overall_damage(INFINITY, INFINITY, INFINITY, null, TRUE) //heal brute and burn dmg on both organic and robotic limbs, and update health right away.
 	ExtinguishMob()


### PR DESCRIPTION
No changelog, just a big oof. I spent a lot of time comparing files to see the differences only to find out it was this one simply line.

No longer will you see this after doing an admin revive: 
![image](https://user-images.githubusercontent.com/32651551/51454609-900f0b80-1d13-11e9-958d-687d2d33bde2.png)
