### PR TITLE
Fixes biohazard doors in science, cosmetics and some overlapping pipes.

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -13714,9 +13714,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -14675,9 +14672,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aKc" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -26586,7 +26580,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -28433,7 +28426,6 @@
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -29072,26 +29064,19 @@
 "bvJ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "Biohazard"
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "bvL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -29099,6 +29084,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "Biohazard"
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
@@ -30245,6 +30233,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -31568,11 +31559,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -31582,6 +31568,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "Biohazard"
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
@@ -32251,16 +32240,14 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "Biohazard"
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
@@ -34481,6 +34468,9 @@
 	icon_state = "pipe11-1";
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bJM" = (
@@ -34499,6 +34489,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -35469,6 +35462,7 @@
 	icon_state = "pipe11-1";
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bMb" = (
@@ -36583,15 +36577,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bOP" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "bOQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37663,12 +37648,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "misclab";
-	name = "test chamber blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "misclab"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRm" = (
@@ -37681,12 +37664,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "misclab";
-	name = "test chamber blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "misclab"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRn" = (
@@ -37698,16 +37679,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "misclab";
-	name = "test chamber blast door"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "misclab"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -37719,24 +37698,20 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "misclab";
-	name = "test chamber blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "misclab"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRp" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "misclab";
-	name = "test chamber blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "misclab"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRq" = (
@@ -37883,9 +37858,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -41063,12 +41035,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio3";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio3"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bZS" = (
@@ -41123,12 +41093,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio8";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio8"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cac" = (
@@ -41545,10 +41513,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio3";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio3"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -41594,10 +41560,8 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio8";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -41819,12 +41783,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio3";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio3"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ccd" = (
@@ -41874,12 +41836,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio8";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio8"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cch" = (
@@ -42586,12 +42546,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio2";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio2"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ceo" = (
@@ -42628,12 +42586,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio7";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio7"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cex" = (
@@ -42965,10 +42921,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio2";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio2"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -42981,10 +42935,8 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio7";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio7"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -43401,12 +43353,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio2";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio2"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cgC" = (
@@ -43433,12 +43383,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio7";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio7"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cgE" = (
@@ -44222,12 +44170,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio1";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio1"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ciH" = (
@@ -44254,12 +44200,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio6";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio6"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ciJ" = (
@@ -44769,10 +44713,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio1";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio1"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -44785,10 +44727,8 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio6";
-	name = "containment blast door"
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio6"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -45090,12 +45030,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio1";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio1"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ckO" = (
@@ -45130,12 +45068,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi';
-	id = "xenobio6";
-	name = "containment blast door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen/biohazard{
+	id = "xenobio6"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ckR" = (
@@ -56597,6 +56533,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"dUv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "dXf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -56637,6 +56579,21 @@
 	icon_state = "rcircuitoff"
 	},
 /area/maintenance/strangeroom)
+"eaB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eco" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57270,13 +57227,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eYA" = (
-/obj/machinery/vending/cart{
-	desc = "Some old machine. You can barely make out the words P**ech";
-	icon_state = "cart-broken";
-	name = "\improper Old Machine";
-	products = list(/obj/item/cartridge/medical = 2, /obj/item/cartridge/engineering = 1, /obj/item/cartridge/security = 0, /obj/item/cartridge/janitor = 1, /obj/item/cartridge/signal/toxins = 2, /obj/item/pda/heads = 1, /obj/item/cartridge/captain = 0, /obj/item/cartridge/quartermaster = 1);
-	scan_id = 0
-	},
+/obj/machinery/vending/cart/old,
 /turf/open/floor/plating,
 /area/maintenance/strangeroom)
 "eYB" = (
@@ -62153,6 +62104,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"mkh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mku" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -62644,7 +62610,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/vending/plasmaresearch,
+/obj/machinery/vending/plasmaresearch{
+	contraband = list(/obj/item/assembly/health = 3, /obj/item/assembly/voice = 3)
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "mUV" = (
@@ -64533,10 +64501,6 @@
 "pUZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -64581,6 +64545,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "pYT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "pZi" = (
@@ -65637,6 +65604,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"rLj" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "rMi" = (
 /obj/structure/table/wood,
 /obj/item/toy/eightball,
@@ -66865,6 +66836,9 @@
 "tAq" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -69012,6 +68986,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"wJg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "wJL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69206,6 +69186,9 @@
 	pixel_y = 32
 	},
 /obj/item/cigbutt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "wXv" = (
@@ -76369,7 +76352,7 @@ aAd
 aAd
 aAd
 aCH
-pYT
+wJg
 aCH
 ayG
 aad
@@ -79239,7 +79222,7 @@ aAd
 koh
 udn
 mlA
-pYT
+rLj
 fmA
 bpL
 aaa
@@ -81038,7 +81021,7 @@ aAd
 koh
 udn
 wEG
-pYT
+rLj
 hom
 aaa
 aaa
@@ -118813,7 +118796,7 @@ bjF
 bkQ
 bmy
 bop
-bpK
+eaB
 bpK
 sXd
 bmx
@@ -119859,9 +119842,9 @@ bxD
 bsR
 bLY
 brs
-bOP
-bQo
 bRC
+bQo
+dUv
 umV
 xfk
 bVf
@@ -120878,7 +120861,7 @@ dCC
 bzb
 bAA
 bDi
-bDi
+mkh
 bDi
 bDi
 bDi

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3382,6 +3382,7 @@
 #include "hippiestation\code\modules\vending\_vending.dm"
 #include "hippiestation\code\modules\vending\autodrobe.dm"
 #include "hippiestation\code\modules\vending\boozeomat.dm"
+#include "hippiestation\code\modules\vending\cartridge.dm"
 #include "hippiestation\code\modules\vending\clothesmate.dm"
 #include "hippiestation\code\modules\vending\medical_wall.dm"
 #include "hippiestation\code\modules\vending\megaseed.dm"

--- a/hippiestation/code/game/machinery/doors/poddoor.dm
+++ b/hippiestation/code/game/machinery/doors/poddoor.dm
@@ -5,3 +5,7 @@
 /obj/machinery/door/poddoor/close(ignorepower = 0)
 	. = ..()
 	playsound(loc, 'hippiestation/sound/machines/blast_door.ogg', 100, 1)
+
+/obj/machinery/door/poddoor/preopen/biohazard
+	name = "biohazard blast door"
+	icon = 'hippiestation/icons/obj/doors/hazarddoor.dmi'

--- a/hippiestation/code/modules/vending/cartridge.dm
+++ b/hippiestation/code/modules/vending/cartridge.dm
@@ -1,0 +1,17 @@
+/obj/machinery/vending/cart/old
+	name = "\improper Old machine"
+	desc = "You can't make out what the description says. It looks like an old vending machine of some sort..."
+	product_slogans = "BzZZzz-zt;ZZzShBhT;W*Ee#w!lLD3st0R-RyYoU!BZZT"
+	icon_state = "cart-broken"
+	icon_deny = "cart-broken"
+	products = list(/obj/item/cartridge/medical = 2,
+		            /obj/item/cartridge/engineering = 1,
+		            /obj/item/cartridge/security = 1,
+					/obj/item/cartridge/janitor = 1,
+					/obj/item/cartridge/signal/toxins = 1,
+					/obj/item/pda/heads = 3,
+					/obj/item/cartridge/captain = 1,
+					/obj/item/cartridge/quartermaster = 0)
+	default_price = 5
+	extra_price = 10
+	scan_id = FALSE


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
Fix: Pod doors in science are no longer invisible!
Fix: Overlapping pipes and some miner cosmetic details have been fixed.
Fix: Fixxed the old machine in the strange room having the incorrect icon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
The CL describes everything. No more rotated "warning symbol corners" in the 4-way between science and the testing range, no more invisible bioahazard doors in science, no more atmos warnings and no more old machine not looking old.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
![2019-01-30_21-29-27](https://user-images.githubusercontent.com/32651551/52027966-38bf2700-24db-11e9-83c7-f906fc42c756.png)
![2019-01-30_21-29-35](https://user-images.githubusercontent.com/32651551/52027968-3957bd80-24db-11e9-85b3-1cdd13153665.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
