### PR TITLE
CQC Relearning

### DIFF
--- a/hippiestation/code/datums/martial/cqc.dm
+++ b/hippiestation/code/datums/martial/cqc.dm
@@ -19,12 +19,13 @@
 
 /datum/martial_art/cqc/proc/drop_restraining()
 	restraining = 0
-	
+
 /datum/martial_art/cqc/proc/can_cook(mob/living/carbon/human/A)
 	if(just_a_cook)
 		var/A_area = get_area(A)
 		if (!is_type_in_typecache(A_area, areas_under_siege))
 			return FALSE
+	return TRUE
 
 /datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	A.hud_used.combo_object.update_icon(streak, 60)


### PR DESCRIPTION
## Changelog
:cl:
fix: Chefs can now use CQC in their limited area again.
fix: Anyone who has learnt CQC can use it again.
/:cl:

## About The Pull Request
As the can_cook proc never returned TRUE when someone could cook with CQC, you would never be able to use the martial art, because the proc would return null if it didn't return FALSE.
Fixes #11852.
Fixes #11751.

## Why It's Good For The Game
The martial art should now work again, since the problem seemed to only be that the can_cook proc always returned a value that wouldn't let someone use their CQC when they should be able to.
