### PR TITLE
Gives nukie reinforcements 25 TC

### DIFF
--- a/hippiestation/code/game/gamemodes/nuclear/nuclear.dm
+++ b/hippiestation/code/game/gamemodes/nuclear/nuclear.dm
@@ -1,3 +1,6 @@
 /datum/outfit/syndicate
 	r_pocket = /obj/item/kitchen/knife/combat
 	backpack_contents = list(/obj/item/storage/box/syndie=1)
+
+/datum/outfit/syndicate/no_crystals
+	tc = 25


### PR DESCRIPTION
prevents stupid 0 IQ nukie teams from botching themselves because they died 5 minutes in and all the reinforcement has is a pistol and 6 pistol mags.