### PR TITLE
No more printable gauss rifle

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3510,7 +3510,6 @@
 #include "hippiestation\code\modules\research\designs\nanite_designs.dm"
 #include "hippiestation\code\modules\research\designs\power_designs.dm"
 #include "hippiestation\code\modules\research\designs\reagent_forge_designs.dm"
-#include "hippiestation\code\modules\research\designs\weapon_designs.dm"
 #include "hippiestation\code\modules\research\nanites\nanite_programs.dm"
 #include "hippiestation\code\modules\research\nanites\nanite_programs\sensor.dm"
 #include "hippiestation\code\modules\research\techweb\_techweb.dm"

--- a/hippiestation/code/modules/research/designs/weapon_designs.dm
+++ b/hippiestation/code/modules/research/designs/weapon_designs.dm
@@ -1,9 +1,0 @@
-/datum/design/gauss_rifle
-	name = "Gauss Rifle"
-	desc = "A seriously powerful rifle with an electromagnetic acceleration core, capable of blowing limbs off."
-	id = "gaussrifle"
-	build_type = PROTOLATHE
-	materials = list(MAT_SILVER = 8000, MAT_URANIUM = 8000, MAT_GLASS = 12000, MAT_METAL = 12000, MAT_GOLD = 10000)
-	build_path = /obj/item/gun/energy/gauss
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/hippiestation/code/modules/research/techweb/all_nodes.dm
+++ b/hippiestation/code/modules/research/techweb/all_nodes.dm
@@ -55,13 +55,3 @@
 
 /datum/techweb_node/adv_beam_weapons
 	design_ids = list()
-
-///GAUSS RIFLE///
-/datum/techweb_node/electromagnetic_weapons
-	id = "gauss_rifle"
-	display_name = "Electromagnetic Weaponry(Gauss Rifle MK1)"
-	description = "The gauss rifle, electromagnetic weaponry at its finest. You won't regret researching this."
-	prereq_ids = list("adv_weaponry", "emp_adv")
-	design_ids = list("gaussrifle")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	export_price = 5000


### PR DESCRIPTION
:cl:
del: The gauss rifle is no longer printable. Bye bye, near-instakill rifles.
/:cl:

actually deletes it, rather than commenting it out, unlike #11869
