### PR TITLE
renames Morphine to Sleep Toxin

### DIFF
--- a/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -225,3 +225,6 @@ datum/reagent/medicine/virogone/on_mob_life(mob/living/M)//cures viruses very ef
 		M.adjustBruteLoss(-0.5*REM, 0)
 		M.adjustFireLoss(-0.5*REM, 0)
 	return FINISHONMOBLIFE(M)
+
+/datum/reagent/medicine/morphine
+	name = "Sleep Toxin"


### PR DESCRIPTION
at the request of wheezl. dunno why, considering that morphine is pretty horrible at it's job and it's only use is for incapacitating a guy in a sleeper

:cl:
tweak: Morphine has been renamed to sleep toxin
/:cl: