### PR TITLE
Reduces the price of combat and hazard nanites slightly, and adds adrenaline burst under combat nanites

### DIFF
--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -208,12 +208,12 @@
 	program_type = /datum/nanite_program/conductive
 	category = list("Augmentation Nanites")
 
-/*/datum/design/nanites/adrenaline
+/datum/design/nanites/adrenaline
 	name = "Adrenaline Burst"
 	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
 	id = "adrenaline_nanites"
 	program_type = /datum/nanite_program/triggered/adrenaline
-	category = list("Augmentation Nanites") HIPPIE EDIT - REMOVES FUCKING ADRENALS */
+	category = list("Augmentation Nanites")
 
 /datum/design/nanites/mindshield
 	name = "Mental Barrier"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -924,7 +924,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
+	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 8000
 
@@ -933,7 +933,7 @@
 	display_name = "Military Nanite Programming"
 	description = "Nanite programs that perform military-grade functions."
 	prereq_ids = list("nanite_harmonic")
-	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites")
+	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites","adrenaline_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 75000)
 	export_price = 12500
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -934,7 +934,7 @@
 	description = "Nanite programs that perform military-grade functions."
 	prereq_ids = list("nanite_harmonic")
 	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites","adrenaline_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 75000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 50000)
 	export_price = 12500
 
 /datum/techweb_node/nanite_hazard
@@ -943,7 +943,7 @@
 	description = "Extremely advanced Nanite programs with the potential of being extremely dangerous."
 	prereq_ids = list("nanite_harmonic")
 	design_ids = list("spreading_nanites","mindcontrol_nanites","mitosis_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 100000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 75000)
 	export_price = 15000
 
 ////////////////////////Alien technology////////////////////////


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
balance: Slightly reduces combat and hazard nanite prices
add: Adds back "Adrenaline Burst" under combat nanites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
I made this pull request because, finally seeing my code in game, i decided it shouldn't take more than a tritium nuke to get combat nanites. I added back adrenals because I don't like wasting code, and it gives combat nanites something other than brutally killing people who contract them. Plus, 2 minute cooldown, so it cant be all that bad. If anyone would like, I could lengthen the cooldown or increase the nanite consumption rate to balance them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
More content, more easily available.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
