### PR TITLE
Fixes for some IC tools

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/core/debugger.dm
+++ b/hippiestation/code/modules/integrated_electronics/core/debugger.dm
@@ -14,7 +14,7 @@
 	var/datum/weakref/idlock = null
 
 /obj/item/integrated_electronics/debugger/attack_self(mob/user)
-	var/type_to_use = input("Please choose a type to use.","[src] type setting") as null|anything in list("string","number","ref","copy","null")
+	var/type_to_use = input("Please choose a type to use.","[src] type setting") as null|anything in list("string","number","ref","copy","null","id lock")
 	if(!user.IsAdvancedToolUser())
 		return
 

--- a/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/input.dm
@@ -163,7 +163,7 @@
 	activate_pin(2)
 
 /obj/item/integrated_circuit/input/slime_scanner
-	name = "slime_scanner"
+	name = "slime scanner"
 	desc = "A very small version of the xenobio analyser. This allows the machine to know every needed properties of slime. Output mutation list is non-associative."
 	icon_state = "medscan_adv"
 	complexity = 12

--- a/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -610,7 +610,8 @@
 	activators = list(
 		"spray" = IC_PINTYPE_PULSE_IN,
 		"on sprayed" = IC_PINTYPE_PULSE_OUT,
-		"on fail" = IC_PINTYPE_PULSE_OUT
+		"on fail" = IC_PINTYPE_PULSE_OUT,
+		"push ref" = IC_PINTYPE_PULSE_IN
 		)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 15
@@ -711,7 +712,8 @@
 	activators = list(
 		"drain" = IC_PINTYPE_PULSE_IN,
 		"on drained" = IC_PINTYPE_PULSE_OUT,
-		"on fail" = IC_PINTYPE_PULSE_OUT
+		"on fail" = IC_PINTYPE_PULSE_OUT,
+		"push ref" = IC_PINTYPE_PULSE_IN
 		)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 15


### PR DESCRIPTION
## Changelog
:cl:
fix: You can actually ID lock your IC designs now and some other minor IC tool fixes.
/:cl:

## About The Pull Request

Input
Changed the slime analyzer name from "slime_analyzer" to "slime analyzer" because it's been like that for more than a year

Reagents
Added the "push ref" functionality to the drain circuit and extinguisher circuit because as it is now you have to manually copy the ref and paste it where you want the circuits to function in an assembly

Debugger
Added the option to scan ID cards for locking printed assemblies. The code to do it was there and the change was merged but someone forgot to add the option to select the function to the circuit debugger

## Why It's BAD For The Game

You can now lock your round ending creations without the fear of them spreading into other hands and getting IC removed from the server when people find out what cancer you can do with it
