### PR TITLE
Fixes ghosts ctrl-click on autodoc

### DIFF
--- a/hippiestation/code/game/machinery/autodoc.dm
+++ b/hippiestation/code/game/machinery/autodoc.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(autodoc_supported_surgery_steps, typecacheof(list(
 	STR.cant_hold = typecacheof(list(/obj/item/card/emag))
 
 /obj/machinery/autodoc/CtrlClick(mob/user)
-	if(in_use)
+	if(in_use && isliving(user))
 		playsound(src, 'sound/machines/buzz-two.ogg', 50, FALSE)
 		return
 	var/datum/component/storage/ST = GetComponent(/datum/component/storage/concrete/autodoc)


### PR DESCRIPTION
## Changelog
:cl: Neotw
fix: Fixed autodoc making beep beeep bep when a ghost ctrl click it
/:cl:

## About The Pull Request
Fixes #12176 