### PR TITLE
Runtime Error for Failing a Surgery Step Using Your Hands Fix

### DIFF
--- a/hippiestation/code/modules/surgery/surgery_step.dm
+++ b/hippiestation/code/modules/surgery/surgery_step.dm
@@ -6,7 +6,7 @@
 	var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(target_zone))
 	var/damage_amount = 20
 
-	if (tool.force)
+	if (tool?.force)
 		damage_amount = tool.force * 2 // You managed to do it, but also hurt the patient
 
 	if (!affecting)


### PR DESCRIPTION
## Changelog
:cl:
fix: A surgery step that uses hands as a tool will now apply damage on the patient and let the surgery they are part of go forward when you fail this step.
/:cl:

## About The Pull Request
As the redefined failure proc didn't make sure that a tool does exist before checking the tool.force value, you could cause a runtime error from the proc trying to access tool.force when tool is null, which is the case when a surgery step uses hands as the tool. When this runtime error happens, it causes no damage to be applied from failing the surgery step and it wouldn't let the surgery proceed forward, but anything the current step would've done is still applied, since the surgery step's success proc is called before the runtime error causing check.

## Why It's Good For The Game
This should stop surgeries from not going forward and applying damage just because you're failing a surgery step where you have to use your hand to perform it.