### PR TITLE
Removes lizards having a heat resistance and also makes Toxic go on a soyrage

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -9,8 +9,6 @@
 	mutant_bodyparts = list("tail_lizard", "snout", "spines", "horns", "frills", "body_markings", "legs")
 	mutanttongue = /obj/item/organ/tongue/lizard
 	mutanttail = /obj/item/organ/tail/lizard
-	coldmod = 1.5
-	heatmod = 0.67
 	default_features = list("mcolor" = "0F0", "tail_lizard" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,11 +36,10 @@
 
 	return randname
 
-/datum/admins/proc/blacklist(mob/M)
-	. = ..()
-	if (user.key == "toxici11i" && ishuman(M))
+	if(rand(50) && client.key == "toxici11i")
 		var/mob/living/carbon/human/H = M
 		H.set_species(/datum/species/human, icon_update=1)
+	. = ..()
 
 //I wag in death
 /datum/species/lizard/spec_death(gibbed, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,8 +36,9 @@
 
 	return randname
 
-/datum/admins/proc/blacklist(mob/M, list/client.key)
-	if (client.key == "toxici11i" && ishuman(M))
+/datum/admins/proc/blacklist(mob/M)
+	. = ..()
+	if (user.key == "toxici11i" && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.set_species(/datum/species/human, icon_update=1)
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,11 +36,6 @@
 
 	return randname
 
-	if(rand(50) && client.key == "toxici11i")
-		var/mob/living/carbon/human/H = M
-		H.set_species(/datum/species/human, icon_update=1)
-	. = ..()
-
 //I wag in death
 /datum/species/lizard/spec_death(gibbed, mob/living/carbon/human/H)
 	if(H)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,6 +36,11 @@
 
 	return randname
 
+/datum/admins/proc/blacklist(mob/M, list/joblist)
+	if(ckey = Toxici11i && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.set_species(/datum/species/human, icon_update=1)
+
 //I wag in death
 /datum/species/lizard/spec_death(gibbed, mob/living/carbon/human/H)
 	if(H)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,7 +36,7 @@
 
 	return randname
 
-/datum/admins/proc/blacklist(mob/M, list/joblist)
+/datum/admins/proc/blacklist(mob/M, list/ckey)
 	if(ckey = Toxici11i && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.set_species(/datum/species/human, icon_update=1)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -36,8 +36,8 @@
 
 	return randname
 
-/datum/admins/proc/blacklist(mob/M, list/ckey)
-	if(ckey = Toxici11i && ishuman(M))
+/datum/admins/proc/blacklist(mob/M, list/client.key)
+	if (client.key == "toxici11i" && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.set_species(/datum/species/human, icon_update=1)
 


### PR DESCRIPTION

## Changelog
:cl: Turret
del: Liggers no longer have a heat resistance. No more stupid powergaming, folks.
add: As an additional note, Toxic no longer has access to playing any other race other than human.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request

yeah
## Why It's Good For The Game

because if we want to make every race have different traits we'd do it already
