### PR TITLE
Lube can now be put into bars

### DIFF
--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -24,7 +24,6 @@ GLOBAL_LIST_INIT(no_reagent_statechange_typecache, typecacheof(list(
 GLOBAL_LIST_INIT(statechange_reagent_blacklist, typecacheof(list(
 	/datum/reagent/water,
 	/datum/reagent/toxin/bleach,
-	/datum/reagent/lube,
 	/datum/reagent/consumable/condensedcapsaicin,
 	/datum/reagent/space_cleaner,
 	/datum/reagent/smoke_powder,


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: Space lube can now be put into bars again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request

Lube was blacklisted from reagent state changes. As a result, it couldn't be solidified for use in the forge and this PR aims to fix that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
You can now use the unique lube reagent traits. Fixes #8354 .
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
