### PR TITLE
Makes scrake zombie event more rarer as it should be

### DIFF
--- a/hippiestation/code/modules/events/scrake.dm
+++ b/hippiestation/code/modules/events/scrake.dm
@@ -2,6 +2,7 @@
 	name = "Scrake attack"
 	typepath = /datum/round_event/ghost_role/scrake
 	max_occurrences = 1
+	weight = 5
 
 /datum/round_event/ghost_role/scrake
 	role_name = "Scrake zombie"


### PR DESCRIPTION
## Changelog
:cl: Neotw
tweak: Lowered chance of scrake zombie event occurrence
/:cl:

## About The Pull Request
> Adds a **very rare** ghost event to let someone play as a Scrake

It spawns every round

Adds a weight of 5 that ~~probably~~ makes it less common
