### PR TITLE
Infiltrators will now spawn with nuke core/SM shard stealy thingies

### DIFF
--- a/hippiestation/code/modules/antagonists/infiltrator/team.dm
+++ b/hippiestation/code/modules/antagonists/infiltrator/team.dm
@@ -59,6 +59,13 @@
 	O.find_target()
 	O.team = src
 	objectives |= O
+	if(istype(O, /datum/objective/steal))
+		var/datum/objective/steal/S = O
+		if(S.targetinfo)
+			for(var/item in S.targetinfo.special_equipment)
+				for(var/turf/T in GLOB.infiltrator_objective_items)
+					if(!(item in T.contents))
+						new item(T)
 
 /datum/team/infiltrator/proc/update_objectives()
 	if(LAZYLEN(objectives))


### PR DESCRIPTION

:cl:
fix: Infiltrators should now properly get non-special objective kits.
/:cl:

