### PR TITLE
Nerfs charge time on nanosuit

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -4,8 +4,8 @@
 #define NANO_STRENGTH "strength"
 #define NANO_NONE "none"
 #define NANO_JUMP_USE 30
-#define NANO_CHARGE_DELAY 15
-#define NANO_EMP_CHARGE_DELAY 40
+#define NANO_CHARGE_DELAY 20
+#define NANO_EMP_CHARGE_DELAY 45
 
 #define POWER_PUNCH "QQQ"
 #define HEAD_EXPLOSION "SSSS"
@@ -307,7 +307,7 @@
 			recharge_cooldown = 15 //then wait 3 seconds(1 value per 2 ticks = 15*2=30/10 = 3 seconds) to recharge again
 		if(mode != NANO_ARMOR && mode != NANO_NONE) //we're not in cloak
 			toggle_mode(NANO_ARMOR, TRUE) //go into it, forced
-	cell.use(round(amount))
+	cell.charge = max(0,(cell.charge - amount))
 	return TRUE
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/addmedicalcharge()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
balance: Nerfs nanosuit recharge delay time
fix: Nanosuit charge was not fully draining and his been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This fix was game breaking.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Nanosuit can recover too fast after doing a move that depletes charge, also decided to nerf EMP recover time to a more fair value.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
