### PR TITLE
Remove gauss rifle from science

### DIFF
--- a/hippiestation/code/modules/research/designs/weapon_designs.dm
+++ b/hippiestation/code/modules/research/designs/weapon_designs.dm
@@ -1,3 +1,4 @@
+/*
 /datum/design/gauss_rifle
 	name = "Gauss Rifle"
 	desc = "A seriously powerful rifle with an electromagnetic acceleration core, capable of blowing limbs off."
@@ -7,3 +8,4 @@
 	build_path = /obj/item/gun/energy/gauss
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+*/

--- a/hippiestation/code/modules/research/techweb/all_nodes.dm
+++ b/hippiestation/code/modules/research/techweb/all_nodes.dm
@@ -57,6 +57,7 @@
 	design_ids = list()
 
 ///GAUSS RIFLE///
+/*
 /datum/techweb_node/electromagnetic_weapons
 	id = "gauss_rifle"
 	display_name = "Electromagnetic Weaponry(Gauss Rifle MK1)"
@@ -65,3 +66,4 @@
 	design_ids = list("gaussrifle")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
+*/


### PR DESCRIPTION
## Changelog Gandalf2k15
:cl:
del: Removed gauss rifle from SCI 
/:cl:

## About The Pull Request
Simply removes the gauss rifle from SCI so it can be nerfed at some point, making it an admin bus weapon

## Why It's Good For The Game
I don't know if it is or not.

