### PR TITLE
Midround abductors shouldn't be spammed anymore

### DIFF
--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -2,7 +2,7 @@
 	name = "Abductors"
 	antag_flag = ROLE_ABDUCTOR
 	required_candidates = 2
-	weight = 5
+	weight = 3
 	cost = 15
 	high_population_requirement = 10
 	var/datum/team/abductor_team/team


### PR DESCRIPTION

:cl:
fix: Non-abductor midround rulesets should actually have a chance of happening now.
/:cl:

