### PR TITLE
[DO NOT MERGE] freon 2 electric boogaloo but proper

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3176,6 +3176,7 @@
 #include "hippiestation\code\modules\assembly\bomb.dm"
 #include "hippiestation\code\modules\assembly\flash.dm"
 #include "hippiestation\code\modules\atmospherics\gasmixtures\reactions.dm"
+#include "hippiestation\code\modules\atmospherics\gasmixtures\gas_types.dm"
 #include "hippiestation\code\modules\atmospherics\machinery\components\binary_devices\pump.dm"
 #include "hippiestation\code\modules\atmospherics\machinery\components\binary_devices\volume_pump.dm"
 #include "hippiestation\code\modules\atmospherics\unary_devices\vent_pump.dm"

--- a/hippiestation/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/hippiestation/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,0 +1,167 @@
+GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
+GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/pluoxium, /datum/gas/stimulum, /datum/gas/nitryl))) //unable to react amongst themselves
+
+/proc/meta_gas_list()
+	. = subtypesof(/datum/gas)
+	for(var/gas_path in .)
+		var/list/gas_info = new(7)
+		var/datum/gas/gas = gas_path
+
+		gas_info[META_GAS_SPECIFIC_HEAT] = initial(gas.specific_heat)
+		gas_info[META_GAS_NAME] = initial(gas.name)
+
+		gas_info[META_GAS_MOLES_VISIBLE] = initial(gas.moles_visible)
+		if(initial(gas.moles_visible) != null)
+			gas_info[META_GAS_OVERLAY] = new /list(FACTOR_GAS_VISIBLE_MAX)
+			for(var/i in 1 to FACTOR_GAS_VISIBLE_MAX)
+				gas_info[META_GAS_OVERLAY][i] = new /obj/effect/overlay/gas(initial(gas.gas_overlay), i * 255 / FACTOR_GAS_VISIBLE_MAX)
+
+		gas_info[META_GAS_FUSION_POWER] = initial(gas.fusion_power)
+		gas_info[META_GAS_DANGER] = initial(gas.dangerous)
+		gas_info[META_GAS_ID] = initial(gas.id)
+		.[gas_path] = gas_info
+
+/proc/gas_id2path(id)
+	var/list/meta_gas = GLOB.meta_gas_info
+	if(id in meta_gas)
+		return id
+	for(var/path in meta_gas)
+		if(meta_gas[path][META_GAS_ID] == id)
+			return path
+	return ""
+
+/*||||||||||||||/----------\||||||||||||||*\
+||||||||||||||||[GAS DATUMS]||||||||||||||||
+||||||||||||||||\__________/||||||||||||||||
+||||These should never be instantiated. ||||
+||||They exist only to make it easier   ||||
+||||to add a new gas. They are accessed ||||
+||||only by meta_gas_list().            ||||
+\*||||||||||||||||||||||||||||||||||||||||*/
+
+/datum/gas
+	var/id = ""
+	var/specific_heat = 0
+	var/name = ""
+	var/gas_overlay = "" //icon_state in icons/effects/atmospherics.dmi
+	var/moles_visible = null
+	var/dangerous = FALSE //currently used by canisters
+	var/fusion_power = 0 //How much the gas accelerates a fusion reaction
+	var/rarity = 0 // relative rarity compared to other gases, used when setting up the reactions list.
+
+/datum/gas/oxygen
+	id = "o2"
+	specific_heat = 20
+	name = "Oxygen"
+	rarity = 900
+
+/datum/gas/nitrogen
+	id = "n2"
+	specific_heat = 20
+	name = "Nitrogen"
+	rarity = 1000
+
+/datum/gas/carbon_dioxide //what the fuck is this?
+	id = "co2"
+	specific_heat = 30
+	name = "Carbon Dioxide"
+	rarity = 700
+
+/datum/gas/plasma
+	id = "plasma"
+	specific_heat = 200
+	name = "Plasma"
+	gas_overlay = "plasma"
+	moles_visible = MOLES_GAS_VISIBLE
+	dangerous = TRUE
+	rarity = 800
+
+/datum/gas/water_vapor
+	id = "water_vapor"
+	specific_heat = 40
+	name = "Water Vapor"
+	gas_overlay = "water_vapor"
+	moles_visible = MOLES_GAS_VISIBLE
+	fusion_power = 8
+	rarity = 500
+
+/datum/gas/freon
+	id = "freon"
+	specific_heat = 40
+	name = "Freon"
+	gas_overlay = "freon"
+	moles_visible = MOLES_GAS_VISIBLE
+	fusion_power = 8
+	rarity = 50
+
+/datum/gas/nitrous_oxide
+	id = "n2o"
+	specific_heat = 40
+	name = "Nitrous Oxide"
+	gas_overlay = "nitrous_oxide"
+	moles_visible = MOLES_GAS_VISIBLE * 2
+	fusion_power = 10
+	dangerous = TRUE
+	rarity = 600
+
+/datum/gas/nitryl
+	id = "no2"
+	specific_heat = 20
+	name = "Nitryl"
+	gas_overlay = "nitryl"
+	moles_visible = MOLES_GAS_VISIBLE
+	dangerous = TRUE
+	fusion_power = 16
+	rarity = 100
+
+/datum/gas/tritium
+	id = "tritium"
+	specific_heat = 10
+	name = "Tritium"
+	gas_overlay = "tritium"
+	moles_visible = MOLES_GAS_VISIBLE
+	dangerous = TRUE
+	fusion_power = 1
+	rarity = 300
+
+/datum/gas/bz
+	id = "bz"
+	specific_heat = 20
+	name = "BZ"
+	dangerous = TRUE
+	fusion_power = 8
+	rarity = 400
+
+/datum/gas/stimulum
+	id = "stim"
+	specific_heat = 5
+	name = "Stimulum"
+	fusion_power = 7
+	rarity = 1
+
+/datum/gas/pluoxium
+	id = "pluox"
+	specific_heat = 80
+	name = "Pluoxium"
+	fusion_power = -10
+	rarity = 200
+
+/datum/gas/miasma
+	id = "miasma"
+	specific_heat = 20
+	name = "Miasma"
+	gas_overlay = "miasma"
+	moles_visible = MOLES_GAS_VISIBLE * 60
+	rarity = 250
+
+/obj/effect/overlay/gas
+	icon = 'icons/effects/atmospherics.dmi'
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	anchored = TRUE  // should only appear in vis_contents, but to be safe
+	layer = FLY_LAYER
+	appearance_flags = TILE_BOUND
+
+/obj/effect/overlay/gas/New(state, alph)
+	. = ..()
+	icon_state = state
+	alpha = alph


### PR DESCRIPTION

## Changelog
:cl: Turret
add: Removed Hyper Nobilium and instead brought back Freon, the old gas which was better.
/:cl:

## About The Pull Request

Hypernobilum was removed from the game, instead it's been replaced by Freon. That's it.

## Why It's Good For The Game

Removing Freon was an unnecesary, /tg/ change.
