### PR TITLE
Contender Fixes

### DIFF
--- a/hippiestation/code/modules/projectiles/ammunition/magazines.dm
+++ b/hippiestation/code/modules/projectiles/ammunition/magazines.dm
@@ -4,5 +4,6 @@
 	name = "contender internal magazine"
 	caliber = "all"
 	ammo_type = /obj/item/ammo_casing
+	start_empty = TRUE
 	max_ammo = 2
 	multiload = 0 // thou must load every shot individually

--- a/hippiestation/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/hippiestation/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -13,5 +13,9 @@
 	obj_flags = UNIQUE_RENAME
 	unique_reskin = 0
 
+/obj/item/gun/ballistic/shotgun/doublebarrel/contender/sawoff(mob/user)
+	to_chat(user, "<span class='warning'>Why would you mutilate this work of art?</span>")
+	return
+
 /obj/item/gun/ballistic/shotgun
 	icon = 'hippiestation/icons/obj/guns/projectile.dmi'


### PR DESCRIPTION
## Changelog
:cl:
fix: You no longer can make invisible sawn-off contenders.
fix: Contenders now get initialized with an empty internal magazine.
/:cl:

## About The Pull Request
It was possible to make sawn-off contenders due to contenders being children of double barrel shotguns. To avoid this, I made a redefinition of the sawoff proc for contenders, since it seemed like a fairly simple option in this case.
If there happens to be a better way for handling this, I would appreciate knowing, since I'm not fully convinced with this being the best way to do it.

Contenders had their internal magazine initialized with empty ammo casings, because start_empty wasn't set to TRUE to stop the Initialize proc from loading the magazine with these ammo casings. Fixes #11826 (since from testing and the discussion of the issue, it seemed like the issue was only limited to contenders with the problem being these empty ammo casings in its internal magazine when it first gets created).


## Why It's Good For The Game
Having the internal magazine for this gun initialize empty seemed to be what was wanted and making sawn-off contenders with no proper icon_state doesn't look like intended behaviour.
