### PR TITLE
Abductors now has a minimum playercount of 20

### DIFF
--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -73,6 +73,7 @@
 	required_candidates = 2
 	weight = 15
 	cost = 20
+	minimum_players = 20
 	var/datum/mind/scientist
 	var/datum/mind/agent
 


### PR DESCRIPTION

:cl:
tweak: No more roundstart abductors on lowpop.
/:cl:
