### PR TITLE
Nerfs science a little bit and other adjustments

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -25350,7 +25350,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "buv" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/machinery/rnd/production/circuit_imprinter/department,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "buw" = (

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -451,7 +451,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "abt" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/research)
 "abu" = (
@@ -1836,7 +1836,7 @@
 	id = "tox1";
 	name = "Toxins Lockdown Door"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
 "aen" = (
@@ -31525,6 +31525,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bMd" = (
@@ -32011,7 +32012,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bNw" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	light_color = "#966432";
+	light_range = 1.4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "bNx" = (
@@ -32435,7 +32439,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "bOV" = (
-/obj/machinery/vending/snack/random,
+/obj/machinery/vending/snack/random{
+	light_color = "#6496FA";
+	light_range = 1.4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "bOW" = (
@@ -32894,6 +32901,9 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -32959,6 +32969,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bQs" = (
@@ -33288,9 +33301,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33302,9 +33312,6 @@
 /area/science/research)
 "bRs" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33313,6 +33320,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bRu" = (
@@ -33386,7 +33394,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/camera{
-	c_tag = "Interrogation room";
+	c_tag = "Toxins Lab - Storage";
 	dir = 8;
 	network = list("interrogation")
 	},
@@ -33727,7 +33735,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bSS" = (
 /obj/machinery/mass_driver{
@@ -34183,7 +34194,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bUj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34907,14 +34921,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bWs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Input to Waste"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -34926,7 +34938,9 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bWu" = (
 /turf/closed/wall/r_wall,
@@ -35443,13 +35457,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthWest 2";
-	dir = 8;
-	network = list("MiniSat");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/closed/wall,
 /area/science/mixing)
 "bXE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -35829,6 +35837,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bYV" = (
@@ -37211,6 +37220,9 @@
 /area/science/research)
 "cdv" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdx" = (
@@ -37460,15 +37472,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cex" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
 /area/science/misc_lab)
 "ceD" = (
 /obj/structure/chair{
@@ -37795,15 +37804,13 @@
 /area/science/xenobiology)
 "cfy" = (
 /obj/structure/table,
-/obj/machinery/chem/centrifuge{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
 /area/science/misc_lab)
 "cfA" = (
@@ -37851,9 +37858,6 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "cfF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Test Chamber";
 	req_access_txt = "47"
@@ -37864,17 +37868,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"cfG" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/misc_lab)
 "cfH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/science/misc_lab)
 "cfK" = (
 /obj/structure/chair{
@@ -38202,9 +38203,6 @@
 /area/science/xenobiology)
 "cgE" = (
 /obj/structure/table,
-/obj/machinery/chem/pressure{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -39412,7 +39410,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/science/misc_lab)
 "ckc" = (
 /obj/structure/cable,
@@ -39723,7 +39723,6 @@
 	dir = 1;
 	network = list("test","rd")
 	},
-/obj/machinery/light,
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "clg" = (
@@ -40805,7 +40804,6 @@
 	name = "Air Supply Maintenance";
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
@@ -42393,11 +42391,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	dir = 4;
-	network = list("turbine")
-	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cuh" = (
@@ -43393,6 +43386,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/sign/warning/enginesafety{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cwM" = (
@@ -43672,7 +43668,6 @@
 	pixel_x = 8;
 	pixel_y = 24
 	},
-/obj/machinery/camera/emp_proof,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cxU" = (
@@ -48449,7 +48444,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Vault";
+	c_tag = "MiniSat AI Core Monitor";
 	dir = 1;
 	network = list("SS13")
 	},
@@ -49410,6 +49405,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"dGe" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/engine,
+/area/science/misc_lab)
 "dGM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -49431,14 +49430,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dJa" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "dJC" = (
@@ -49570,6 +49566,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49833,6 +49832,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "esQ" = (
@@ -50160,9 +50160,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/port_engineering)
 "eYO" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
 "eYX" = (
 /obj/structure/cable,
@@ -50752,6 +50751,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"fWp" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "fWN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -50794,12 +50797,14 @@
 /area/maintenance/aft)
 "fZA" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -50943,7 +50948,7 @@
 /area/science/misc_lab)
 "glI" = (
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Starboard - Art Storage";
+	c_tag = "Toxins Lab - West";
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -50976,21 +50981,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "gmN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/misc_lab)
 "gnp" = (
 /obj/structure/table/glass,
@@ -51136,6 +51134,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gzS" = (
+/obj/machinery/camera{
+	c_tag = "Toxins Lab - East";
+	dir = 2;
+	network = list("MiniSat");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "gBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -51146,7 +51153,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/science/misc_lab)
 "gBw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51767,6 +51776,12 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"hLA" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/engine,
+/area/science/misc_lab)
 "hLG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -51835,17 +51850,15 @@
 	})
 "hPx" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Kill Chamber";
+	c_tag = "Toxins Lab - South";
 	dir = 1;
 	network = list("ss13","rd","xeno");
 	start_active = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "hPR" = (
@@ -52136,13 +52149,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"irr" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
 "itf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -52484,6 +52490,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iUU" = (
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "iVd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/dark,
@@ -53356,6 +53365,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"knC" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "koe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53906,9 +53926,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
 "lpc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -53917,7 +53934,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "lpx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -54036,6 +54055,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lAB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/science/mixing)
 "lAF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54297,7 +54322,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "lQQ" = (
-/obj/machinery/camera,
+/obj/machinery/camera{
+	c_tag = "Toxins Lab - Maintenance"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "lRe" = (
@@ -56007,6 +56034,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oNN" = (
+/obj/machinery/light/built{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/misc_lab)
 "oPf" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet,
@@ -56209,7 +56242,9 @@
 /area/maintenance/starboard/aft)
 "peX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/camera,
+/obj/machinery/camera{
+	c_tag = "Toxins Lab - North"
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -56224,6 +56259,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"pfa" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Input to Waste"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "pfC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -56233,10 +56278,8 @@
 	},
 /area/maintenance/aft)
 "pge" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 1
-	},
 /obj/machinery/light,
+/obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "pgj" = (
@@ -56988,6 +57031,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"qvn" = (
+/obj/structure/closet/bombcloset,
+/obj/structure/sign/warning/explosives{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "qvq" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -57075,6 +57125,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qHi" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "qHJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -57748,13 +57803,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"rXP" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "rYw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58019,14 +58067,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sAs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Output to Waste"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "sAC" = (
 /obj/effect/spawner/structure/window,
@@ -58858,10 +58902,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tPB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/sign/plaques/kiddie/perfect_drone{
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "tPT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59068,6 +59113,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uin" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Output to Waste"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "uio" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -59110,14 +59165,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "umV" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	on = 1;
-	target_temperature = 80
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/science/mixing)
 "uop" = (
 /obj/structure/cable,
@@ -59266,6 +59317,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"uAm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "uBD" = (
 /obj/structure/cable,
 /obj/structure/grille,
@@ -59518,7 +59578,7 @@
 /area/engine/port_engineering)
 "uYH" = (
 /obj/machinery/light,
-/obj/machinery/autolathe,
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "uYY" = (
@@ -60438,6 +60498,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wDc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "wDU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -108927,7 +108993,7 @@ bTZ
 bUX
 bUX
 meu
-bYN
+qvn
 cah
 bRB
 cac
@@ -109445,7 +109511,7 @@ cCR
 cah
 dgr
 hpv
-rXP
+jZP
 cmf
 cfD
 cgJ
@@ -109454,7 +109520,7 @@ cYI
 dzD
 cbi
 cbi
-cbi
+dGe
 coP
 cmf
 bWr
@@ -110215,7 +110281,7 @@ rIm
 cah
 cah
 ptk
-iVd
+iUU
 pge
 cmf
 lba
@@ -110472,13 +110538,13 @@ bVd
 cXV
 cah
 ptk
-iVd
+iUU
 hPx
 cmf
 gmN
 cmf
-cbi
-cbn
+fWp
+wDc
 cka
 cbi
 cmf
@@ -110732,7 +110798,7 @@ cbo
 iVd
 bif
 cmf
-cfG
+cbi
 cgP
 cbi
 ciN
@@ -110977,13 +111043,13 @@ nhK
 jZP
 fHb
 uZB
-bRB
-irr
-bUf
+bRD
+bSQ
+uin
 cah
-bWq
-iPe
-koe
+pfa
+jZP
+fHb
 cah
 jjE
 jZP
@@ -111234,24 +111300,24 @@ bLY
 cah
 cah
 ppG
-bRB
-umV
-bUf
 cah
-bWq
-bif
-koe
+umV
+lAB
+bLN
+lAB
+bLN
+cah
 cah
 cbp
 ccr
 cdE
 cmf
+hLA
+cbi
+oNN
 cbi
 cbi
-cbi
-cbi
-cbi
-cbi
+qHi
 cmf
 cnA
 cnA
@@ -111491,13 +111557,13 @@ bLZ
 cah
 cah
 cae
-bRD
-bSQ
+cah
+uAm
 sAs
 tPB
 bWs
-jZP
-fHb
+bLN
+gzS
 cah
 cbp
 pLR
@@ -112265,7 +112331,7 @@ bQs
 fOu
 fOu
 fOu
-bMb
+knC
 kpg
 kpg
 egT

--- a/hippiestation/code/modules/power/port_gen.dm
+++ b/hippiestation/code/modules/power/port_gen.dm
@@ -1,5 +1,5 @@
 /obj/machinery/power/port_gen
-	icon_hippie = 'hippiestation/icons/obj/power.dmi'
+	icon = 'hippiestation/icons/obj/power.dmi'
 	icon_state = "portgen0"
 
 /obj/machinery/power/port_gen/pacman/super

--- a/hippiestation/code/modules/research/designs/machine_designs.dm
+++ b/hippiestation/code/modules/research/designs/machine_designs.dm
@@ -13,11 +13,43 @@
 	build_path = /obj/item/circuitboard/computer/telesci_console
 	category = list("Teleportation Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
-	
-/datum/design/board/sleeper	
-	name = "Machine Design (Sleeper Board)"	
-	desc = "The circuit board for a sleeper."	
-	id = "sleeper"	
-	build_path = /obj/item/circuitboard/machine/sleeper	
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_MEDICAL	
+
+/datum/design/board/sleeper
+	name = "Machine Design (Sleeper Board)"
+	desc = "The circuit board for a sleeper."
+	id = "sleeper"
+	build_path = /obj/item/circuitboard/machine/sleeper
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Medical Machinery")
+
+/datum/design/board/lcass_pressure
+	name = "Machine Design (Pessurized Reaction Vessel Board)"
+	desc = "The circuit board for a pressurized reaction vessel."
+	id = "lcass_pressure"
+	build_path = /obj/item/circuitboard/machine/pressure
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Medical Machinery")
+
+/datum/design/board/lcass_centrifuge
+	name = "Machine Design (Centrifuge Board)"
+	desc = "The circuit board for a centrifuge."
+	id = "lcass_centrifuge"
+	build_path = /obj/item/circuitboard/machine/centrifuge
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Medical Machinery")
+
+/datum/design/board/lcass_radioactive
+	name = "Machine Design (Radioactive Molecular Reassembler Board)"
+	desc = "The circuit board for a radioactive molecular reassembler."
+	id = "lcass_radioactive"
+	build_path = /obj/item/circuitboard/machine/radioactive
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Medical Machinery")
+
+/datum/design/board/lcass_bluespace
+	name = "Machine Design (Bluespace Recombobulator Board)"
+	desc = "The circuit board for a bluespace recombobulator."
+	id = "lcass_bluespace"
+	build_path = /obj/item/circuitboard/machine/bluespace
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL
 	category = list ("Medical Machinery")

--- a/hippiestation/code/modules/research/techweb/all_nodes.dm
+++ b/hippiestation/code/modules/research/techweb/all_nodes.dm
@@ -67,3 +67,12 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 */
+
+/datum/techweb_node/adv_chem
+	id = "adv_chem"
+	display_name = "Advanced Chemistry"
+	description = "Advanced chemical processing machines."
+	prereq_ids = list("biotech")
+	design_ids = list("lcass_pressure", "lcass_centrifuge", "lcass_radioactive", "lcass_bluespace")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
balance: Toxins lab has been nerfed slightly and given extra supplies to make up for it
del: Removed lcass chem machines and autolathe from science
del: Plasma glass windows in science are now normal reinforced windows
del: Reverted plasma glass window above engineering SMES with reinforced wall
fix: Fixed incorrectly named cameras around the station
del: Testing lab has been made partially derelict
add: LCass chemistry machines added to techweb 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## About The Pull Request

The other day I was speaking with manly about why we feel science could use a rework. I decided to hop into the map editor and make some changes. The big changes for this are making the testing lab more derelict and less of a hotspot for gangs/cultists and team antags to use to their advantage. In doing so, I've also removed the autolathe and the 2 lcass chem machines and some of the blast doors to the chamber. Toxins lab has been changed. I've axed the excessive heater and freezers and added a wall to make the room less of an ideal spot for gangers. I've also fixed some lazy camera setups done by whoever decided to touch the map and not know what a bloody c-tag is! I also fixed that annoying scrubber built under the fire lock in the science main hallway. Anyways, that should be it. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

The science meta alone is powerful on top of this excessively robustly built department, it appeals to powergamers and so the meta has now been altered slightly. Granted, the fundamental routine for a power gamer is NOT laziness, so I don't expect this to foil their plot, but merely make it slightly more challenging, prolonging the inevitable and taking away the lazy element, if you will. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


Here are some pics:

![2019-08-23_15-52-37](https://user-images.githubusercontent.com/32651551/63620684-fe74be80-c5bf-11e9-81bd-b58aa4a94240.png)
![2019-08-23_15-52-53](https://user-images.githubusercontent.com/32651551/63620628-cff6e380-c5bf-11e9-8a8a-4878d19a1a48.png)
![2019-08-23_15-53-06](https://user-images.githubusercontent.com/32651551/63620629-cff6e380-c5bf-11e9-8bef-dbbdfa0ddbb1.png)

