### PR TITLE
Adds Gatfruit as a botany only traitor item

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3194,6 +3194,7 @@
 #include "hippiestation\code\modules\hydroponics\grown\berries.dm"
 #include "hippiestation\code\modules\hydroponics\grown\cereals.dm"
 #include "hippiestation\code\modules\hydroponics\grown\flowers.dm"
+#include "hippiestation\code\modules\hydroponics\grown\gatfruit.dm"
 #include "hippiestation\code\modules\hydroponics\grown\grass_carpet.dm"
 #include "hippiestation\code\modules\hydroponics\grown\misc.dm"
 #include "hippiestation\code\modules\hydroponics\grown\nettle.dm"

--- a/hippiestation/code/modules/hydroponics/grown/gatfruit.dm
+++ b/hippiestation/code/modules/hydroponics/grown/gatfruit.dm
@@ -1,0 +1,2 @@
+/obj/item/seeds/gatfruit/syndi
+	maturation = 20

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -46,6 +46,13 @@
 	cost = 14
 	item = /obj/vehicle/ridden/lawnmower/emagged
 
+/datum/uplink_item/role_restricted/gatfruit
+	name = "Syndi Gatfruit"
+	desc = "An extrememly rare plant seed which grows .357 revolvers. Has been modified to mature twice as fast as normal Gatfruit"
+	restricted_roles = list("Botanist")
+	cost = 16
+	item = /obj/item/seeds/gatfruit/syndi
+
 /datum/uplink_item/dangerous/echainsaw
 	name = "Energy Chainsaw"
 	desc = "An incredibly deadly modified chainsaw with plasma-based energy blades instead of metal and a slick black-and-red finish. While it rips apart matter with extreme efficiency, it is heavy, large, and monstrously loud."

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -50,7 +50,7 @@
 	name = "Syndi Gatfruit"
 	desc = "An extrememly rare plant seed which grows .357 revolvers. Has been modified to mature twice as fast as normal Gatfruit"
 	restricted_roles = list("Botanist")
-	cost = 20
+	cost = 18
 	item = /obj/item/seeds/gatfruit/syndi
 
 /datum/uplink_item/dangerous/echainsaw

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -50,7 +50,7 @@
 	name = "Syndi Gatfruit"
 	desc = "An extrememly rare plant seed which grows .357 revolvers. Has been modified to mature twice as fast as normal Gatfruit"
 	restricted_roles = list("Botanist")
-	cost = 16
+	cost = 20
 	item = /obj/item/seeds/gatfruit/syndi
 
 /datum/uplink_item/dangerous/echainsaw


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
add: Traitor botanists can now buy Gatfruit
/:cl:

## About The Pull Request

Adds Gatfruit to the uplink for traitor botanists. it costs 20TC and its a plant that grows .357 revolvers
matures extremely slowly, but still twice as fast as xenobio gatfruit
roughly 8-9 minutes until first harvest on a private server. 

## Why It's Good For The Game

More options for a traitor botanist