### PR TITLE
NukeOps balance pass :spange:

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -530,3 +530,71 @@
 	desc = "Mark threats and check enemies for objective items, weapons and high level access. Guaranteed to greentext or your telecrystals back."
 	item = /obj/item/clothing/glasses/hud/threat
 	cost = 6
+	
+//Nuke Ops low pop restriction
+/datum/uplink_item/bundles_TC/c20r
+	player_minimum = 40
+	
+/datum/uplink_item/bundles_TC/surplus
+	player_minimum = 30
+	
+/datum/uplink_item/dangerous/rawketlawnchair
+	player_minimum = 30
+	
+/datum/uplink_item/dangerous/smg
+	player_minimum = 35
+	
+/datum/uplink_item/dangerous/doublesword
+	player_minimum = 35
+	
+/datum/uplink_item/dangerous/rapid
+	player_minimum = 30
+	
+/datum/uplink_item/dangerous/machinegun
+	player_minimum = 40
+	
+/datum/uplink_item/dangerous/carbine
+	player_minimum = 35
+	
+/datum/uplink_item/dangerous/revolver
+	player_minimum = 25
+	
+/datum/uplink_item/stealthy_weapons/combatglovesplus
+	player_minimum = 20
+	
+/datum/uplink_item/stealthy_weapons/cqc
+	player_minimum = 20
+	
+/datum/uplink_item/stealthy_weapons/martialarts
+	player_minimum = 20
+	
+/datum/uplink_item/stealthy_weapons/crossbow
+	player_minimum = 20
+	
+/datum/uplink_item/ammo/a40mm
+	player_minimum = 35
+	
+/datum/uplink_item/ammo/smg/bag
+	player_minimum = 35
+	
+/datum/uplink_item/ammo/smg
+	player_minimum = 35
+	
+/datum/uplink_item/ammo/carbine
+	player_minimum = 35
+	
+/datum/uplink_item/ammo/machinegun
+	player_minimum = 40
+	
+/datum/uplink_item/ammo/rocket
+	player_minimum = 30
+	
+/datum/uplink_item/explosives/buzzkill
+	player_minimum = 20
+	
+/datum/uplink_item/support/reinforcement/assault_borg
+	player_minimum = 40
+
+/datum/uplink_item/suits/hardsuit/shielded
+	player_minimum = 30
+

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -551,7 +551,7 @@
 	player_minimum = 30
 	
 /datum/uplink_item/dangerous/machinegun
-	player_minimum = 40
+	player_minimum = 35
 	
 /datum/uplink_item/dangerous/carbine
 	player_minimum = 35
@@ -584,7 +584,7 @@
 	player_minimum = 35
 	
 /datum/uplink_item/ammo/machinegun
-	player_minimum = 40
+	player_minimum = 35
 	
 /datum/uplink_item/ammo/rocket
 	player_minimum = 30

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -547,9 +547,6 @@
 /datum/uplink_item/dangerous/doublesword
 	player_minimum = 35
 	
-/datum/uplink_item/dangerous/rapid
-	player_minimum = 30
-	
 /datum/uplink_item/dangerous/machinegun
 	player_minimum = 35
 	
@@ -559,16 +556,7 @@
 /datum/uplink_item/dangerous/revolver
 	player_minimum = 25
 	
-/datum/uplink_item/stealthy_weapons/combatglovesplus
-	player_minimum = 20
-	
-/datum/uplink_item/stealthy_weapons/cqc
-	player_minimum = 20
-	
 /datum/uplink_item/stealthy_weapons/martialarts
-	player_minimum = 20
-	
-/datum/uplink_item/stealthy_weapons/crossbow
 	player_minimum = 20
 	
 /datum/uplink_item/ammo/a40mm

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -533,7 +533,7 @@
 	
 //Nuke Ops low pop restriction
 /datum/uplink_item/bundles_TC/c20r
-	player_minimum = 40
+	player_minimum = 30
 	
 /datum/uplink_item/bundles_TC/surplus
 	player_minimum = 30
@@ -542,7 +542,7 @@
 	player_minimum = 30
 	
 /datum/uplink_item/dangerous/smg
-	player_minimum = 35
+	player_minimum = 30
 	
 /datum/uplink_item/dangerous/doublesword
 	player_minimum = 35
@@ -575,10 +575,10 @@
 	player_minimum = 35
 	
 /datum/uplink_item/ammo/smg/bag
-	player_minimum = 35
+	player_minimum = 30
 	
 /datum/uplink_item/ammo/smg
-	player_minimum = 35
+	player_minimum = 30
 	
 /datum/uplink_item/ammo/carbine
 	player_minimum = 35


### PR DESCRIPTION
Nuke ops sucks on lower pops. Clown ops is fun on lower pop. Balances item pop requirements to make nuke ops more like clown ops on lower pop.

:cl:
balance: Nuke ops sucks on lower pops. Clown ops is fun on lower pop. Balanced item pop requirements to make nuke ops more like clown ops on lower pop.
/:cl: