### PR TITLE
Revert "Fire damage by rads is log(rads) * 2"

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1008,7 +1008,7 @@ hippie end */
 	var/blocked = getarmor(null, "rad")
 
 	if(amount > RAD_BURN_THRESHOLD)
-		apply_damage(log(amount)*2, BURN, null, blocked)
+		apply_damage((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, BURN, null, blocked)
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 


### PR DESCRIPTION
Reverts HippieStation/HippieStation#12289

this was literally not a bug and intended behaviour to stop cyborg/plasmamen from creating superchernobyl