### PR TITLE
[OLD HIPPIESTATION PORT] Reduces tourettes stun time from literally 20 seconds to 1 second

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -134,7 +134,7 @@
 
 /datum/mutation/human/tourettes/on_life()
 	if(prob(10 * GET_MUTATION_SYNCHRONIZER(src)) && owner.stat == CONSCIOUS && !owner.IsStun())
-		owner.Stun(200)
+		owner.Stun(10)	//Hippie - reduced tourettes stun from literally 20 seconds down to 1 second
 		switch(rand(1, 3))
 			if(1)
 				owner.emote("twitch")


### PR DESCRIPTION
Old hippie port

## Changelog
:cl:
balance: Tourettes now only stuns for 1 second compared to a whopping 20 seconds because it's literally no fun when it happens nearly every minute anyway
/:cl: