### PR TITLE
makes holoparasites cost less

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -247,6 +247,7 @@
 /datum/uplink_item/dangerous/guardian
 	surplus = 5 //Up yours TGbalanceing
 	player_minimum = 0
+	cost = 12
 
 /datum/uplink_item/colab/romerol_kit
 	name = "Romerol"


### PR DESCRIPTION

## Changelog
:cl: zamolxius
tweak: tweaked holoparasite's TC price from 18 to 12, as you usually get retards anyways and it's too huge of a liability to cost 18 TC when you can get multiple syndicate bombs
/:cl:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
