### PR TITLE
Toolboxes now deal 15 brute

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 12
+	force = 15
 	throwforce = 12
 	throw_speed = 2
 	throw_range = 7

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 15
+	force = 20
 	throwforce = 12
 	throw_speed = 2
 	throw_range = 7

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 20
+	force = 15
 	throwforce = 12
 	throw_speed = 2
 	throw_range = 7


### PR DESCRIPTION
## Changelog
:cl: Turret
balance: Toolboxes now deal 15 brute instead of 12. Power of da toolbox.
/:cl:

## About The Pull Request

i think the toolboxes deal too little damage

also null rods deal 18 damage and they fit in pockets

toolbox is a massive item and it deals only 12 brute and DOESN'T fit in pockets
## Why It's Good For The Game

i said so so it is
