### PR TITLE
Fix mousetrap grenades

### DIFF
--- a/hippiestation/code/game/objects/items/grenades/chem_grenade.dm
+++ b/hippiestation/code/game/objects/items/grenades/chem_grenade.dm
@@ -3,6 +3,20 @@
 /obj/item/grenade/chem_grenade
 	banned_containers = list() // reverts bluespace beaker's nerf
 
+
+/obj/item/grenade/chem_grenade/Crossed(atom/movable/AM, oldloc)
+	for(var/A in wires.assemblies)
+		var/obj/item/I = wires.assemblies[A]
+		if(istype(I))
+			I.Crossed(AM, oldloc)
+	return ..()
+
+/obj/item/grenade/chem_grenade/on_found(mob/finder)
+	for(var/A in wires.assemblies)
+		var/obj/item/assembly/I = wires.assemblies[A]
+		if(istype(I))
+			I.on_found(finder)
+
 /obj/item/grenade/chem_grenade/saringas
 	name = "Sarin gas grenade"
 	desc = "Tiger Cooperative military grade nerve gas. WARNING: Ensure internals are active before use, nerve agents are exceptionally lethal regardless of dosage"


### PR DESCRIPTION

:cl:
fix: Mousetrap grenades work again. Just remember to arm the mousetrap before putting it in!
/:cl:


