### PR TITLE
Vampires: Dead and not loathing it

### DIFF
--- a/hippiestation/code/datums/antagonists/vampire.dm
+++ b/hippiestation/code/datums/antagonists/vampire.dm
@@ -20,6 +20,7 @@
 
 	var/list/upgrade_tiers = list(
 		/obj/effect/proc_holder/spell/self/rejuvenate = 0,
+		/obj/effect/proc_holder/spell/self/revive = 0,
 		/obj/effect/proc_holder/spell/targeted/hypnotise = 0,
 		/datum/vampire_passive/vision = 175,
 		/obj/effect/proc_holder/spell/self/shapeshift = 175,
@@ -32,8 +33,7 @@
 		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/mistform = 500,
 		/datum/vampire_passive/full = 666,
 		/obj/effect/proc_holder/spell/self/summon_coat = 666,
-		/obj/effect/proc_holder/spell/targeted/vampirize = 700,
-		/obj/effect/proc_holder/spell/self/revive = 800)
+		/obj/effect/proc_holder/spell/targeted/vampirize = 666)
 
 /datum/antagonist/vampire/get_admin_commands()
 	. = ..()

--- a/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -336,12 +336,13 @@
 /obj/effect/proc_holder/spell/self/revive/proc/revive(mob/living/user)
 	user.revive(full_heal = TRUE)
 	user.visible_message("<span class='warning'>[user] reanimates from death!</span>", "<span class='notice'>We get back up.</span>")
+	playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
 	var/list/missing = user.get_missing_limbs()
 	if(missing.len)
-		playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
 		user.visible_message("<span class='warning'>Shadowy matter takes the place of [user]'s missing limbs as they reform!</span>")
 		user.regenerate_limbs(0, list(BODY_ZONE_HEAD))
 	user.regenerate_organs()
+	user.Paralyze(100)
 	
 /obj/effect/proc_holder/spell/self/summon_coat
 	name = "Summon Dracula Coat (5)"

--- a/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/hippiestation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -114,7 +114,7 @@
 /obj/effect/proc_holder/spell/targeted/hypnotise/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as he stares into [target]'s eyes</span>")
-		if(do_mob(user, target, 50))
+		if(do_mob(user, target, 20))
 			to_chat(user, "<span class='warning'>Your piercing gaze knocks out [target].</span>")
 			to_chat(target, "<span class='warning'>You find yourself unable to move and barely able to speak.</span>")
 			target.Paralyze(150)


### PR DESCRIPTION
## Changelog
:cl: NautilusViper
balance: Reviving is now an inherent vampire power available from the start. Who the FUCK thought that IMMORTAL VAMPIRES should have to UNLOCK being IMMORTAL?
balance: Vampirize is now unlocked at 666 total blood instead of 700. 666 is the ceiling, it's common sense.
balance: Hypnotize now takes two seconds to cast instead of five. Now it's not completely worthless!
/:cl:

## About The Pull Request

These were the big three uh oh spots that I've observed for vampires. Reviving should never have been locked behind 800 fucking blood, being able to come back from death is literally the one thing about vampires that's remained consistent throughout pop culture.
666 blood is the threshold where the in-game text itself tells you that you've hit your full potential, and that not being the case was misleading.
Hypnotize taking FIVE SECONDS of uninterrupted casting to stun someone is ass-bustingly hilarious, because someone thought it was actually a good idea.

## Why It's Good For The Game

Vampires are AIDS. Gameplay wise, they're supposed to replace changelings, which were a very heavily flawed but still infinitely more fun antag to play than vampires are. This is a meager attempt at making the reverberating 'SUCC' seem more like an audible opportunity for becoming the bat man than a knell of frustration.