### PR TITLE
Thanos wardec now makes it impossible to get uranium bullets

### DIFF
--- a/hippiestation/code/modules/gauntlet/gauntlet.dm
+++ b/hippiestation/code/modules/gauntlet/gauntlet.dm
@@ -552,6 +552,8 @@ GLOBAL_VAR_INIT(telescroll_time, 0)
 					for(var/obj/machinery/power/apc/APC in world)
 						if(istype(get_area(APC), /area/tcommsat))
 							APC.resistance_flags |= INDESTRUCTIBLE
+					for(var/obj/machinery/reagent_forge/RF in world)
+						qdel(RF)
 					// move ai(s) to bridge
 					var/list/bridge_tiles = list()
 					for(var/turf/T in get_area_turfs(/area/bridge))


### PR DESCRIPTION
Garbage bandaid solution to a garbage hard-to-balance problem.

:cl:
balance: The reagent forge is now destroyed on thanos wardec.
/:cl:

Possible alternative/companion to https://github.com/HippieStation/HippieStation/pull/12007