### PR TITLE
Fixes floorcluwne getting confused when mob changes body

### DIFF
--- a/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/floor_cluwne.dm
@@ -207,10 +207,11 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/On_Stage()
 	var/mob/living/carbon/human/H = current_victim
+	if(!H)
+		FindTarget()
+		return
 	switch(stage)
-
 		if(STAGE_HAUNT)
-
 			if(prob(5))
 				H.blur_eyes(1)
 
@@ -227,7 +228,6 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 					to_chat(H, "<span class='warning'>What threw that?</span>")
 
 		if(STAGE_SPOOK)
-
 			if(prob(4))
 				var/turf/T = get_turf(H)
 				T.handle_slip(H, 20)
@@ -268,7 +268,6 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 					addtimer(CALLBACK(src, /mob/living/simple_animal/hostile/floor_cluwne/.proc/Reset_View, screens), 10)
 
 		if(STAGE_TORMENT)
-
 			if(prob(5))
 				var/turf/T = get_turf(H)
 				T.handle_slip(H, 20)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
fix: Floor cluwnes no longer freak out when target mob changes bodies suddenly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This is mainly if a vamp suddenly changes into bat form and the floor cluwne no longer understands where it's target is, so we just make it look for a new one and stop it's stage from processing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
It's a very rare case, but this should prevent some bugs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
