### PR TITLE
Rebalances shields properly.

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -115,7 +115,7 @@
 
 /obj/item/shield/riot/tele
 	name = "telescopic shield"
-	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage."
+	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage. Alt-click to deploy." //hippie edit -- make tele riot shields expand via alt click
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "teleriot0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
@@ -133,7 +133,7 @@
 		return ..()
 	return 0
 
-/obj/item/shield/riot/tele/attack_self(mob/living/user)
+/obj/item/shield/riot/tele/AltClick(mob/living/user) //hippie edit -- make tele riot shields expand via alt click
 	active = !active
 	icon_state = "teleriot[active]"
 	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)

--- a/hippiestation/code/game/objects/items/shields.dm
+++ b/hippiestation/code/game/objects/items/shields.dm
@@ -22,3 +22,153 @@
 			owner.visible_message("<span class='danger'>[owner] skillfully blocks [attack_text] with [src]!</span>")
 			return TRUE
 	return FALSE
+
+/obj/item/shield
+	block_chance = 0
+	var/block_chance_unwielded = 0
+	var/block_chance_wielded = 75
+	var/wielded = FALSE
+	var/can_2hand = TRUE
+	var/boost_armor = TRUE
+
+/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(!is_A_facing_B(owner,hitby))
+		to_chat(owner, "<span class='notice'>[src] fails to deflect [attack_text].</span>")
+		return FALSE
+	final_block_chance -= damage
+	return ..()
+
+/obj/item/shield/proc/unwield(mob/living/carbon/user, show_message = TRUE)
+	if(!wielded || !user)
+		return
+	wielded = FALSE
+	if(!isnull(block_chance_unwielded))
+		block_chance = block_chance_unwielded
+	var/sf = findtext(name," (Wielded)")
+	if(sf)
+		name = copytext(name,1,sf)
+	else //something wrong
+		name = "[initial(name)]"
+	update_icon()
+	if(user.get_item_by_slot(SLOT_BACK) == src)
+		user.update_inv_back()
+	else
+		user.update_inv_hands()
+	if(show_message)
+		to_chat(user, "<span class='notice'>You are now carrying [src] with one hand.</span>")
+	var/obj/item/shield/offhand/O = user.get_inactive_held_item()
+	if(O && istype(O))
+		O.unwield()
+	return
+
+/obj/item/shield/proc/wield(mob/living/carbon/user)
+	if(wielded)
+		return
+	if(ismonkey(user))
+		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
+		return
+	if(user.get_inactive_held_item())
+		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
+		return
+	if(user.get_num_arms() < 2)
+		to_chat(user, "<span class='warning'>You don't have enough intact hands.</span>")
+		return
+	wielded = TRUE
+	if(!isnull(block_chance_wielded))
+		block_chance = block_chance_wielded
+	name = "[name] (Wielded)"
+	update_icon()
+	to_chat(user, "<span class='notice'>You grab [src] with both hands.</span>")
+	var/obj/item/shield/offhand/O = new(user) ////Let's reserve his other hand~
+	O.name = "[name] - offhand"
+	O.desc = "Your second grip on [src]."
+	O.wielded = TRUE
+	user.put_in_inactive_hand(O)
+	return
+
+/obj/item/shield/dropped(mob/living/user)
+	..()
+	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
+	if(!wielded)
+		return
+	unwield(user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.physiology.armor = H.physiology.armor.setRating(melee = 0, bullet = 0, bomb = 0)
+
+/obj/item/shield/attack_self(mob/user)
+	. = ..()
+	if(can_2hand)
+		if(wielded) //Trying to unwield it
+			unwield(user)
+		else //Trying to wield it
+			wield(user)
+
+/obj/item/shield/equip_to_best_slot(mob/living/carbon/user)
+	if(..())
+		unwield(user)
+		return
+
+/obj/item/shield/equipped(mob/living/user, slot)
+	..()
+	if(!user.is_holding(src) && wielded)
+		unwield(user)
+	if(ishuman(user) && boost_armor)
+		var/mob/living/carbon/human/H = user
+		H.physiology.armor = H.physiology.armor.modifyRating(melee = 15, bullet = 5, bomb = 15)
+
+///////////OFFHAND///////////////
+/obj/item/shield/offhand
+	name = "offhand"
+	icon_state = "offhand"
+	w_class = WEIGHT_CLASS_HUGE
+	item_flags = ABSTRACT
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	boost_armor = FALSE
+
+/obj/item/shield/offhand/Destroy()
+	wielded = FALSE
+	return ..()
+
+/obj/item/shield/offhand/dropped(mob/living/user, show_message = TRUE) //Only utilized by dismemberment since you can't normally switch to the offhand to drop it.
+	var/obj/I = user.get_active_held_item()
+	if(I && istype(I, /obj/item/shield))
+		var/obj/item/twohanded/thw = I
+		thw.unwield(user, show_message)
+	if(!QDELETED(src))
+		qdel(src)
+
+/obj/item/shield/offhand/unwield()
+	if(wielded)//Only delete if we're wielded
+		wielded = FALSE
+		qdel(src)
+
+/obj/item/shield/offhand/wield()
+	if(wielded)//Only delete if we're wielded
+		wielded = FALSE
+		qdel(src)
+
+/obj/item/shield/offhand/attack_self(mob/living/carbon/user)		//You should never be able to do this in standard use of two handed items. This is a backup for lingering offhands.
+	var/obj/item/shield/O = user.get_inactive_held_item()
+	if (istype(O) && !istype(O, /obj/item/shield/offhand))		//If you have a proper item in your other hand that the offhand is for, do nothing. This should never happen.
+		return
+	if (QDELETED(src))
+		return
+
+/obj/item/shield/energy
+	can_2hand = FALSE
+	boost_armor = FALSE
+
+/obj/item/shield/riot/tele/attack_self(mob/living/user)
+	can_2hand = active
+	if(!active)
+		to_chat(user, "<span class='notice'>You must extend [src] before you wield it!</span>")
+	..()
+
+/obj/item/shield/riot/tele/AltClick(mob/living/user)
+	..()
+	update_icon()
+	if(wielded)
+		unwield(user)
+		active = FALSE
+		can_2hand = FALSE

--- a/hippiestation/code/game/objects/items/shields.dm
+++ b/hippiestation/code/game/objects/items/shields.dm
@@ -32,8 +32,10 @@
 	var/boost_armor = TRUE
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!is_A_facing_B(owner,hitby))
+	if(attack_type == PROJECTILE_ATTACK)
 		to_chat(owner, "<span class='notice'>[src] fails to deflect [attack_text].</span>")
+		return FALSE
+	if(!is_A_facing_B(owner,hitby))
 		return FALSE
 	final_block_chance -= damage
 	return ..()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
add: Shields can be wielded to have a 75% block damage only when facing their attacker and at the cost of a free hand.
tweak: Telescopic riot shields now extend with alt click
balance: Shields no longer block projectiles
balance: Shields not including energy based must be wielded to block damage
balance: Shields not including energy based now give you 15 melee, 5 bullet and 15 bomb armor when equipped
balance: Energy shields no longer block damage but will still deflect energy based weapons
balance: Shields now have their block chances reduced by the value of incoming damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
What this does is make energy shields less over fucking powered by ONLY having them deflect projectiles and not have a 50% fucking block which makes them waaay more appropriately balanced. Shields and I mean all of them except energy based ones, give an armor bonus when equipped/held, and will give away a 75% block chance when wielded (two handed) and only when facing said attacker that isn't firing a projectile at you. In addition, the stronger the weapon used against the shield holder, the less likely they are to block the attack. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Did I mention that this will affect additional arms? Yes, you're forced to sacrifice 2 slots to wield them, and if you stack them with energy shields, you only have one slot free for a gun. The part of it is, you still get insane armor bonus, but the crew can still use shotguns against you without issue. I've considered the nanosuit too when doing this. At worst, the nanosuit has armor mode which is a 50% block to all damage, stacking with the shield, you get a 75% non-projectile, directional block only when held in both hands + an energy shield which deflects energy based weapons. The worst case scenario is you can't effectively use melee weapons and energy based weapon. This is not a problem considering you can use a shotgun and AT WORST with all of this including the shotgun, the most effective this robust nukie has is a 50% block chance with armor! Ta da! Nanosuit with 4 arms, riot and energy shield can still be powerful as fuck (I mean all together it's 44 TC NOT including discounts and guns) but not completely stupidly overpowered, broken and impossible to kill. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


I hope I did this right, I've considered just about every single factor into play here and spent a long time perfecting the code itself, I hope I've covered anything. If there is something that you're not sure about, I prefer if you would ask rather than assume the worst.