### PR TITLE
Buffs locomotion circuit to be not utterly useless

### DIFF
--- a/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -143,8 +143,8 @@
 	being held, or anchored in some way. It should be noted that the ability to move is dependant on the type of assembly that this circuit inhabits; only drone assemblies can move."
 	w_class = WEIGHT_CLASS_SMALL
 	complexity = 10
-	cooldown_per_use = 1 SECONDS
-	ext_cooldown = 1 SECONDS
+	cooldown_per_use = 0.5 SECONDS
+	ext_cooldown = 0.5 SECONDS
 	inputs = list("direction" = IC_PINTYPE_DIR)
 	outputs = list("obstacle" = IC_PINTYPE_REF)
 	activators = list("step towards dir" = IC_PINTYPE_PULSE_IN,"on step"=IC_PINTYPE_PULSE_OUT,"blocked"=IC_PINTYPE_PULSE_OUT)


### PR DESCRIPTION
## Changelog
:cl:

balance: Locomotion circuit is now a bit slower than a walking human

/:cl:


## Why It's Good For The Game

0.5 second will let a fully healed and fed player outrun a bot in a straight line,
gaining maybe 1 tile of distance every 4 tiles traveled when walking, so running you get away from it real fast.

I really want to bring back dead players into the game by placing them into mmi / pai tank bots and let them do stuff borgs can't do, but SOMEONE had to go and suicide bomb people all the goddamn time and get it nerfed into the ground

video for your viewing pleasure - 
https://streamable.com/524c6

