### PR TITLE
Adds infiltrators to dynamic mode

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -270,7 +270,7 @@
 /datum/dynamic_ruleset/roundstart/nuclear/pre_execute()
 	// If ready() did its job, candidates should have 5 or more members in it
 
-	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)
+	var/indice_pop = min(10,round(mode.roundstart_pop_ready/pop_per_requirement)+1) // hippie -- fix this not using pop_per_requirement
 	var/operatives = operative_cap[indice_pop]
 	for(var/operatives_number = 1 to operatives)
 		if(candidates.len <= 0)

--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -161,7 +161,7 @@
 
 /datum/dynamic_ruleset/roundstart/infiltrator/ready(forced = FALSE)
 	var/indice_pop = min(10,round(mode.roundstart_pop_ready/pop_per_requirement)+1)
-	required_candidates = operative_cap[indice_pop]
+	required_candidates = infil_cap[indice_pop]
 	. = ..()
 
 /datum/dynamic_ruleset/roundstart/infiltrator/pre_execute()

--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -145,3 +145,41 @@
 	
 /datum/dynamic_ruleset/roundstart/delayed/revs
 	weight = 20
+
+/datum/dynamic_ruleset/roundstart/infiltrator
+	name = "Infiltration Unit"
+	antag_flag = ROLE_INFILTRATOR
+	antag_datum = /datum/antagonist/infiltrator
+	minimum_required_age = 14
+	required_candidates = 3
+	weight = 10
+	cost = 35
+	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	high_population_requirement = 10
+	var/infil_cap = list(2,3,3,3,3,4,4,5,5,5)
+	var/datum/team/infiltrator/sit_team
+
+/datum/dynamic_ruleset/roundstart/infiltrator/ready(forced = FALSE)
+	var/indice_pop = min(10,round(mode.roundstart_pop_ready/pop_per_requirement)+1)
+	required_candidates = operative_cap[indice_pop]
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/infiltrator/pre_execute()
+	// If ready() did its job, candidates should have 5 or more members in it
+	var/indice_pop = min(10,round(mode.roundstart_pop_ready/pop_per_requirement)+1)
+	var/infiltrators = infil_cap[indice_pop]
+	for(var/infils_number = 1 to infiltrators)
+		if(candidates.len <= 0)
+			break
+		var/mob/M = pick_n_take(candidates)
+		assigned += M.mind
+		M.mind.assigned_role = ROLE_INFILTRATOR
+		M.mind.special_role = ROLE_INFILTRATOR
+	return TRUE
+
+/datum/dynamic_ruleset/roundstart/infiltrator/execute()
+	sit_team = new /datum/team/infiltrator
+	for(var/datum/mind/M in assigned)
+		M.add_antag_datum(/datum/antagonist/infiltrator, sit_team)
+	sit_team.update_objectives()
+	return TRUE

--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -153,7 +153,7 @@
 	minimum_required_age = 14
 	required_candidates = 3
 	weight = 10
-	cost = 35
+	cost = 25
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 10
 	var/infil_cap = list(2,3,3,3,3,4,4,5,5,5)

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -310,6 +310,7 @@
 	Put two together to create the carp suit, which allows you to deflect ranged attacks."
 	cost = 5
 	limited_stock = 2
+	exclude_modes = list(/datum/game_mode/infiltration)
 
 /datum/uplink_item/stealthy_weapons/throwingweapons
 	cost = 2
@@ -357,6 +358,7 @@
 	item = /obj/item/storage/box/syndie_kit/armstrong
 	cost = 14
 	surplus = 20 // someone who respects the eldritch god Nar-Sie a little (((too much))) complained
+	exclude_modes = list(/datum/game_mode/infiltration)
 
 /datum/uplink_item/device_tools/brainwash_disk
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer")
@@ -521,3 +523,4 @@
 	item = /obj/item/storage/belt/hfblade
 	cost = 9
 	surplus = 15
+	exclude_modes = list(/datum/game_mode/infiltration)


### PR DESCRIPTION
:cl:
add: Roundstart infiltrators are now possible (yet uncommon) in Dynamic
fix: Nukies should now spawn the proper number of ops
tweak: Infiltrators can no longer buy carp masks, HF blades, or Armstrong kits
/:cl:

