### PR TITLE
Crossbow Fixes

### DIFF
--- a/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -111,7 +111,7 @@
 		bowstring = bowstring + "not drawn"
 	to_chat(user, "[bowstring][charge > 2 ? "!" : "."]")
 
-	if (chambered && chambered.BB)
+	if (chambered?.BB)
 		to_chat(user, "A [chambered.BB] is loaded.")
 
 /obj/item/gun/ballistic/crossbow/update_icon()

--- a/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -111,11 +111,12 @@
 		bowstring = bowstring + "not drawn"
 	to_chat(user, "[bowstring][charge > 2 ? "!" : "."]")
 
-	if (chambered.BB)
-		to_chat(user, "A [chambered.BB] is loaded.")
+	if (chambered)
+		to_chat(user, "\A [chambered.BB] is loaded.")
 
 /obj/item/gun/ballistic/crossbow/update_icon()
 	..()
+	cut_overlays()
 	if (charge >= max_charge)
 		add_overlay("charge_[max_charge]")
 	else if (charge < 1)

--- a/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -111,7 +111,7 @@
 		bowstring = bowstring + "not drawn"
 	to_chat(user, "[bowstring][charge > 2 ? "!" : "."]")
 
-	if (chambered)
+	if (chambered && chambered.BB)
 		to_chat(user, "\A [chambered.BB] is loaded.")
 
 /obj/item/gun/ballistic/crossbow/update_icon()

--- a/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/hippiestation/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -112,7 +112,7 @@
 	to_chat(user, "[bowstring][charge > 2 ? "!" : "."]")
 
 	if (chambered && chambered.BB)
-		to_chat(user, "\A [chambered.BB] is loaded.")
+		to_chat(user, "A [chambered.BB] is loaded.")
 
 /obj/item/gun/ballistic/crossbow/update_icon()
 	..()


### PR DESCRIPTION
## Changelog
:cl:
fix: Crossbows now show their current state properly.
fix: Crossbows won't now cause a runtime error when examined without a rod loaded in.
/:cl:

## About The Pull Request
The reason for why the overlays were shown oddly on the crossbow seemed to be more or less due to the fact that none of the previous overlays were cut before applying another combination of them to show the current state of the crossbow. To fix this, I just introduced the cut_overlays call to get rid of any previous combination before applying another combination of the overlays appropriate for the current state. Fixes #10429.

If you examined a crossbow, the examine proc would lastly try to output text related to the loaded rod by first looking at its BB variable. This causes a problem in the case that there was no rod loaded, because if there is no rod in the crossbow, chambered is null, so now we check that the chambered rod exists before we check that the BB variable exists.

## Why It's Good For The Game
The first fix should help with the problem that crossbows had with showing their overlays. As for the other fix, a player wouldn't really see any difference when the runtime error happens, but I would suppose that fixing it is more preferable than letting it still be around.
