### PR TITLE
Dynamic stuff

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -14,8 +14,8 @@
 GLOBAL_VAR_INIT(dynamic_latejoin_delay_min, (5 MINUTES))
 GLOBAL_VAR_INIT(dynamic_latejoin_delay_max, (25 MINUTES))
 
-GLOBAL_VAR_INIT(dynamic_midround_delay_min, (15 MINUTES))
-GLOBAL_VAR_INIT(dynamic_midround_delay_max, (35 MINUTES))
+GLOBAL_VAR_INIT(dynamic_midround_delay_min, (10 MINUTES)) // hippie -- change midround injection time
+GLOBAL_VAR_INIT(dynamic_midround_delay_max, (25 MINUTES)) // hippie -- change midround injection time
 
 // Are HIGHLANDER_RULESETs allowed to stack?
 GLOBAL_VAR_INIT(dynamic_no_stacking, TRUE)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2945,6 +2945,7 @@
 #include "hippiestation\code\game\gamemodes\objective_items.dm"
 #include "hippiestation\code\game\gamemodes\clock_cult\clock_scriptures\neovgre.dm"
 #include "hippiestation\code\game\gamemodes\cult\needed_players.dm"
+#include "hippiestation\code\game\gamemodes\dynamic\dynamic_rulesets_midround.dm"
 #include "hippiestation\code\game\gamemodes\dynamic\dynamic_rulesets_roundstart.dm"
 #include "hippiestation\code\game\gamemodes\gangs\dominator.dm"
 #include "hippiestation\code\game\gamemodes\gangs\gang_items.dm"

--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -1,0 +1,24 @@
+/datum/dynamic_ruleset/midround/from_ghosts/abductor
+	name = "Abductors"
+	antag_flag = ROLE_ABDUCTOR
+	required_candidates = 2
+	weight = 5
+	cost = 15
+	high_population_requirement = 10
+	var/datum/team/abductor_team/team
+
+/datum/dynamic_ruleset/midround/from_ghosts/abductor/ready(forced = FALSE)
+	if (required_candidates > (dead_players.len + list_observers.len))
+		return FALSE
+	team = new
+	if(team.team_number > ABDUCTOR_MAX_TEAMS)
+		return FALSE
+	return ..()
+
+/datum/dynamic_ruleset/midround/from_ghosts/abductor/finish_setup(mob/new_character, index)
+	new_character.mind.special_role = ROLE_ABDUCTOR
+	new_character.mind.assigned_role = ROLE_ABDUCTOR
+	if (index == 1)
+		new_character.mind.add_antag_datum(/datum/antagonist/abductor/scientist, team)
+	else
+		new_character.mind.add_antag_datum(/datum/antagonist/abductor/agent, team)


### PR DESCRIPTION

:cl:
add: Abductors can now be a midround antagonist in dynamic.
tweak: Changed the range for dynamic midround injection to 10-25 minutes, from 15-35 minutes.
/:cl:


