### PR TITLE
you can now black list reagents from strange seeds using can_synth_seeds

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -367,7 +367,7 @@
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
-		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
+		var/datum/plant_gene/reagent/R = new(get_random_reagent_id_seeds(), random_amount) // hippie --  before change line was var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount); changed this line to use a hippie proc, why: created a new list to improve balance and only blacklist reagents from appearing only in seeds using can_synth_seeds in datum/reagent, this pro was only used by seeds anyway
 		if(R.can_add(src))
 			genes += R
 		else

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3167,6 +3167,7 @@
 #include "hippiestation\code\modules\hydroponics\limbflower.dm"
 #include "hippiestation\code\modules\hydroponics\planet_genes.dm"
 #include "hippiestation\code\modules\hydroponics\seed_extractor.dm"
+#include "hippiestation\code\modules\hydroponics\seeds.dm"
 #include "hippiestation\code\modules\hydroponics\grown\berries.dm"
 #include "hippiestation\code\modules\hydroponics\grown\nettle.dm"
 #include "hippiestation\code\modules\integrated_electronics\core\analyzer.dm"

--- a/hippiestation/code/modules/hydroponics/seeds.dm
+++ b/hippiestation/code/modules/hydroponics/seeds.dm
@@ -1,0 +1,9 @@
+/obj/item/seeds/proc/get_random_reagent_id_seeds()
+	var/static/list/random_reagents = list()
+	if(!random_reagents.len)
+		for(var/thing  in subtypesof(/datum/reagent))
+			var/datum/reagent/R = thing
+			if(initial(R.can_synth) || initial(R.can_synth_seeds))
+				random_reagents += initial(R.id)
+	var/picked_reagent = pick(random_reagents)
+	return picked_reagent

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -3,6 +3,7 @@
 	var/boiling_point = 500//the point at which a reagent changes from a liquid to a gaseous state
 	var/melting_point = 273//the point at which a reagent changes from a liquid to a solid state
 	var/processes = FALSE
+	var/can_synth_seeds = TRUE
 
 /datum/reagent/New()
 	..()


### PR DESCRIPTION
had to edit a tg file to implement this, created a new proc: get_random_reagent_id_seeds(), created a new var: can_synth_seeds
:cl: uBadush
code: created a new var for reagents to black list reagents from strange seeds only
:cl:

@Jujumatic everything you wanted is here minus modularization of the tg line

