### PR TITLE
Removes reactive teleport armor from RD's locker

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -81,13 +81,13 @@
 	targetitem = /obj/item/clothing/suit/armor/laserproof
 	difficulty = 3
 	excludefromjob = list("Head of Security", "Warden")
-
+/* -- Hippie Edit -- Removes Objective
 /datum/objective_item/steal/reactive
 	name = "the reactive teleport armor."
 	targetitem = /obj/item/clothing/suit/armor/reactive
 	difficulty = 5
 	excludefromjob = list("Research Director")
-
+*/
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization."
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -20,7 +20,7 @@
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
-	new /obj/item/clothing/suit/armor/reactive/teleport(src)
+	//new /obj/item/clothing/suit/armor/reactive/teleport(src) hippie edit -- peace the fuck out powergamers
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
del: Removed roundstart reactive teleport armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
What it says on the tin. RD is the ultimate power gamer's job, and the RTA's purpose is only for being extra robust at combat.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because science is extremely broken and what can be powergamed will be powergamed on hippiestation. Research director really does not need an RTA to do research, it's exclusively used by powergaming traitors and validhunters who need an extra brisk of luck to carry them to safety in the event they get fairly struck by an opponents taser. 

You also can make RTA using a blue space anomaly core and reactive armour shell
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
