### PR TITLE
Superboom Changes (N-amino)

### DIFF
--- a/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -151,7 +151,7 @@
 /datum/reagent/superboom/process()
 	if(prob(0.5) && holder) //even if you do nothing it can explode
 		if(holder.has_reagent(/datum/reagent/stabilizing_agent)) //unless its stabilised :spoi:
-			return
+			return ..()
 		var/location = get_turf(holder.my_atom)
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(round(volume, 0.5), location, 0, 0, message = 0)

--- a/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -149,6 +149,8 @@
 	..()
 
 /datum/reagent/superboom/process()
+	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
+		return
 	if(prob(0.5) && holder) //even if you do nothing it can explode
 		var/location = get_turf(holder.my_atom)
 		var/datum/effect_system/reagents_explosion/e = new()

--- a/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -149,9 +149,9 @@
 	..()
 
 /datum/reagent/superboom/process()
-	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
-		return
 	if(prob(0.5) && holder) //even if you do nothing it can explode
+		if(holder.has_reagent(/datum/reagent/stabilizing_agent)) //unless its stabilised :spoi:
+			return
 		var/location = get_turf(holder.my_atom)
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(round(volume, 0.5), location, 0, 0, message = 0)


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: tweaks superboom (N-amino) to have no chance of exploding while stabilized
/:cl:

<!-- Both :cl:'s are required for the change-log to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Changes N-Amino(Superboom) To not randomly explode while stabilised.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
This makes superboom more realistically storable without having 9 billion bwoinks as to why medbay just dissapeared off of the station. This also encourages people to make it legitimately, rather than duplicating it via space cleaner bottles (stabilising agent in 1u wont be duped, meaning the n-amino will explode unless stabilised quickly.)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
