### PR TITLE
A Fix for Invisible Cardboard Boxes

### DIFF
--- a/hippiestation/code/modules/paperwork/photography.dm
+++ b/hippiestation/code/modules/paperwork/photography.dm
@@ -82,8 +82,7 @@
 		disguise = null
 
 		if (!opened)
-			cut_overlays()
-			icon = initial(icon)
+			appearance = initial(appearance)
 	else
 		. = ..()
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Closed cardboard boxes no longer are invisible after a disguise is removed from one.
/:cl:

## About The Pull Request
A closed cardboard box would keep using the appearance of its disguise after it had been removed, since the appearance of the closed cardboard box was never set back to the initial appearance of the closed box, which is why the previous two lines that were used for trying to change the icon of the closed cardboard box would not bear fruit. Replacing the attempt to change the icon of the closed cardboard box with just a reassignment of the appearance variable to its initial value seems to do the job of removing the disguise so that a closed cardboard box will be shown rather nicely. Fixes #10675.

## Why It's Good For The Game
This fixes the issue with getting invisible (closed) cardboard boxes when you just remove a disguise placed on it.