### PR TITLE
Fixes our alternate slip sounds

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -232,18 +232,31 @@
 				return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
-			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+			// Hippie Start - custom sounds for slipping
+			var/slip_sound = 'sound/misc/slip.ogg'
+			if(prob(95))
+				if (O)
+					if (istype(O, /obj))
+						var/obj/Obj = O
+						if (Obj)
+							LAZYINITLIST(Obj.alternate_slip_sounds)
+							if (LAZYLEN(Obj.alternate_slip_sounds))
+								slip_sound = pick(Obj.alternate_slip_sounds)
+			else
+				slip_sound = 'hippiestation/sound/misc/oof.ogg'
+			playsound(C.loc, (slip_sound), 50, 1, -3)
+			// Hippie End
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
 		if(force_drop)
 			for(var/obj/item/I in C.held_items)
 				C.accident(I)
 
-		// hippie start -- Throw some hats if we slipped	
-		if (prob(33))	
-			var/list/L = list()	
-			LAZYADD(L, C.dir)	
-			C.throw_hats(1 + rand(1, 3), L)	
+		// hippie start -- Throw some hats if we slipped
+		if (prob(33))
+			var/list/L = list()
+			LAZYADD(L, C.dir)
+			C.throw_hats(1 + rand(1, 3), L)
 		// hippie end
 
 		var/olddir = C.dir

--- a/hippiestation/code/datums/outputs.dm
+++ b/hippiestation/code/datums/outputs.dm
@@ -28,5 +28,5 @@
 							   'hippiestation/sound/misc/hitsounds/cartoon_woink.ogg'=1)
 
 /datum/outputs/rubberducky
-	sounds = list('hippiestation/sound/misc/quack.ogg'=1)
+	sounds = list('hippiestation/sound/misc/quack.ogg')
 	text = "You hear a QUACK."

--- a/hippiestation/code/modules/clothing/shoe.dm
+++ b/hippiestation/code/modules/clothing/shoe.dm
@@ -9,7 +9,7 @@
 	slowdown = SHOES_SLOWDOWN+1
 	var/footstep = 1
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes/clown
-	
+
 /obj/item/clothing/shoes/hippie/cluwne/Initialize()
 	. = ..()
 	add_trait(TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
@@ -48,7 +48,14 @@
 
 /obj/item/clothing/shoes/buttshoes/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('hippiestation/sound/effects/fart.ogg'=1), 50)
+	AddComponent(/datum/component/squeak/buttshoes, 50)
+
+/datum/component/squeak/buttshoes
+	datum_outputs = list(/datum/outputs/buttshoes)
+
+/datum/outputs/buttshoes
+	sounds = list('hippiestation/sound/effects/fart.ogg')
+	text = "You hear a FART."
 
 /obj/item/clothing/shoes/jackboots/larp
 	name = "guard boots"

--- a/hippiestation/code/modules/clothing/under/jobs/civilian.dm
+++ b/hippiestation/code/modules/clothing/under/jobs/civilian.dm
@@ -1,10 +1,8 @@
 /obj/item/clothing/under/rank/clown/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak/clownsuit, 50)
+	var/datum/component/comp = GetComponent(/datum/component/squeak/bikehorn)
+	qdel(comp)
 
 /datum/component/squeak/clownsuit
 	datum_outputs = list(/datum/outputs/clownsuit)
-
-/obj/item/clothing/shoes/clown_shoes/Initialize()
-	. = ..()
-	AddComponent(/datum/component/squeak/clownstep, 50, ,0)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
fix: Alternate slips now work again. Banana peels are great once again.
fix: Also fixed some other squeak components + buttshoes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
