### PR TITLE
Fixes borg heads giving humans lisps

### DIFF
--- a/hippiestation/code/modules/teeth/misc.dm
+++ b/hippiestation/code/modules/teeth/misc.dm
@@ -46,6 +46,9 @@
 		amt += teeth.amount
 	return amt
 
+/obj/item/bodypart/head/robot/get_teeth() //override to prevent lisps
+	return max_teeth
+
 /proc/punchouttooth(var/mob/living/carbon/human/target, var/mob/living/carbon/human/user, var/strength, var/obj/Q)
 	if(istype(Q, /obj/item/bodypart/head) && prob(strength * (user.zone_selected == "mouth" ? 3 : 1))) //MUCH higher chance to knock out teeth if you aim for mouth
 		var/obj/item/bodypart/head/U = Q


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: YoYoBatty
fix: Fixes robot heads giving humans lisps 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
What is says on the tin. Normal human and human species heads when initialized generate organs such as teeth. Cyborg won't do this and so as a result when attached to a human, gives them a lisp and indicates that they have no teeth.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Fixes: https://github.com/HippieStation/HippieStation/issues/12016
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
