### PR TITLE
Adds another hardsuit reaction message

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1,27 +1,39 @@
+#define WARN_COOLDOWN_TIMER 150
+
 /obj/item/clothing/head/helmet/space/hardsuit
-	var/next_warn_rad = 0
-	var/warn_rad_cooldown = 180
+	var/next_warn = 0
 
-/obj/item/clothing/suit/space/hardsuit
-	var/next_warn_acid = 0
-	var/warn_acid_cooldown = 150
-
-/obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
+/obj/item/clothing/head/helmet/space/hardsuit/rad_act(strength)
 	.=..()
-	if (prob(33) && rad_count > 500 && severity > 25)
-		if (next_warn_rad > world.time)
+	if (prob(33) && rad_count > 500 && strength > 25)
+		if (next_warn > world.time)
 			return
-		next_warn_rad = world.time + warn_rad_cooldown
+		next_warn = world.time + WARN_COOLDOWN_TIMER
 		display_visor_message("Radiation present, seek distance from source!")
 
 /obj/item/clothing/suit/space/hardsuit/acid_act(acidpwr, acid_volume)
 	.=..()
-	if (prob(33) && acidpwr >= 10)
-		if(helmet)
-			if(next_warn_acid > world.time)
-				return
-			next_warn_acid = world.time + warn_acid_cooldown
-			helmet.display_visor_message("Corrosive Chemical Detected!")
+	if (prob(33) && acidpwr >= 10 && helmet)
+		if(helmet.next_warn > world.time)
+			return
+		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
+		helmet.display_visor_message("Corrosive chemical detected!")
+
+/obj/item/clothing/suit/space/hardsuit/bullet_act(obj/item/projectile/P, def_zone)
+	.=..()
+	if (prob(P.damage*5) && P.damage_type == BRUTE && helmet)
+		if(helmet.next_warn > world.time)
+			return
+		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
+		helmet.display_visor_message("Ballistic trauma detected!")
+
+/obj/item/clothing/suit/space/hardsuit/tesla_act(power, tesla_flags, shocked_targets)
+	.=..()
+	if (prob(33) && power > 100000 && (tesla_flags & TESLA_OBJ_DAMAGE) && helmet)
+		if(helmet.next_warn > world.time)
+			return
+		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
+		helmet.display_visor_message("Electrical damage detected!")
 
 /obj/item/clothing/head/helmet/space/hardsuit/spurdosuit
 	name = "emergency spurdo suit helmet"
@@ -34,7 +46,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 50, "fire" = 80, "acid" = 70)
 	strip_delay = 130
 	actions_types = list()
-	
+
 /obj/item/clothing/head/helmet/space/hardsuit/spurdosuit/Initialize()
 	. = ..()
 	add_trait(TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)

--- a/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/hardsuit.dm
@@ -4,36 +4,34 @@
 	var/next_warn = 0
 
 /obj/item/clothing/head/helmet/space/hardsuit/rad_act(strength)
-	.=..()
-	if (prob(33) && rad_count > 500 && strength > 25)
+	. = ..()
+	if(prob(33) && rad_count > 500 && strength > 25)
 		if (next_warn > world.time)
 			return
 		next_warn = world.time + WARN_COOLDOWN_TIMER
 		display_visor_message("Radiation present, seek distance from source!")
 
 /obj/item/clothing/suit/space/hardsuit/acid_act(acidpwr, acid_volume)
-	.=..()
-	if (prob(33) && acidpwr >= 10 && helmet)
+	. = ..()
+	if(prob(33) && acidpwr >= 10 && helmet)
 		if(helmet.next_warn > world.time)
 			return
 		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
 		helmet.display_visor_message("Corrosive chemical detected!")
 
+/obj/item/clothing/suit/space/hardsuit/hit_reaction(mob/living/carbon/human/user, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	var/obj/item/projectile/P = hitby
+	bullet_act(P)
+	return ..()
+
 /obj/item/clothing/suit/space/hardsuit/bullet_act(obj/item/projectile/P, def_zone)
-	.=..()
-	if (prob(P.damage*5) && P.damage_type == BRUTE && helmet)
+	. = ..()
+	if(prob(P.damage*5) && P.damage_type == BRUTE && helmet)
 		if(helmet.next_warn > world.time)
 			return
 		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
 		helmet.display_visor_message("Ballistic trauma detected!")
 
-/obj/item/clothing/suit/space/hardsuit/tesla_act(power, tesla_flags, shocked_targets)
-	.=..()
-	if (prob(33) && power > 100000 && (tesla_flags & TESLA_OBJ_DAMAGE) && helmet)
-		if(helmet.next_warn > world.time)
-			return
-		helmet.next_warn = world.time + WARN_COOLDOWN_TIMER
-		helmet.display_visor_message("Electrical damage detected!")
 
 /obj/item/clothing/head/helmet/space/hardsuit/spurdosuit
 	name = "emergency spurdo suit helmet"


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
add: Hardsuits now react when being shot with a message.
tweak: Cleaned up hardsuit reaction messages and unified the cooldown timer for all messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This basically makes hardsuits have a reaction when getting shot. Like other messages, has a cooldown. I also took the time to cleanup up some of the code I wrote a long time ago and put all the messages under one single cool down. These messages don't happen that often and I don't want to confuse the user with a bunch of spam.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
It's a neat little hint that adds a bit of little bit more personality to hardsuits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
