### PR TITLE
Fixes smoke not creating enough reagents

### DIFF
--- a/hippiestation/code/modules/reagents/chemistry/holder.dm
+++ b/hippiestation/code/modules/reagents/chemistry/holder.dm
@@ -194,10 +194,12 @@
 					R.reaction_turf(A, R.volume * volume_modifier, show_message)
 				if(world.time >= next_react)
 					R.handle_state_change(A, R.volume * special_modifier, cached_my_atom)
-					next_react = world.time + 1
+					if(method == VAPOR)
+						next_react = world.time + 1
 			if("OBJ")
 				if(R.reagent_state != SOLID)
 					R.reaction_obj(A, R.volume * volume_modifier, show_message)
 				if(world.time >= next_react)
 					R.handle_state_change(get_turf(A), R.volume * special_modifier, cached_my_atom)
-					next_react = world.time + 1
+					if(method == VAPOR)
+						next_react = world.time + 1

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -77,8 +77,7 @@
 			if(atom && istype(atom, /obj/effect/particle_effect))
 				volume *= LIQUID_PARTICLE_EFFECT_EFFICIENCY//big nerf to smoke and foam duping
 
-			var/obj/effect/decal/cleanable/chempile/c = locate() in T//handles merging existing chempiles
-			if(istype(c))
+			for(var/obj/effect/decal/cleanable/chempile/c in T.contents)//handles merging existing chempiles
 				if(c.reagents)
 					if(touch_msg)
 						c.add_fingerprint(touch_mob)
@@ -103,8 +102,7 @@
 			if(atom && istype(atom, /obj/effect/particle_effect))
 				volume *= SOLID_PARTICLE_EFFECT_EFFICIENCY//big nerf to smoke and foam duping
 
-			var/obj/item/reagent_containers/food/snacks/solid_reagent/SR = locate() in T
-			if(istype(SR))
+			for(var/obj/item/reagent_containers/food/snacks/solid_reagent/SR in T.contents)
 				if(SR.reagents && SR.reagent_type == type && SR.reagents.total_volume < 200)
 					if(touch_msg)
 						SR.add_fingerprint(touch_mob)


### PR DESCRIPTION
I am partially reverting hippie chem fixes PR, as the main issue of chem duplication was patched, it just so happens that these lines of code I left in were the thing that was not fixing the chem duplication, but simply made it so smoke and nades wouldn't keep adding to a chem pile, which is an issue.

TL;DR: Thought the code was a fix, didn't undo my process of elimination to isolate the duplicate fix. Most importantly, smoke and nade chem piles should no longer have a very small amount of chemicals in them. 