### PR TITLE
Add Stand Arrow to Summon magic

### DIFF
--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -73,7 +73,8 @@ GLOBAL_LIST_INIT(summoned_magic, list(
 	/obj/item/warpwhistle,
 	/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
 	/obj/item/immortality_talisman,
-	/obj/item/melee/ghost_sword))
+	/obj/item/melee/ghost_sword,
+	/obj/item/stand_arrow)) // hippie -- stand arrow
 
 GLOBAL_LIST_INIT(summoned_special_magic, list(
 	/obj/item/gun/magic/staff/change,


### PR DESCRIPTION
Summon magic is cancer, why not make it less terrible?


:cl:
add: Stand arrow can now appear in Summon Magic
/:cl: