### PR TITLE
Unfucks the Syndicate Shuttle turrets

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2937,6 +2937,7 @@
 #include "hippiestation\code\game\machinery\cell_charger.dm"
 #include "hippiestation\code\game\machinery\cryo.dm"
 #include "hippiestation\code\game\machinery\doppler_array.dm"
+#include "hippiestation\code\game\machinery\porta_turret\portable_turret.dm"
 #include "hippiestation\code\game\machinery\reagent_forge.dm"
 #include "hippiestation\code\game\machinery\reagent_material_manipulator.dm"
 #include "hippiestation\code\game\machinery\reagent_sheet.dm"

--- a/hippiestation/code/game/machinery/porta_turret/portable_turret.dm
+++ b/hippiestation/code/game/machinery/porta_turret/portable_turret.dm
@@ -1,0 +1,3 @@
+/obj/machinery/porta_turret/syndicate/shuttle
+	stun_projectile = /obj/item/projectile/bullet/syndicate_turret
+	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret


### PR DESCRIPTION
## Changelog
:cl: NautilusViper
tweak: Syndicate Infiltrator turrets no longer wallbang and stunlock everybody who comes into range.
/:cl:

## About The Pull Request

The Infiltrator was using heavy caliber penetrator rounds for some godawful reason and this makes that not so.
## Why It's Good For The Game

Literally everybody fucking hated this, the infiltrator became infinitely more dangerous than the actual nukies themselves, especially when parked at escapes so anybody who runs towards departures gets gatted to death from something they could never see coming.