### PR TITLE
Nerf nanosuit slightly

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -327,11 +327,11 @@
 			user.visible_message("<span class='danger'>[user]'s shields deflect [attack_text] draining their energy!</span>")
 			if(damage)
 				if(attack_type != STAMINA)
-					set_nano_energy(5 + damage,NANO_CHARGE_DELAY)//laser guns, anything lethal drains 5 + the damage dealth
+					set_nano_energy(10 + damage,NANO_CHARGE_DELAY)//laser guns, anything lethal drains 5 + the damage dealt
 				else if(P.damage_type == STAMINA && attack_type == PROJECTILE_ATTACK)
-					set_nano_energy(15,NANO_CHARGE_DELAY)//stamina damage, aka disabler beams
+					set_nano_energy(20,NANO_CHARGE_DELAY)//stamina damage, aka disabler beams
 			if(istype(P, /obj/item/projectile/energy/electrode))//if electrode aka taser
-				set_nano_energy(25,NANO_CHARGE_DELAY)
+				set_nano_energy(35,NANO_CHARGE_DELAY)
 			return TRUE
 		else
 			user.visible_message("<span class='warning'>[user]'s shields fail to deflect [attack_text].</span>")
@@ -341,7 +341,7 @@
 			s.set_up(1, 1, src)
 			s.start()
 	kill_cloak()
-	if(prob(damage*2) && user.health < 60 && current_charges > 0)
+	if(prob(damage*1.5) && user.health < 50 && current_charges)
 		addtimer(CALLBACK(src, .proc/addmedicalcharge), medical_delay,TIMER_UNIQUE|TIMER_OVERRIDE)
 		current_charges--
 		heal_nano(user)
@@ -370,8 +370,6 @@
 					helmet.display_visor_message("Thoracic burns detected!")
 					msg_time_react = 300
 
-	if(attack_type == THROWN_PROJECTILE_ATTACK)
-		final_block_chance += 15
 	if(attack_type == LEAP_ATTACK)
 		final_block_chance = 75
 	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
@@ -404,8 +402,8 @@
 				helmet.display_visor_message("Maximum Armor!")
 				block_chance = 50
 				slowdown = initial(slowdown)
-				armor = armor.setRating(melee = 60, bullet = 60, laser = 60, energy = 65, bomb = 100, rad =100)
-				helmet.armor = helmet.armor.setRating(melee = 60, bullet = 60, laser = 60, energy = 65, bomb = 100, rad =100)
+				armor = armor.setRating(melee = 50, bullet = 50, laser = 50, energy = 55, bomb = 90, rad = 90)
+				helmet.armor = helmet.armor.setRating(melee = 50, bullet = 50, laser = 50, energy = 55, bomb = 90, rad = 90)
 				Wearer.filters = list()
 				animate(Wearer, alpha = 255, time = 5)
 				Wearer.remove_movespeed_modifier(NANO_SPEED)
@@ -444,7 +442,7 @@
 				animate(Wearer, alpha = 255, time = 5)
 				Wearer.remove_trait(TRAIT_PUSHIMMUNE, NANO_STRENGTH)
 				Wearer.add_trait(TRAIT_TACRELOAD, NANO_SPEED)
-				Wearer.add_movespeed_modifier(NANO_SPEED, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
+				Wearer.add_movespeed_modifier(NANO_SPEED, update=TRUE, priority=100, multiplicative_slowdown=-0.5, blacklisted_movetypes=(FLYING|FLOATING))
 				Wearer.add_trait(TRAIT_IGNORESLOWDOWN, NANO_SPEED)
 				Wearer.remove_trait(TRAIT_LIGHT_STEP, NANO_SPEED)
 				style.remove(Wearer)
@@ -769,8 +767,7 @@
 
 /datum/martial_art/nanosuit
 	name = "Nanosuit strength mode"
-	block_chance = 75
-	deflection_chance = 25
+	block_chance = 50
 	id = MARTIALART_NANOSUIT
 
 /datum/martial_art/nanosuit/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -442,7 +442,7 @@
 				animate(Wearer, alpha = 255, time = 5)
 				Wearer.remove_trait(TRAIT_PUSHIMMUNE, NANO_STRENGTH)
 				Wearer.add_trait(TRAIT_TACRELOAD, NANO_SPEED)
-				Wearer.add_movespeed_modifier(NANO_SPEED, update=TRUE, priority=100, multiplicative_slowdown=-0.5, blacklisted_movetypes=(FLYING|FLOATING))
+				Wearer.add_movespeed_modifier(NANO_SPEED, update=TRUE, priority=100, multiplicative_slowdown=-0.25, blacklisted_movetypes=(FLYING|FLOATING))
 				Wearer.add_trait(TRAIT_IGNORESLOWDOWN, NANO_SPEED)
 				Wearer.remove_trait(TRAIT_LIGHT_STEP, NANO_SPEED)
 				style.remove(Wearer)

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -335,10 +335,10 @@
 //Nanosuit uplink item, available in all traitor rounds and nuke.
 /datum/uplink_item/dangerous/nanosuit
 	name = "CryNet Nanosuit"
-	desc = "Become a posthuman warrior. The items cannot be taken off once you wear them."
+	desc = "Become a posthuman warrior. The items cannot be taken off once you wear them and alerts the crew of your position if equipped on station."
 	item = /obj/item/storage/box/syndie_kit/nanosuit
 	cost = 20
-	exclude_modes = list(/datum/game_mode/infiltration)
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration)
 
 /datum/uplink_item/dangerous/synth
 	name = "Cybersun Sponsorship Kit"

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -338,6 +338,8 @@
 	desc = "Become a posthuman warrior. The items cannot be taken off once you wear them and alerts the crew of your position if equipped on station."
 	item = /obj/item/storage/box/syndie_kit/nanosuit
 	cost = 20
+	surplus = 10
+	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration)
 
 /datum/uplink_item/dangerous/synth


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
balance: Nanosuit only runs 25% faster than running speed now.
balance: Adjusted some armor depletion values on the nanosuit.
del: Nanosuit no longer randomly deflects projectiles in strength mode.
balance: Reduced martial block chance in nanosuit str mode.
balance: Reduced activation chance and threshold of emergency medical of nanosuit.
balance: Reduced max assigned values of armor mode for nanosuit.
balance: Nanosuit can no longer be used in nukies.
balance: Nanosuit can't be found as a discount in uplink and is less likely to be a surplus crate spawn
del: Nanosuit no longer has an increased block chance against thrown items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This PR is balancing some numbers for the nanosuit I felt were giving it a unfair advantage over a simple crew that had little to no chance of surviving an extremely robust user. Also it can no longer be bought in nukies.
The first thing I want to discuss are armor depletion values. Starting off with simple damage, the previous amount of energy that would drain from a basic hit would be 5 + dmg dealth. Energy guns take 25 away, 5 + base damage of 20, now it takes 30. 3 Direct hits from a laser gun leaves the wearer with exactly 10 charge left, not nearly enough to use to run away far enough, whereas the previous amount would have left them with 25, which when you combine with the old speed mode speed, was more than enough to run out of harms way and wait around to have the suit charge up. Next are disablers which take away 15 armor per hit. It would take 7 hits to properly deplete a nanosuit charge, which is too much. That number is now is 5 at 20 charge per hit. Onto tasers, 4 hits was needed to kill armor, now it's 3. 
I feel like the values will be fair for both sec and whoever wears the suit.
Last thing, nukies didn't deserve this suit, it outclasses pretty much any other suit
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because apparently everyone was complaining the suit was too strong so this will address those complaints.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
