### PR TITLE
Fixes some outdated/old hippie map stuff

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -504,10 +504,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/main)
-"abt" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "abu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2148,11 +2144,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aem" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
 "aen" = (
 /obj/machinery/button/door{
 	id = "permacell3";
@@ -3150,8 +3141,11 @@
 	req_access_txt = "1";
 	security_level = 6
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/maintenance/department/security)
 "agu" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -15902,7 +15896,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/hippie/clown)
 "aMN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -28872,15 +28866,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Central Maintenance APC";
-	areastring = "/area/maintenance/central/secondary";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "bvl" = (
@@ -39818,6 +39803,11 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/door/window/westleft{
+	name = "Atmospherics Delivery";
+	req_access_txt = "24"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWJ" = (
@@ -56494,7 +56484,7 @@
 "dRT" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/security/prison)
+/area/maintenance/department/security)
 "dSc" = (
 /obj/machinery/light{
 	dir = 1
@@ -58850,6 +58840,22 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
+"htG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "htW" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light{
@@ -59323,13 +59329,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Port Engineering";
-	req_access_txt = "10"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Port Engineering";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -60685,7 +60691,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "keI" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bucket,
@@ -61660,7 +61666,7 @@
 "lFA" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "lFD" = (
 /obj/structure/closet/cardboard,
 /obj/machinery/light/small{
@@ -61797,7 +61803,7 @@
 "lLX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "lMg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63812,6 +63818,18 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oPq" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/security";
+	dir = 1;
+	name = "Security Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "oQZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -63946,7 +63964,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "pbO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -64381,7 +64399,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/prison)
+/area/maintenance/department/security)
 "pIi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -64885,6 +64903,12 @@
 	name = "floor"
 	},
 /area/engine/port_engineering)
+"qxN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "qyz" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -64912,6 +64936,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qBv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "qBB" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet,
@@ -65897,6 +65927,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"sgP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "shd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -66307,7 +66346,7 @@
 "sOn" = (
 /obj/item/bot_assembly/secbot,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "sOM" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -66498,6 +66537,9 @@
 "sXO" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"sYr" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "sYF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -67329,7 +67371,7 @@
 "umS" = (
 /obj/structure/closet/wardrobe/red,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "umV" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -67435,6 +67477,9 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"uvG" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/security)
 "uwu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68033,7 +68078,7 @@
 "vsE" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "vtk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -68867,7 +68912,7 @@
 "wBx" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "wBK" = (
 /obj/item/stack/rods,
 /turf/open/space,
@@ -69531,7 +69576,7 @@
 "xvV" = (
 /obj/item/rack_parts,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security)
 "xwa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -90729,9 +90774,9 @@ aaa
 aaa
 aaa
 aaa
-aFi
 aaa
-bqy
+aaa
+aad
 aad
 aaa
 aaa
@@ -90975,23 +91020,23 @@ aad
 aaj
 aad
 aFi
-bqy
+aad
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-bqy
+aad
 afO
 afO
 afO
 afI
 afO
-bqy
+aad
 aaa
 aaa
-aFi
+aaa
 aaa
 aaa
 aaa
@@ -91230,28 +91275,28 @@ aaa
 aaf
 aad
 aaj
-bqy
-bqy
-bqy
-bqy
-bqy
-bqy
-bqy
-bqy
-bqy
-bqy
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 afO
 aef
 lzg
 afJ
 afO
-bqy
+aad
 aaa
 aaa
 aaa
 aaa
 aaa
-bqy
+aad
 ako
 ali
 ali
@@ -91487,7 +91532,7 @@ aaa
 aaf
 aad
 aaj
-bqy
+aad
 aaa
 aaa
 aaa
@@ -91503,11 +91548,11 @@ aeU
 afK
 afO
 afO
-aal
-aal
+uvG
+uvG
 aaa
 aaa
-bqy
+aad
 aad
 ako
 ako
@@ -91761,9 +91806,9 @@ afL
 agr
 afO
 vsE
-aal
-bqy
-bqy
+uvG
+aad
+aad
 aad
 aad
 aaa
@@ -92004,8 +92049,8 @@ aaj
 aaa
 aaa
 aaa
-bqy
-bqy
+aad
+aad
 afO
 iZD
 aba
@@ -92018,9 +92063,9 @@ afM
 fAd
 afO
 lFA
-aal
-aal
-bqy
+uvG
+uvG
+aad
 aad
 aaa
 aaa
@@ -92261,8 +92306,8 @@ aaj
 aaa
 aaa
 aaa
-bqy
-bqy
+aad
+aad
 afO
 abB
 abg
@@ -92274,9 +92319,9 @@ adG
 adY
 aek
 afO
-aaA
+sYr
 pbB
-aal
+uvG
 aaa
 aaa
 aaa
@@ -92516,10 +92561,10 @@ aaa
 aad
 aaj
 aaa
-abt
-abt
-abt
-abt
+ahy
+ahy
+ahy
+ahy
 afO
 afO
 afO
@@ -92532,8 +92577,8 @@ adZ
 afO
 afO
 kdI
-aaA
-aal
+sYr
+uvG
 aaa
 aaa
 aaa
@@ -92773,7 +92818,7 @@ aaa
 aad
 aaj
 aaa
-abt
+ahy
 aFi
 aad
 aFi
@@ -92790,7 +92835,7 @@ oLC
 aal
 xvV
 wBx
-aal
+uvG
 aaa
 aaa
 aaa
@@ -93030,7 +93075,7 @@ aaa
 aad
 aaj
 aaa
-abt
+ahy
 aFi
 mHG
 eTA
@@ -93045,7 +93090,7 @@ abv
 uTS
 abM
 aal
-aaA
+sYr
 wBx
 dRT
 aad
@@ -93287,7 +93332,7 @@ aaa
 aad
 aaj
 aaa
-abt
+ahy
 aFi
 vnO
 lYj
@@ -93302,7 +93347,7 @@ adX
 aec
 afR
 aal
-aaA
+sYr
 wBx
 dRT
 aad
@@ -93544,7 +93589,7 @@ aad
 aad
 aaj
 aaa
-abt
+ahy
 aFi
 abw
 goU
@@ -93559,9 +93604,9 @@ aeJ
 suA
 afR
 aal
-aaA
+oPq
 lLX
-aal
+uvG
 aad
 aai
 aai
@@ -93800,8 +93845,8 @@ aad
 aaj
 aaj
 aaj
-bqy
-abt
+aad
+ahy
 aFi
 dAU
 aeK
@@ -93816,9 +93861,9 @@ oLC
 pIi
 mzH
 aal
-aaA
-aaA
-aal
+qxN
+sYr
+uvG
 aaa
 ajc
 ajc
@@ -94059,7 +94104,7 @@ aad
 aad
 aad
 ahy
-bqy
+aad
 aal
 aal
 aal
@@ -94070,10 +94115,10 @@ aal
 abk
 oLC
 oLC
-suA
-afR
+htG
+sgP
 ags
-aaA
+qBv
 sOn
 dRT
 aad
@@ -94313,12 +94358,12 @@ aad
 aad
 aaj
 aad
-bqy
-bqy
-abt
-bqy
-bqy
-jEA
+aad
+aad
+ahy
+aad
+aad
+aae
 aal
 aaV
 abl
@@ -94570,11 +94615,11 @@ aae
 aad
 aaj
 aad
-bqy
-bqy
-abt
-jEA
-jEA
+aad
+aad
+ahy
+aae
+aae
 aal
 aal
 aaY
@@ -94588,8 +94633,8 @@ suA
 abZ
 aal
 umS
-aaA
-aal
+sYr
+uvG
 aaa
 ajd
 ajD
@@ -94827,9 +94872,9 @@ aaf
 aad
 aaj
 aad
-eMk
-eMk
-aem
+aai
+aai
+aaE
 aal
 aal
 aal


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
tweak: Security prison maintenance now has it's own area and apc.
fix: Removed duplicated central maint apc.
tweak: Added in a delivery door to the flaps in atmos delivery (from box station).
fix: Fixed random space area in clown's office.
tweak: Port engineering entrance is now a glass door.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Basically I just did some fixes and tweaks that were added to box station like the atmos delivery door, nothing too huge.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Maps get outdated, so consider this a very minor tune up.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
