### PR TITLE
makes chem puddles not appear where you draw

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -402,9 +402,11 @@
 	var/fraction = min(1, . / reagents.maximum_volume)
 	if(affected_turfs.len)
 		fraction /= affected_turfs.len
+	/* hippie start -- making chem puddle not appear where you draw
 	for(var/t in affected_turfs)
 		reagents.reaction(t, TOUCH, fraction * volume_multiplier)
 		reagents.trans_to(t, ., volume_multiplier, transfered_by = user)
+	hippie end */
 	check_empty(user)
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -399,10 +399,10 @@
 		return
 	. = charges_used
 	// hippie end
+	/* hippie start -- making chem puddle not appear where you draw
 	var/fraction = min(1, . / reagents.maximum_volume)
 	if(affected_turfs.len)
 		fraction /= affected_turfs.len
-	/* hippie start -- making chem puddle not appear where you draw
 	for(var/t in affected_turfs)
 		reagents.reaction(t, TOUCH, fraction * volume_multiplier)
 		reagents.trans_to(t, ., volume_multiplier, transfered_by = user)


### PR DESCRIPTION
## Changelog
:cl:
tweak: crayons and spraycans dont make chem puddles anymore
/:cl:

## About The Pull Request

makes chem puddles not appear where you draw

## Why It's Good For The Game

it made precise drawing with spraycans/crayons harder and a pain, and made wherever you drew a toxic hallway that poisons you with fuel and ethanol if it was made with a spraycan or a hallway that made you fat if it was a crayon
now it doesnt