### PR TITLE
Fire damage by rads is log(rads) * 2

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1009,7 +1009,7 @@ hippie end */
 	var/blocked = getarmor(null, "rad")
 
 	if(amount > RAD_BURN_THRESHOLD)
-		apply_damage((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, BURN, null, blocked)
+		apply_damage(log(amount)*2, BURN, null, blocked)
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 

--- a/html/changelogs/AutoChangeLog-pr-46806.yml
+++ b/html/changelogs/AutoChangeLog-pr-46806.yml
@@ -1,0 +1,4 @@
+author: "Tlaltecuhtli"
+delete-after: True
+changes: 
+  - bugfix: "High amounts of radiation will no longer deal extreme amounts of burn damage."


### PR DESCRIPTION
Mirror of: https://github.com/tgstation/tgstation/pull/46806

Makes it so stupidly high radiation level can't insta kill you but at the same time reduces burn damage from rads. Don't worry, you'll still accumulate toxin damage.