### PR TITLE
Forge "Shotgun" Caliber Addition

### DIFF
--- a/hippiestation/code/game/objects/items/forged_weapons.dm
+++ b/hippiestation/code/game/objects/items/forged_weapons.dm
@@ -291,7 +291,7 @@
 	desc = "A custom bullet casing designed to be quickly changeable to any caliber"
 	projectile_type = /obj/item/projectile/bullet/forged
 	var/datum/reagent/reagent_type
-	var/static/list/calibers = list("357" = 4.5, "a762" = 5, "n762" = 5, ".50" = 6, "38" = 1.5, "10mm" = 3, "9mm" = 2, "4.6x30mm" = 2, ".45" = 2.5, "a556" = 3.5, "mm195129" = 4.5)
+	var/static/list/calibers = list("357" = 4.5, "a762" = 5, "n762" = 5, ".50" = 6, "38" = 1.5, "10mm" = 3, "9mm" = 2, "4.6x30mm" = 2, ".45" = 2.5, "a556" = 3.5, "mm195129" = 4.5, "shotgun" = 3.5)
 
 
 /obj/item/ammo_casing/forged/proc/assign_properties()//placeholder proc to prevent runtimes, this SHOULD be the only exception to the rule


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
add: Adds the "shotgun" caliber to forged bullets - allowing you to produce custom forged shells!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This allows people to make omegalul spacelube shotgun shells for the wardens shotgun - also 1 brute zombie powder shells for subduing CRIMINALS


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
General good change to forge, allows for more supported weaponry.

soon ill probably add custom rods for the crossbow :spoi:


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
