### PR TITLE
makes only one traitor per "create traitors" button press

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -66,15 +66,9 @@
 					candidates += applicant
 
 	if(candidates.len)
-		var/numTraitors = min(candidates.len, 3)
-
-		for(var/i = 0, i<numTraitors, i++)
-			H = pick(candidates)
-			H.mind.make_Traitor()
-			candidates.Remove(H)
-
+		H = pick(candidates)
+		H.mind.make_Traitor()
 		return 1
-
 
 	return 0
 


### PR DESCRIPTION
## Changelog
:cl: mideanon
tweak: only a single traitor is now made per "create traitors" button press instead of 3
/:cl:

## About The Pull Request
removes a few lines

## Why It's Good 
now i can randomize a single traitor instead of having to choose a person randomly
