### PR TITLE
Fixes a mousetrap exploit involving click+dragging your backpack (or opening it) while stunned to instantly annihilate everyone around you

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -116,13 +116,15 @@
 	..()
 
 
-/obj/item/assembly/mousetrap/on_found(mob/finder)
+/obj/item/assembly/mousetrap/on_found(mob/living/finder) // hippie -- consider this whole section edited
 	if(armed)
-		if(finder && !finder.incapacitated && !finder.handcuffed)
-			finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking their fingers.</span>", \
-							   "<span class='warning'>You accidentally trigger [src]!</span>")
-			triggered(finder, (finder.active_hand_index % 2 == 0) ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND)
-			return TRUE	//end the search!
+		if(finder && ishuman(finder))
+			var/mob/living/carbon/human/H = finder
+			if(!H.handcuffed && !H.incapacitated())
+				finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking their fingers.</span>", \
+								   "<span class='warning'>You accidentally trigger [src]!</span>")
+				triggered(finder, (finder.active_hand_index % 2 == 0) ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND)
+				return TRUE	//end the search!
 		else
 			visible_message("<span class='warning'>[src] snaps shut!</span>")
 			triggered(loc)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -118,7 +118,7 @@
 
 /obj/item/assembly/mousetrap/on_found(mob/finder)
 	if(armed)
-		if(finder)
+		if(finder && !finder.incapacitated && !finder.handcuffed)
 			finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking their fingers.</span>", \
 							   "<span class='warning'>You accidentally trigger [src]!</span>")
 			triggered(finder, (finder.active_hand_index % 2 == 0) ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -63,6 +63,7 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 	armed = FALSE
 	update_icon()
+	sleep(1.5) // hippie -- adds a small enough delay to prevent mousetrap signalers from being better voice analyzers
 	pulse(FALSE)
 
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: Manly Dwarf
fix: Fixed an exploit related to mousetrap bombs exploding despite the user being stunned or handcuffed.
balance: Also slowed down the explosion a bit so they aren't outright better than voice analyzers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
steamp0rt in shambles
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
scientists in shambles
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
destroy science when