### PR TITLE
Nanosuit upgrades, balance changes, bug squashing. [READY]

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -603,7 +603,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/nano/Initialize()
 	. = ..()
-	bomb_radar = new
+	bomb_radar = new(src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/nano/ui_action_click()
 	return FALSE

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -648,7 +648,6 @@
 	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
 
 /obj/item/clothing/suit/space/hardsuit/nano/equipped(mob/user, slot)
-	..()
 	if(ishuman(user))
 		Wearer = user
 	if(slot == SLOT_WEAR_SUIT)
@@ -665,6 +664,7 @@
 		if(help_verb)
 			Wearer.verbs += help_verb
 		bootSequence()
+	..()
 
 /obj/item/clothing/suit/space/hardsuit/nano/dropped()
 	..()

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -264,6 +264,8 @@
 		return
 	if(shutdown)
 		return
+	if(!cell)
+		return
 	if(Wearer.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 		if(!detecting)
 			temp_cooldown = world.time + restore_delay
@@ -320,7 +322,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/hit_reaction(mob/living/carbon/human/user, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	var/obj/item/projectile/P = hitby
-	if(mode == NANO_ARMOR && cell.charge)
+	if(mode == NANO_ARMOR && cell && cell.charge)
 		if(prob(final_block_chance))
 			user.visible_message("<span class='danger'>[user]'s shields deflect [attack_text] draining their energy!</span>")
 			if(damage)
@@ -1038,6 +1040,7 @@
 	desc = "Ashes to ashes."
 	icon_state = "explosive"
 	actions_types = list(/datum/action/item_action/dusting_implant)
+	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 
 /obj/item/implant/explosive/disintegrate/activate(cause)
 	if(!cause || !imp_in || cause == "emp" || active)
@@ -1063,6 +1066,7 @@
 	volume = 3
 	icon_state = "emergency_tst"
 	item_flags = DROPDEL
+	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 
 /obj/item/tank/internals/emergency_oxygen/recharge/New()
 	..()
@@ -1122,6 +1126,7 @@
 /obj/item/stock_parts/cell/nano
 	name = "nanosuit self charging battery"
 	maxcharge = 100
+	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 
 mob/living/carbon/human/key_down(_key, client/user)
 	switch(_key)

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -56,7 +56,6 @@
 /obj/item/clothing/shoes/combat/coldres/nanojump/ui_action_click(mob/user, action)
 	if(!isliving(user))
 		return
-
 	var/turf/open/floor/T = get_turf(src)
 	var/obj/structure/S = locate() in get_turf(user.loc)
 	var/mob/living/carbon/human/H = user
@@ -107,11 +106,11 @@
 
 /obj/item/radio/headset/syndicate/alt/nano
 	name = "\proper the nanosuit's bowman headset"
-	desc = "Operator communication headset. Property of CryNet Systems."
+	desc = "Operator communication headset. Property of CryNet Systems. Alt-click to toggle interface."
 	icon_state = "syndie_headset"
 	item_state = "syndie_headset"
 	subspace_transmission = FALSE
-	keyslot = new /obj/item/encryptionkey/binary
+	subspace_switchable = TRUE
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 	item_flags = DROPDEL
 
@@ -119,6 +118,18 @@
 	..()
 	if(slot == SLOT_EARS)
 		item_flags |= NODROP
+
+/obj/item/radio/headset/syndicate/alt/nano/AltClick()
+	var/mob/M = usr
+	if(usr.canUseTopic(src))
+		attack_self(M)
+	..()
+
+/obj/item/radio/headset/syndicate/alt/nano/MouseDrop(obj/over_object, src_location, over_location)
+	var/mob/M = usr
+	if((!istype(over_object, /obj/screen)) && usr.canUseTopic(src))
+		return attack_self(M)
+	return ..()
 
 /obj/item/radio/headset/syndicate/alt/nano/emp_act()
 	return

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -249,6 +249,7 @@
 		to_chat(user, "The suit appears to be offline.")
 
 /obj/item/clothing/suit/space/hardsuit/nano/process()
+	..()
 	if(!Wearer)
 		return
 	if(shutdown)
@@ -260,7 +261,7 @@
 		if(world.time > temp_cooldown)
 			if(!defrosted)
 				helmet.display_visor_message("Activating suit defrosting protocols.")
-				Wearer.reagents.add_reagent("leporazine", 2)
+				Wearer.reagents.add_reagent("leporazine", 3)
 				defrosted = TRUE
 				temp_cooldown += 100
 	else
@@ -404,7 +405,7 @@
 			if(NANO_CLOAK)
 				helmet.display_visor_message("Cloak Engaged!")
 				block_chance = initial(block_chance)
-				slowdown = 0.4 //cloaking makes us go sliightly faster
+				slowdown = 0.4 //cloaking makes us move slightly faster
 				armor = armor.setRating(melee = 40, bullet = 40, laser = 40, energy = 45, bomb = 70, rad = 70)
 				helmet.armor = helmet.armor.setRating(melee = 40, bullet = 40, laser = 40, energy = 45, bomb = 70, rad = 70)
 				Wearer.filters = filter(type="blur",size=1)
@@ -481,6 +482,7 @@
 /obj/item/clothing/suit/space/hardsuit/nano/proc/emp_assault()
 	if(!Wearer)
 		return //Not sure how this could happen.
+	SSblackbox.record_feedback("tally", "nanosuit_emp_shutdown", 1, type)
 	Wearer.confused += 50
 	helmet.display_visor_message("EMP Assault! Systems impaired.")
 	sleep(40)
@@ -492,7 +494,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/emp_assaulttwo()
 	sleep(35)
-	helmet.display_visor_message("Warning. EMP shutdown, all systems impaired.")
+	helmet.display_visor_message("Warning, EMP shutdown, all systems impaired!")
 	sleep(25)
 	helmet.display_visor_message("Switching to: core function mode.")
 	sleep(25)
@@ -522,15 +524,15 @@
 	sleep(10)
 	helmet.display_visor_message("LOADING//...")
 	sleep(30)
-	helmet.display_visor_message("Cardiac dysrhythmias treatment in progress, standby...")
+	helmet.display_visor_message("Cardiac dysrhythmia treatment in progress, standby...")
 	playsound(src, 'sound/machines/defib_charge.ogg', 75, FALSE)
 	sleep(25)
 	playsound(src, 'sound/machines/defib_zap.ogg', 50, FALSE)
 	Wearer.apply_effects(stun = -100, paralyze = -100, stamina = -55)
 	Wearer.adjustOxyLoss(-55)
-	helmet.display_visor_message("Cleared to proceed.")
 	sleep(3)
 	playsound(src, 'sound/machines/defib_success.ogg', 75, FALSE)
+	helmet.display_visor_message("Cleared to proceed.")
 	shutdown = FALSE
 	toggle_mode(NANO_ARMOR)
 
@@ -646,6 +648,7 @@
 	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
 
 /obj/item/clothing/suit/space/hardsuit/nano/equipped(mob/user, slot)
+	..()
 	if(ishuman(user))
 		Wearer = user
 	if(slot == SLOT_WEAR_SUIT)
@@ -662,9 +665,9 @@
 		if(help_verb)
 			Wearer.verbs += help_verb
 		bootSequence()
-	..()
 
 /obj/item/clothing/suit/space/hardsuit/nano/dropped()
+	..()
 	if(!Wearer)
 		return
 	if(help_verb)
@@ -951,10 +954,11 @@
 	return FALSE
 
 /mob/living/carbon/human/check_weakness(obj/item/weapon, mob/living/carbon/attacker)
+	. = ..()
 	if(attacker && ishuman(attacker))
 		if(attacker.mind.has_martialart(MARTIALART_NANOSUIT) && weapon && weapon.damtype == BRUTE)
-			return 1.25 //deal 25% more damage in strength
-	. = ..()
+			. += 1.25 //deal 25% more damage in strength
+
 
 /obj/attacked_by(obj/item/I, mob/living/user)
 	if(I.force && I.damtype == BRUTE && user.mind.has_martialart(MARTIALART_NANOSUIT))
@@ -1119,7 +1123,7 @@ mob/living/carbon/human/key_down(_key, client/user)
 	..()
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/check_menu(mob/living/user)
-	if(!istype(user))
+	if(!user)
 		return FALSE
 	if(user.incapacitated() || !user.Adjacent(src))
 		return FALSE

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -244,9 +244,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/nano/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
-	if(Wearer)
-		if(help_verb)
-			Wearer.verbs -= help_verb
+	if(Wearer && help_verb)
+		Wearer.verbs -= help_verb
 	Wearer = null
 	QDEL_NULL(style)
 	QDEL_NULL(cell)

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -915,29 +915,6 @@
 		visible_message("<span class='danger'>[user] has [hitverb] [src]!</span>", \
 		"<span class='userdanger'>[user] has [hitverb] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
 		return TRUE
-/*
-/mob/living/carbon/alien/humanoid/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
-	if(user.a_intent == INTENT_HARM)
-		..(user, TRUE)
-		apply_damages(brute = 25, stamina = 35)
-		var/hitverb = "punched"
-		playsound(loc, "punch", 25, TRUE, -1)
-		visible_message("<span class='danger'>[user] has [hitverb] [src]!</span>", \
-		"<span class='userdanger'>[user] has [hitverb] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
-		return TRUE
-
-/mob/living/carbon/monkey/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
-	if(user.a_intent == INTENT_HARM)
-		..(user, TRUE)
-		apply_damage(20, BRUTE)
-		var/hitverb = "punched"
-		if(mob_size < MOB_SIZE_LARGE)
-			step_away(src,user,15)
-			hitverb = "slammed"
-		playsound(loc, "punch", 25, TRUE, -1)
-		visible_message("<span class='danger'>[user] has [hitverb] [src]!</span>", \
-		"<span class='userdanger'>[user] has [hitverb] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
-		return TRUE*/
 
 /obj/item/attack_nanosuit(mob/living/carbon/human/user)
 	return FALSE
@@ -1006,7 +983,7 @@
 	if(style)
 		if(style.on_attack_hand(src, A, proximity))
 			return
-		else if(iscarbon(A) && style.harm_act(src, A))
+		else if(iscarbon(A) && !ishuman(A) && style.harm_act(src, A))
 			return
 	..()
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
add: Nanosuit strength mode can be used on carbon mobs like monkies.
add: Strength mode in nanosuit now has a 35% cleaving attack which hits all enemies you face within 1 range. 
fix: Head splatter ability on the nanosuit has been given a bug cleanup.
tweak: Nanosuit headset ui now can be toggle and has subspace switching.
fix: Fixed nanosuit not having a geiger counter.
balance: Leporazine injection on nanosuit defrosting sequence increased from 2 to 3.
balance: Increased nanosuit's refilling tank volume to 3 from 2.
spellcheck: Fixed typos in nanosuit help and reboot sequence.
/:cl:

[why]: The main thing of this PR is minor tweaks that just reduced the quality of life of the user of the nanosuit, such as the o2 tank draining to fast with a jetpack, not enough defrosting capabilities and worst of all; bugs. I realized that sometimes overlooked code can cause small, irritating problems and features you'd expect to work right, so I took the time to kill them all (There's still some I'm not aware of, I'm sure, but I imagine they would be incredibly rare this far into the game). Not being able to interact with the interface on your nanosuit was kind of annoying, especially if you wanted to fully utilize a captains encryption key, you could toggle the modes past command and sec. Also I felt like having subspace transmission off was a bit annoying, so you now have the option to select it so you can use the `;` key to talk on syndi chat normally. Let's see, resetting filters to null is a bad way of doing things and hard coding variable resets is bad for the sake of var editting and debugging, yada yada ya... Also adjust damage has been replaced with apply damage, this is just the appropriate way of doing things. 
Here comes the juicy part of this PR: Cleave attacking and martial arts on XENOS AND MONKIES!! That's right! You wanna beat the pulp out of a monkey or xenomorph? Well boom, you actually have a decent chance now. Have fun exploding their heads too. The Cleave attack will trigger around 35% of the time, which will hit all mobs you face within 1 tile and by the way, it works with monkies and xenos too. I'm going to do a little video demoing it very soon. I will update this soon.