### PR TITLE
adds spooky saxophone to caves away mission skeleton spawn

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1701,7 +1701,7 @@
 /obj/effect/mob_spawn/human/skeleton/alive{
 	name = "spooky skeleton remains"
 	},
-/obj/item/instrument/saxophone,
+/obj/item/instrument/saxophone/spectral,
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14"
 	},

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1701,6 +1701,7 @@
 /obj/effect/mob_spawn/human/skeleton/alive{
 	name = "spooky skeleton remains"
 	},
+/obj/item/instrument/saxophone,
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14"
 	},


### PR DESCRIPTION
 #12273
:cl: zamolxius
add: Added a VERY SPOOKY saxophone to the Caves away mission skeleton spawner
/:cl:


![image](https://user-images.githubusercontent.com/29981240/68530165-9ad07680-030e-11ea-818a-bd1c799933ca.png)

![image](https://user-images.githubusercontent.com/29981240/68530230-3eba2200-030f-11ea-9d6c-0e0cdc8feaae.png)
from https://github.com/tgstation/tgstation/pull/31966

hopefully this will make the skeleton more comedic