### PR TITLE
Turns on chat subsystem

### DIFF
--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(chat)
 	name = "Chat"
-	flags = SS_TICKER|SS_NO_INIT
+	flags = SS_TICKER
 	wait = 1
 	priority = FIRE_PRIORITY_CHAT
 	init_order = INIT_ORDER_CHAT


### PR DESCRIPTION
Mirror of: https://github.com/tgstation/tgstation/pull/47653

Quote:

I accidentally set it to not initialize, and it doesn't run if not initialized. So we've had it disabled for a good while... more than three months at least.

So here it is! the chat subsystem! tadaaa!
About The Pull Request

This is just a subsystem that queues to_chats, so they cannot lag out your game. If the subsystem doesn't work, it will just revert back to the old system. <-- lol

I really gotta test it more, because i'm not perfectly sure everything is alright yet! <-- you even knew there would be trouble, past tralezab