### PR TITLE
Adminoradizine now gives blood back as well

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -53,6 +53,7 @@
 	M.SetParalyzed(0, FALSE)
 	M.SetImmobilized(0, FALSE)
 	M.silent = FALSE
+	M.blood_volume = BLOOD_VOLUME_NORMAL
 	M.dizziness = 0
 	M.disgust = 0
 	M.drowsyness = 0
@@ -616,7 +617,7 @@
 		M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
 		M.Unconscious(100)
 		M.Jitter(350)
-		
+
 	if(prob(33))
 		M.adjustToxLoss(4*REM, 0)
 		M.losebreath += 4


### PR DESCRIPTION
## Changelog
:cl:
fix: Adminoradizine now fixes your bleeding problems as well
/:cl:

adminoradizine didnt give back blood, which meant that if you removed the blood from a person afflicted, they were basically dead men walking/falling on their ass from oxyloss until next tick.
now vampires can also benefit from adminoradizine on their victms