### PR TITLE
Craftable Rubber Ducks.

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -255,6 +255,16 @@
 	build_path = /obj/item/tank/internals/plasma/empty
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	
+/datum/design/rubberducky
+	name = "Rubber Ducky"
+	desc = "Release the quacken!"
+	id = "rubberducky"
+	build_type = PROTOLATHE
+	materials = list(MAT_PLASTIC = 5000)
+	build_path = /obj/item/bikehorn/rubberducky
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////

--- a/hippiestation/code/modules/research/techweb/all_nodes.dm
+++ b/hippiestation/code/modules/research/techweb/all_nodes.dm
@@ -85,3 +85,7 @@
 	design_ids = list("autodoc")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
 	export_price = 10000
+
+/datum/techweb_node/clown
+	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "rubberducky")


### PR DESCRIPTION
## Changelog
:cl: SharkboySarrador
add: Rubber duckies can now be made on the service protolathe. Release the quacken!
/:cl:

## About The Pull Request
Yeah. Needed research is clown technology, and requires plastic to make (To throttle duck spamming). Buildable only on service protolathe because.. Well, it doesn't really fit into any of the other departments. Maybe cargo, actually. Maybe.

## Why It's Good For The Game
Honk?