### PR TITLE
Stopped nanosuit from runtiming when using martial arts

### DIFF
--- a/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
+++ b/hippiestation/code/modules/clothing/spacesuits/nanosuit.dm
@@ -991,14 +991,14 @@
 			if(NS.mode == NANO_STRENGTH)
 				.=..(target, range*1.5, speed*2, thrower, spin, diagonals_first, callback)
 				return
-	.=..()
+	. = ..()
 
 /datum/martial_art/nanosuit/proc/on_attack_hand(mob/living/carbon/human/owner, atom/target, proximity)
 	if(proximity)
 		return target.attack_nanosuit(owner)
 
 /mob/living/carbon/human/UnarmedAttack(atom/A, proximity)
-	var/datum/martial_art/nanosuit/style = mind.has_martialart(MARTIALART_NANOSUIT)
+	var/datum/martial_art/nanosuit/style = mind?.has_martialart(MARTIALART_NANOSUIT)
 	if(style)
 		if(style.on_attack_hand(src, A, proximity))
 			return
@@ -1007,10 +1007,10 @@
 	..()
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M)
+	. = ..()
 	if(istype(M.wear_suit, /obj/item/clothing/suit/space/hardsuit/nano))
 		var/obj/item/clothing/suit/space/hardsuit/nano/NS = M.wear_suit
 		NS.kill_cloak()
-	..()
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/kill_cloak()
 	if(mode == NANO_CLOAK)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
fix: Nanosuit no longer runtimes when a mob attacks with an invalid mind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Kept seeing this in the server runtimes so I decided to fix it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Less runtimes the better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
