### PR TITLE
Changes practical bluespace, micro bluespace and blue travel node cost to 2500

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -181,7 +181,7 @@
 	description = "Application of Bluespace for static teleportation technology."
 	prereq_ids = list("practical_bluespace")
 	design_ids = list("tele_station", "tele_hub", "teleconsole", "quantumpad", "launchpad", "launchpad_console", "bluespace_pod")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/micro_bluespace
@@ -190,7 +190,7 @@
 	description = "Extreme reduction in space required for bluespace engines, leading to portable bluespace technology."
 	prereq_ids = list("bluespace_travel", "practical_bluespace", "high_efficiency")
 	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "bag_holding", "quantum_keycard", "wormholeprojector")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/practical_bluespace
@@ -199,7 +199,7 @@
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
 	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "ore_silo")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/bluespace_power


### PR DESCRIPTION

## Changelog

balance: Changed practical bluespace, micro bluespace and blue travel node cost to 2500


## About The Pull Request
This changes these three nodes that every machine on the station can benefit from to a lower price, reducing wait time by around 4 minutes to get it.

## Why It's Good For The Game
In 4 minutes i can raid the armoury and kill half the server, i believe most nodes should be lowered to around this number. There's so many things you can branch into researching and its pretty bad for hippies pace. You can either go for general upgrade parts that benefit everyone or go nanites / robotics / mining / medical implants/  weapons   (lmao 10k per weapon node 3 minutes of waiting each).

I know you all hate the science power creep but the current system of waiting things out is really bad and the ways of speeding up research is really boring and requires other departments to go out of their way for your benefit. 
