### PR TITLE
Fixes stun gun/baton special attack exploding random machinery.

### DIFF
--- a/hippiestation/code/game/objects/items/special_attacks.dm
+++ b/hippiestation/code/game/objects/items/special_attacks.dm
@@ -149,7 +149,7 @@
 
 /obj/item/melee/baton/do_special_attack(atom/target, mob/living/carbon/user)
 	if(isliving(user) && status == TRUE)
-		tesla_zap(src, 4, 10000)
+		tesla_zap(src, 4, 10000, TESLA_FUSION_FLAGS)
 		user.electrocute_act(20, src, TRUE, TRUE)
 		deductcharge(hitcost)
 		user.visible_message("<span class='danger'>[user] spits on the active end of [src]!</span>")

--- a/hippiestation/code/game/objects/items/special_attacks.dm
+++ b/hippiestation/code/game/objects/items/special_attacks.dm
@@ -151,6 +151,8 @@
 	if(isliving(user) && status == TRUE)
 		tesla_zap(src, 4, 10000, TESLA_FUSION_FLAGS)
 		user.electrocute_act(20, src, TRUE, TRUE)
+		log_admin("[user] used [special_name] on [target]")
+		message_admins("<span class='adminnotice'>[user] used [special_name] on [target]</span>")
 		deductcharge(hitcost)
 		user.visible_message("<span class='danger'>[user] spits on the active end of [src]!</span>")
 		playsound(user, 'sound/magic/lightningbolt.ogg', 100, 1, -1)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
fix: Stun baton/gun special attacks can no longer explode machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This fixes a really old and annoying bug that was often abused to break into areas, kill random bystanders and cause an unlogged suicide. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because shit's cancer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
