### PR TITLE
Justice for Codreanu's NCDL Disarms (or the PR that removes disarm RNG)

### DIFF
--- a/hippiestation/code/modules/mob/living/carbon/human/species.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species.dm
@@ -41,7 +41,7 @@
 		// does the vars n stuff
 		target.times_disarmed += 1
 		target.disarm_cooldown = world.time + 20
-		if(world.time >= target.disarm_cooldown || target.stat || target.IsUnconscious())
+		if(world.time >= target.disarm_cooldown || target.stat || target.IsUnconscious() || target.IsParalyzed())
 			target.times_disarmed = 0
 			target.disarm_cooldown = 0
 

--- a/hippiestation/code/modules/mob/living/carbon/human/species.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species.dm
@@ -1,3 +1,7 @@
+/mob/living/carbon/human
+	var/times_disarmed = 0
+	var/disarm_cooldown = 0
+
 /datum/species
 	var/hurt_sound_cd = 0
 	attack_sound = 'hippiestation/sound/weapons/punch1.ogg'
@@ -20,6 +24,7 @@
 	hurt_sound_cd = world.time + 30
 	addtimer(CALLBACK(src, .proc/play_hurt_sound, H), 5)
 
+
 /datum/species/proc/play_hurt_sound(mob/living/carbon/human/H)
 	// The sound frequency is set to 11,025 and I want to vary it by 25% both ways
 	playsound(H, "male_hurt", 75, 1, frequency = rand(11025*0.75, 11025*1.25))
@@ -33,38 +38,48 @@
 	else
 		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
 
+		// does the vars n stuff
+		target.times_disarmed += 1
+		target.disarm_cooldown = world.time + 20
+		if(world.time >= target.disarm_cooldown || target.stat || target.IsUnconscious())
+			target.times_disarmed = 0
+			target.disarm_cooldown = 0
+
 		if(target.w_uniform)
 			target.w_uniform.add_fingerprint(user)
 		var/randomized_zone = ran_zone(user.zone_selected)
 		SEND_SIGNAL(target, COMSIG_HUMAN_DISARM_HIT, user, user.zone_selected)
 		var/obj/item/bodypart/affecting = target.get_bodypart(randomized_zone)
-		var/randn = rand(1, 100)
-		if(randn <= 25)
+
+		// The actual disarm part
+
+		if(target.times_disarmed >= 3)
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			target.visible_message("<span class='danger'>[user] has pushed [target]!</span>",
 				"<span class='userdanger'>[user] has pushed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
-			target.apply_effect(40, EFFECT_PARALYZE, target.run_armor_check(affecting, "melee", "Your armor prevents your fall!", "Your armor softens your fall!"))
+			target.apply_effect(20, EFFECT_PARALYZE, target.run_armor_check(affecting, "melee", "Your armor prevents your fall!", "Your armor softens your fall!"))
 			target.forcesay(GLOB.hit_appends)
+			target.times_disarmed = 0
+			target.disarm_cooldown = 0
 			log_combat(user, target, "pushed over")
 			return
 
-		if(randn <= 60)
+		if(target.times_disarmed == 2)
 			var/obj/item/I = null
-			if(target.pulling)
-				target.visible_message("<span class='warning'>[user] has broken [target]'s grip on [target.pulling]!</span>")
-				target.stop_pulling()
+			I = target.get_active_held_item()
+			if(target.dropItemToGround(I))
+				target.visible_message("<span class='danger'>[user] has disarmed [target]!</span>", \
+					"<span class='userdanger'>[user] has disarmed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
 			else
-				I = target.get_active_held_item()
-				if(target.dropItemToGround(I))
-					target.visible_message("<span class='danger'>[user] has disarmed [target]!</span>", \
-						"<span class='userdanger'>[user] has disarmed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
-				else
-					I = null
+				I = null
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			log_combat(user, target, "disarmed", "[I ? " removing \the [I]" : ""]")
 			return
-
-
+		if(target.pulling)
+			playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+			target.visible_message("<span class='warning'>[user] has broken [target]'s grip on [target.pulling]!</span>")
+			target.stop_pulling()
+			return
 		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>", \
 						"<span class='userdanger'>[user] attempted to disarm [target]!</span>", null, COMBAT_MESSAGE_RANGE)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: Manly Dwarf, Lunaman22
balance: Disarm is no longer RNG.
balance: Disarm now works off of a "three strike" system, if you would. One disarm does nothing, two disarms will drop your weapon, three will guaranteed push you. This means if two people are disarming you, you'll likely go down rather fast. The strikes reset two seconds after the last disarm you were hit by.
tweak: You can no longer chain disarm push someone, attempting to disarm someone who is already down will just result in you failing to disarm them and will not count as a strike.
tweak: Disarm push stun time is halved (2 seconds, down from 4).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Read the changelog. It's explained there.

![fatty](https://user-images.githubusercontent.com/33744849/60309760-722a8000-991d-11e9-9f55-c71278fab0c1.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Disarm RNG sucks and no one likes it. Few people like the /tg/station fix either. So, this was a designer's idea. I liked it so much, I immediately coded it. Wasn't hard, to be fair.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The only argument against this PR is its implementation. Nobody thinks disarm RNG is good.
Two seconds is a surprisingly long time for the disarm clock from my testing, especially because the clock resets every time you get hit by another disarm.
As for the disarm stun, a lot of people complained about how four seconds is long enough to absolutely ruin your day. Now it'll prevent you from getting your weapon back, possibly a hit or two, but not enough to outright end you.

Does this fix disarming eswords? Kind of. You won't die immediately to a single disarm any more, but at the same time you're still at a disadvantage and have to rely on RNG blocks to not get your sword disarmed, and when that happens you're one away from a push. We should move blocks to a strike system as well.

One disarm does nothing, two disarms knocks your item out of your hand, three pushes you. An argument could be made for four to push, but I think that's dumb considering push time was also halved. They don't get that long to really kill you.