### PR TITLE
Ports the luxury bar survival pod from TG

### DIFF
--- a/_maps/templates/shelter_3.dmm
+++ b/_maps/templates/shelter_3.dmm
@@ -1,0 +1,414 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/survivalpod)
+"b" = (
+/obj/structure/sign/mining/survival{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/survivalpod)
+"c" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"d" = (
+/obj/structure/sign/mining/survival{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"e" = (
+/obj/structure/sign/mining/survival{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"f" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"g" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"h" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"i" = (
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"j" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/clipboard,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"k" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_y = 4
+	},
+/obj/item/storage/fancy/cigarettes/cigars/havana{
+	pixel_y = 8
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"l" = (
+/obj/structure/table/wood/fancy/black,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"m" = (
+/obj/structure/closet/secure_closet/bar,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"n" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"o" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/survivalpod)
+"p" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	req_access_txt = "25"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"q" = (
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"r" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"s" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/lighter,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"t" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"u" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"v" = (
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "25"
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"w" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"x" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"y" = (
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"z" = (
+/obj/machinery/vending/cigarette/beach,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"A" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"B" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"C" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille,
+/turf/open/floor/pod/dark,
+/area/survivalpod)
+"D" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"E" = (
+/obj/machinery/door/airlock/survival_pod,
+/turf/open/floor/pod/light,
+/area/survivalpod)
+"F" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"G" = (
+/obj/structure/urinal{
+	pixel_y = 24
+	},
+/turf/open/floor/pod/light,
+/area/survivalpod)
+"H" = (
+/turf/open/floor/pod/light,
+/area/survivalpod)
+"I" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/survivalpod)
+"J" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"K" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"L" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"M" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+"N" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/survivalpod)
+"O" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/survivalpod)
+"P" = (
+/obj/structure/sign/mining/survival,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/survivalpod)
+"Q" = (
+/obj/structure/sign/mining/survival,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/survivalpod)
+"R" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/structure/fans/tiny,
+/turf/open/floor/carpet/black,
+/area/survivalpod)
+
+(1,1,1) = {"
+a
+e
+p
+e
+c
+e
+C
+e
+C
+e
+a
+"}
+(2,1,1) = {"
+b
+f
+q
+s
+x
+y
+D
+F
+K
+L
+P
+"}
+(3,1,1) = {"
+c
+g
+q
+t
+x
+y
+y
+y
+y
+M
+c
+"}
+(4,1,1) = {"
+d
+h
+q
+t
+x
+y
+D
+F
+K
+y
+Q
+"}
+(5,1,1) = {"
+c
+i
+q
+u
+x
+y
+D
+F
+K
+y
+c
+"}
+(6,1,1) = {"
+d
+j
+q
+t
+x
+y
+y
+y
+y
+y
+R
+"}
+(7,1,1) = {"
+c
+k
+q
+t
+x
+y
+c
+c
+c
+c
+c
+"}
+(8,1,1) = {"
+d
+l
+q
+t
+x
+y
+c
+G
+H
+H
+Q
+"}
+(9,1,1) = {"
+c
+m
+q
+v
+y
+y
+E
+H
+c
+E
+c
+"}
+(10,1,1) = {"
+b
+n
+q
+t
+z
+A
+c
+I
+c
+N
+P
+"}
+(11,1,1) = {"
+a
+o
+r
+w
+r
+B
+c
+J
+c
+O
+a
+"}

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -81,10 +81,17 @@
 		new /obj/effect/particle_effect/smoke(get_turf(src))
 		qdel(src)
 
+//Non-default pods
+
 /obj/item/survivalcapsule/luxury
 	name = "luxury bluespace shelter capsule"
 	desc = "An exorbitantly expensive luxury suite stored within a pocket of bluespace."
 	template_id = "shelter_beta"
+
+/obj/item/survivalcapsule/luxuryelite
+	name = "luxury elite bar capsule"
+	desc = "A luxury bar in a capsule. Bartender required and not included."
+	template_id = "shelter_charlie"
 
 //Pod objects
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -42,6 +42,7 @@
 		new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,										2500),
 		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										2500),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule",		/obj/item/survivalcapsule/luxury,									3000),
+		new /datum/data/mining_equipment("Luxury Bar Capsule",			/obj/item/survivalcapsule/luxuryelite,								10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot",			/mob/living/simple_animal/hostile/mining_drone,						800),
 		new /datum/data/mining_equipment("Minebot Melee Upgrade",		/obj/item/mine_bot_upgrade,											400),
 		new /datum/data/mining_equipment("Minebot Armor Upgrade",		/obj/item/mine_bot_upgrade/health,									400),

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -58,3 +58,18 @@
 	. = ..()
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
 	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/datum/map_template/shelter/charlie
+	name = "Shelter Charlie"
+	shelter_id = "shelter_charlie"
+	description = "A luxury elite bar which holds an entire bar \
+		along with two vending machines, tables, and a restroom that \
+		also has a sink. This isn't a survival capsule and so you can \
+		expect that this won't save you if you're bleeding out to \
+		death."
+	mappath = "_maps/templates/shelter_3.dmm"
+
+/datum/map_template/shelter/charlie/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)


### PR DESCRIPTION
## Changelog
:cl: FantasticFwoosh
add: The Lavaland luxury bar for a reasonable price of 10,000 mining points is now availible!
add: Equipped with all the commodities that regressing alcoholic or ghost role sympathetic miner needs, like a fully stocked alcohol-vendomat, dining tables and bathroom facilities.  
/:cl:
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR adds the 11x11 luxury bar pod, which as explained in the changelog has different miscallenous bar faculties or depending on your inclination a nice large atmospherically stable room to build in. Whatever purpose you find for it, it makes a welcome centrepiece to any communal area.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It greatly improves temporary settlements viability on the lavaland planet from public mining base or tourism via teleportation pads. Also counts for a space bar that can be laid out indirectly attached to the station also in a pinch for creative people to utilize.
____________________
``(cherry picked from commit fd070e3ae236ee1538f1ab2fcbd1ee91da723172)`` creative credit to Narcissisko with #45547
