### PR TITLE
Update package-lock.json

### DIFF
--- a/tgui/package-lock.json
+++ b/tgui/package-lock.json
@@ -4311,8 +4311,8 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
         "argparse": "^1.0.7",
@@ -6993,7 +6993,7 @@
         "coa": "~1.0.1",
         "colors": "~1.1.2",
         "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
+        "js-yaml": "~3.13.1",
         "mkdirp": "~0.5.1",
         "sax": "~1.2.1",
         "whet.extend": "~0.9.9"


### PR DESCRIPTION
Js-yaml prior to 3.13.1 are vulnerable to Code Injection. The load() function may execute arbitrary code injected through a malicious YAML file.