### PR TITLE
Bug Fixes

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -401,6 +401,7 @@
 	if(copytext(seed.name, 1, 13) == "experimental")
 		return // Already modded name and icon
 	seed.name = "experimental " + seed.name
+	seed.icon = 'icons/obj/hydroponics/seeds.dmi' //hippie edit -- Fixes having invisible experimental seeds due to them using the hippiestation/icons/obj/hydroponics/seeds.dmi file.
 	seed.icon_state = "seed-x"
 
 // Gene modder for seed vault ship, built with high tech alien parts.

--- a/hippiestation/code/modules/detectivework/footprints_and_rag.dm
+++ b/hippiestation/code/modules/detectivework/footprints_and_rag.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/glass/rag/afterattack(obj/A, mob/user,proximity)
+/obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user,proximity)
 	if(!istype(A) || !proximity || !check_allowed_items(A, target_self=1))
 		return
 	if(iscarbon(A) && A.reagents && reagents.total_volume)

--- a/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/hippiestation/code/modules/integrated_electronics/subtypes/smart.dm
@@ -235,7 +235,11 @@
 	brainholder.do_work(6)
 
 /mob/living/brain/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
-	return check_bot_self
+	//They only need the check_bot_self variable for electronic assemblies.
+	if(istype(M, /obj/item/electronic_assembly))
+		return check_bot_self
+
+	return ..()
 
 /obj/item/integrated_circuit/smart/advanced_pathfinder/proc/hippie_xor_decrypt()
 	var/Ps = get_pin_data(IC_INPUT, 4)
@@ -366,4 +370,12 @@
 	paiholder.do_work(6)
 
 /mob/living/silicon/pai/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
-	return check_bot_self
+	//It's only used for these.
+	if(istype(M, /obj/item/electronic_assembly))
+		return check_bot_self
+
+	//They could use these otherwise.
+	if(istype(M, /obj/item/integrated_circuit))
+		return FALSE
+
+	return ..()

--- a/hippiestation/code/modules/surgery/organs/tongue.dm
+++ b/hippiestation/code/modules/surgery/organs/tongue.dm
@@ -25,7 +25,8 @@ GLOBAL_LIST_EMPTY(abductortongue_other)
 			for(var/mob/M in GLOB.dead_mob_list)
 				var/link = FOLLOW_LINK(M, user)
 				to_chat(M, "[link] [rendered]")
-				return ""
+
+		speech_args[SPEECH_MESSAGE] = ""
 
 /obj/item/organ/tongue/abductor/Insert(mob/living/carbon/M, special = 0)	//Hippie add, we add mobs to the global list if they have an abductor tongue so they can get messages
 	..()


### PR DESCRIPTION
## Changelog
:cl:
fix: Someone with an abductor tongue no longer gibbers out loud whatever they said.
fix: Stun nettles, limb flower and butt flower seeds no longer become invisible after you have modified them with a plant DNA manipulator.
fix: You can smother someone with a damp rag again (and touch them too, I suppose).
fix: MMIs and positronic brains now get whatever messages they were supposed to get when they were incapable of doing certain actions.
fix: pAIs can now use their Loudness Booster software once again.
/:cl:

## About The Pull Request
The first issue seemed to be due to the message variable never being set to empty text. If you return empty text, it would only have an impact on the following check:
https://github.com/HippieStation/HippieStation/blob/b550a17f94c20347630b78bdd9a7e0492e15e035/code/modules/mob/living/say.dm#L188
a line above it sends a signal that will call the handle_speech proc, with the sigreturn variable having the value returned by this proc. So, in order to not have any gibbering from abductors, I made it set message to empty text instead of returning empty text to satisfy the check
https://github.com/HippieStation/HippieStation/blob/b550a17f94c20347630b78bdd9a7e0492e15e035/code/modules/mob/living/say.dm#L190
since !message is True when message = "", and this check will make the proc return early. Fixes #12179.

The second one was only limited to these three plants, because they use the hippiestation/icons/obj/hydroponics/seeds.dmi file for the icon states of their seeds, which doesn't have the seed-x icon state any seed will get after you experiment on them with a plant DNA manipulator.
In order to avoid this, I modified the repaint_seed proc to force any experimental seed to use the icons/obj/hydroponics/seeds.dmi path instead.
An alternative would've been to just include the seed-x icon state in the hippiestation/icons/obj/hydroponics/seeds.dmi file, but that seemed redundant when you can also just change the path for the repaint. Fixes #11952 and Fixes #12266.

Damp rags wouldn't let you smother someone with them, because the first variable in the after_attack proc was assumed to be an obj instead of an atom, which will make !istype(A) in the first check be True when A is a carbon. This causes any behaviour that should be done on carbons to never happen, since the proc returns early. When the A variable is assumed to be an atom, !istype(A) will be False for carbons as well.
The variable is straightly copied from the other after_attack proc for damp rags, but the "as obj|area|turf" part probably was only added, because other than carbons, those seem to be affected by damp rags. Fixes #11958.

In the hippiestation/code/modules/integrated_electronics/subtypes/smart.dm file, there are two  canUseTopic procs; one for brain mobs, and another for pAIs. As both only returned the value of the check_bot_self variable, any possible messaging or interaction they should've had with some other topics than the topic of electronic assemblies was removed.
I made the overrides more or less just use the parent proc whenever either doesn't try to use the topic of an electronic assembly, but I also added an additional check in the pAI's overridden canUseTopic proc to make them incapable of interacting with integrated circuits, since the parent proc will not stop this interaction and I assume it shouldn't be possible. Fixes #11504 and Fixes #10494.

From the testing I did (with it being just doing a build with these changes and hosting a local server to test them out), there didn't seem to be any particular issues.

Let me know if I still missed some duplicate issues in relation to some of these fixes or if I should write the canUseTopic procs a bit more differently, since to me at least the one I made for the pAI still seems like it could be written in a better way.

## Why It's Good For The Game
Having these work 'properly' is better than nothing I suppose.
