### PR TITLE
Reverts Energy/Disabler speed.

### DIFF
--- a/hippiestation/code/modules/projectiles/projectile.dm
+++ b/hippiestation/code/modules/projectiles/projectile.dm
@@ -8,10 +8,10 @@
 	speed = 0.8 //as before
 
 /obj/item/projectile/energy
-	speed = 0.2
-
-/obj/item/projectile/energy/electrode
 	speed = 0.8
+
+/obj/item/projectile/beam/disabler
+	speed = 0.7
 
 /obj/item/projectile/beam
 	speed = 0.2


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: Manly Dwarf
balance: Disabler is now the speed it was before some clown decided to speed it up four times.
/:cl:

[why]: 
The point of speeding up ballistic projectile was to buff them! Don't buff disablers too, you absolute clown!
![IDIOTS](https://user-images.githubusercontent.com/33744849/51770761-cf8f7c00-20b4-11e9-8478-ecf0b60b2a92.png)
Who merged this?!