### PR TITLE
Puts the bee shit in a crate in the back of botany

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -14572,6 +14572,16 @@
 	req_access_txt = "35"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/hydroponics{
+	name = "Beekeeping Starter Crate"
+	},
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/melee/flyswatter,
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aOQ" = (
@@ -59161,13 +59171,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tWi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/beebox/premade,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "tWk" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -102447,7 +102450,7 @@ aQJ
 aLR
 aTq
 aUI
-tWi
+kWp
 aXV
 aZB
 aWv
@@ -102704,7 +102707,7 @@ aQK
 aLR
 aTp
 aUI
-tWi
+kWp
 aXW
 aZC
 aWv


### PR DESCRIPTION
[Guidelines]: 
![image](https://user-images.githubusercontent.com/29981240/68378885-90b74800-0155-11ea-9cc2-99b22c4d5868.png)

## Changelog
:cl: zamolxius
tweak: made bee kit start packed in the botanist's backroom place; Also it's half as many stuff. Same contents as cargo bee crate
/:cl:

