### PR TITLE
Engraved messages no longer give off light

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -152,8 +152,6 @@
 	var/hash = md5(hidden_message)
 	var/newcolor = copytext(hash, 1, 7)
 	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
-	light_color = "#[newcolor]"
-	set_light(1)
 
 /obj/structure/chisel_message/proc/pack()
 	var/list/data = list()


### PR DESCRIPTION

:cl:
tweak: Engraved messages no longer give off light
/:cl:
