### PR TITLE
Webeditor PR touching chem-pile reaction chance

### DIFF
--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(chempiles)
 	return ..()
 
 /obj/effect/decal/cleanable/chempile/ex_act(severity)
-	if(prob(severity)*2)
+	if(prob(severity*2))
 		..()
 	else
 		qdel(src)

--- a/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
+++ b/hippiestation/code/game/objects/effects/decals/cleanable/chem.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(chempiles)
 	return ..()
 
 /obj/effect/decal/cleanable/chempile/ex_act(severity)
-	if(prob(severity))
+	if(prob(severity)*2)
 		..()
 	else
 		qdel(src)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
tweak: Doubled chem-pile reaction chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Honestly since smoke got heavily nerfed, this has made any chance to effectively use chain reaction chem-piles effectively.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
This will probably make these reactions actually happen seeing as in game test of roughly 130 chempiles only resulted in 5 secondary explosions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
