### PR TITLE
Removes hivemind from dynamic rotation

### DIFF
--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -27,7 +27,7 @@
 /datum/dynamic_ruleset/roundstart/choose/proc/let_choice(datum/mind/M)
 	var/choice
 	while(!choice)
-		choice = input(M.current, "Which antagonist would you like to be?", "Your lucky day!") as null|anything in list("Traitor", "Vampire", "Devil", "Hivemind")
+		choice = input(M.current, "Which antagonist would you like to be?", "Your lucky day!") as null|anything in list("Traitor", "Vampire", "Devil")
 		if(!choice)
 			continue
 		switch(choice)
@@ -40,30 +40,6 @@
 			if("Devil")
 				M.add_antag_datum(/datum/antagonist/devil)
 				M.special_role = ROLE_DEVIL
-			if("Hivemind")
-				M.add_antag_datum(/datum/antagonist/hivemind)
-				M.special_role = ROLE_HIVE
-
-
-/datum/dynamic_ruleset/roundstart/hivemind
-	name = "Hivemind"
-	antag_flag = ROLE_HIVE
-	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
-	restricted_roles = list("Cyborg")
-	required_candidates = 2
-	weight = 20
-	cost = 25
-	antag_datum = /datum/antagonist/hivemind
-
-/datum/dynamic_ruleset/roundstart/hivemind/pre_execute()
-	var/num_hosts = max( 1 , rand(0,1) + min(8, round(mode.roundstart_pop_ready / 8) ) ) //1 host for every 8 players up to 64, with a 50% chance of an extra
-	for (var/i = 1 to num_hosts)
-		var/mob/M = pick(candidates)
-		candidates -= M
-		assigned += M.mind
-		M.mind.restricted_roles = restricted_roles
-		M.mind.special_role = ROLE_HIVE
-	return TRUE
 	
 /datum/dynamic_ruleset/roundstart/abductors
 	name = "Abductors"


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
del: removes hivemind from dynamic rotation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Removes hivemind from dynamic rotation

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
This antag requires 10+ people to even achieve its assimilation objective (same issue as abductor, but slightly worse due to rng). Its buggy, and is generally reliant on people being alive to do anything, along with highpop. Why was this even in rotation here? I dont really know.

Delet this already nobody likes this fucking terrible antag
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
