### PR TITLE
Slightly increases amount of chemicals smoke adds

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -238,7 +238,7 @@ hippie end */
 				continue
 			if(T.intact && AM.level == 1) //hidden under the floor
 				continue
-			reagents?.reaction(AM, TOUCH, fraction, special_modifier = amount*0.05)//hippie edit -- apparently this sanity check is needed for runtime prevention
+			reagents?.reaction(AM, TOUCH, fraction, special_modifier = amount*0.1)//hippie edit -- apparently this sanity check is needed for runtime prevention
 
 		reagents?.reaction(T, TOUCH, fraction)//hippie edit -- apparently this sanity check is needed for runtime prevention
 		return 1


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
tweak: Smoke wasn't adding a lot of chemicals to the floor which felt a tad unfun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This will double the amount of smoke chem piles add from my nerf I did but still keep it under the threshold that allows for duplication.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
We don't want to completely cuck fun for chemists and traitors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
