### PR TITLE
Increases restart/shuttle call vote delay

### DIFF
--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -241,6 +241,7 @@ datum/controller/subsystem/vote
 			else if (SSshuttle.emergency.mode != SHUTTLE_CALL)
 				SSshuttle.emergency.request()
 				SSshuttle.emergency.setTimer(6000)
+				SSshuttle.emergencyNoRecall = TRUE
 				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes.")
 
 			message_admins("The emergency shuttle has been force-called due to a successful shuttle call vote.")

--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -1,6 +1,6 @@
 datum/controller/subsystem/vote
-	var/min_restart_time = 75 MINUTES
-	var/min_shuttle_time = 45 MINUTES
+	var/min_restart_time = 60 MINUTES
+	var/min_shuttle_time = 35 MINUTES
 
 /datum/controller/subsystem/vote/proc/get_result()
 	//get the highest number of votes

--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -1,6 +1,6 @@
 datum/controller/subsystem/vote
-	var/min_restart_time = 60 MINUTES
-	var/min_shuttle_time = 30 MINUTES
+	var/min_restart_time = 75 MINUTES
+	var/min_shuttle_time = 45 MINUTES
 
 /datum/controller/subsystem/vote/proc/get_result()
 	//get the highest number of votes
@@ -236,11 +236,11 @@ datum/controller/subsystem/vote
 		var/shuttle_timer = SSshuttle.emergency.timeLeft()
 		if(shuttle_timer >= 300 || (SSshuttle.emergency.mode != SHUTTLE_CALL && SSshuttle.emergency.mode != SHUTTLE_DOCKED && SSshuttle.emergency.mode != SHUTTLE_ESCAPE)) // hippie -- fix shuttle votes upping timers to 5 minutes
 			if(SSshuttle.emergency.mode == SHUTTLE_CALL && shuttle_timer >= 300)	//Apparently doing the emergency request twice cancels the call so these check are just in case
-				SSshuttle.emergency.setTimer(3000)
+				SSshuttle.emergency.setTimer(6000)
 				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes.")
 			else if (SSshuttle.emergency.mode != SHUTTLE_CALL)
 				SSshuttle.emergency.request()
-				SSshuttle.emergency.setTimer(3000)
+				SSshuttle.emergency.setTimer(6000)
 				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes.")
 
 			message_admins("The emergency shuttle has been force-called due to a successful shuttle call vote.")


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: Increases restart vote delay from 30 to 35 mins
tweak: Shuttle vote now makes the shuttle call normally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Title. People complain that these votes are used too early into the round and I agree myself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
No more forced 5 min shuttle call.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
