### PR TITLE
Glow berries now have a 5% chance to have the no react trait

### DIFF
--- a/hippiestation/code/modules/hydroponics/grown/berries.dm
+++ b/hippiestation/code/modules/hydroponics/grown/berries.dm
@@ -1,2 +1,7 @@
 /obj/item/seeds/berry/glow
-	genes = list(/datum/plant_gene/trait/glow/berry , /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/repeated_harvest)
+
+/obj/item/seeds/berry/glow/Initialize()
+	if(prob(5))
+		LAZYADD(genes, /datum/plant_gene/trait/noreact)
+


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
balance: Glowberries now only have a 5% chance of having the no react trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Glow berries are extremely easily abused to make insta explode bomb and are super easy to obtain (10-15 mins max prob). This isn't removing the trait from the game but simply making it so it's very rare to obtain so you don't get le instadeath bombs that you can murderbone entire server populations with.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
This is a long needed nerf without completely removing it from the game like TG did, which I personally disagree with. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
