### PR TITLE
Makes gibs less OP

### DIFF
--- a/hippiestation/code/modules/mob/living/simple_animal/hostile/sentientgibs.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/hostile/sentientgibs.dm
@@ -21,9 +21,9 @@
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	pass_flags = LETPASSTHROW
-	move_to_delay = 1
+	move_to_delay = 2
 	rapid_melee = 2
-	speed = 1
+	speed = 1.5
 	var/in_vent = FALSE
 	var/min_next_vent = 0
 	var/obj/machinery/atmospherics/components/unary/vent_pump/entry_vent
@@ -55,7 +55,7 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/lunch = target
-		if(lunch && prob(30))
+		if(lunch && prob(25))
 			if(!EatLunch(lunch) && (health < maxHealth * 0.25) && prob(33))//Don't want to see this message all the time.
 				visible_message("<span class='warning'>[src] flails in exasperation!</span>", \
 						"<span class='danger'>Failing to eat angers you!</span>")
@@ -114,7 +114,7 @@
 			addtimer(CALLBACK(src, .proc/exit_vents), travel_time) //come out at exit vent in 2 to 20 seconds
 
 
-		if(world.time > min_next_vent && !entry_vent && !in_vent && prob(GIB_VENT_CHANCE) && !target) //small chance to go into a vent
+		if(world.time > min_next_vent && prob(GIB_VENT_CHANCE) && !entry_vent && !in_vent && !target) //small chance to go into a vent
 			for(var/obj/machinery/atmospherics/components/unary/vent_pump/v in view(7,src))
 				if(!v.welded)
 					entry_vent = v
@@ -137,4 +137,4 @@
 		new_area.Entered(src)
 	visible_message("<span class='notice'>[src] climbs out of the ventilation ducts!</span>")
 	emote("scream")
-	min_next_vent = world.time + 900 //90 seconds between ventcrawls
+	min_next_vent = world.time + 450 //45 seconds between ventcrawls


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
tweak: Gibs are no longer as fast as players
tweak: Gibs eat slightly slower
tweak: Gibs vent search time is lowered to make them more interesting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
I don't even feel like this should be under a rebalance as it was pretty much an unfair adminbus mob that would just kill the entire crew in a matter of minutes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because adminbus is fun but shouldn't be unfair.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
