### PR TITLE
Bumps fireball cost to 3

### DIFF
--- a/hippiestation/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/hippiestation/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -115,6 +115,9 @@
 		return FALSE
 	return (SSticker.mode.name != "ragin' mages" && !CONFIG_GET(flag/no_summon_events))
 
+/datum/spellbook_entry/fireball
+	cost = 3
+
 /obj/item/spellbook
 	persistence_replacement = /obj/item/book/granter/spell/random
 


### PR DESCRIPTION
:cl:
balance: Fireball now costs 3 spellpoints
/:cl:
**Why:** fireball is an OP insta-crit spell, that's why.