### PR TITLE
patches BZ canister infinite money exploit [speedmerge]

### DIFF
--- a/hippiestation/code/modules/cargo/packs.dm
+++ b/hippiestation/code/modules/cargo/packs.dm
@@ -77,3 +77,6 @@
 
 /datum/supply_pack/emergency/syndicate
 	cost = 10000
+
+/datum/supply_pack/materials/bz
+	cost = 8000


### PR DESCRIPTION
## Changelog
:cl:
fix: fixed being able to continuously sell and buy BZ canisters at a profit
/:cl:
