### PR TITLE
Fixes glow berries not initializing properly

### DIFF
--- a/hippiestation/code/modules/hydroponics/grown/berries.dm
+++ b/hippiestation/code/modules/hydroponics/grown/berries.dm
@@ -2,6 +2,7 @@
 	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/repeated_harvest)
 
 /obj/item/seeds/berry/glow/Initialize()
+	. = ..()
 	if(prob(5))
 		LAZYADD(genes, /datum/plant_gene/trait/noreact)
 


### PR DESCRIPTION
I forgot to call parent proc which was causing them to behave extremely odd.