### PR TITLE
T-ray scanners can now find wire breaks

### DIFF
--- a/code/__DEFINES/~hippie_defines/tools.dm
+++ b/code/__DEFINES/~hippie_defines/tools.dm
@@ -1,0 +1,1 @@
+#define TOOL_TRAY		"t_ray"

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -136,6 +136,7 @@
 #include "code\__DEFINES\~hippie_defines\sound.dm"
 #include "code\__DEFINES\~hippie_defines\stat.dm"
 #include "code\__DEFINES\~hippie_defines\subsystems.dm"
+#include "code\__DEFINES\~hippie_defines\tools.dm"
 #include "code\__DEFINES\~hippie_defines\traits.dm"
 #include "code\__DEFINES\~hippie_defines\vv.dm"
 #include "code\__HELPERS\_lists.dm"

--- a/hippiestation/code/game/objects/items/devices/multitool.dm
+++ b/hippiestation/code/game/objects/items/devices/multitool.dm
@@ -2,11 +2,9 @@
 
 //I know copypasting it and overwriting the old procs is a pretty rough thing to do, but hey, it's the simplest and most effective
 /obj/item/multitool/examine(mob/user)
-	..()
+	. = ..()
 	if(selected_io)
-		to_chat(user, "<span class='notice'>Activate [src] to detach the data wire.</span>")
-	if(buffer)
-		to_chat(user, "<span class='notice'>Its buffer contains [buffer].</span>")
+		. += "<span class='notice'>Activate [src] to detach the data wire.</span>"
 
 /obj/item/multitool/attack_self(mob/user)
 	if(selected_io)

--- a/hippiestation/code/game/objects/items/devices/scanners.dm
+++ b/hippiestation/code/game/objects/items/devices/scanners.dm
@@ -51,3 +51,9 @@
 				display += "-"
 			display += copytext(temp, 1 + i*DNA_MUTATION_BLOCKS, DNA_MUTATION_BLOCKS*(1+i) + 1)
 		to_chat(user, "<span class='boldnotice'>- [mut_name] > [display]</span>")
+
+/obj/item/t_scanner
+	tool_behaviour = TOOL_TRAY
+
+/obj/item/t_scanner/adv_mining_scanner
+	tool_behaviour = null

--- a/hippiestation/code/modules/power/cable.dm
+++ b/hippiestation/code/modules/power/cable.dm
@@ -3,7 +3,7 @@
 	amount = 30
 
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null, param_color = null)
-	.=..()
+	. = ..()
 	recipes = list(new/datum/stack_recipe("cable restraints", /obj/item/restraints/handcuffs/cable, 15), new/datum/stack_recipe("noose", /obj/structure/chair/noose, 30, time = 80, one_per_turf = 1, on_floor = 1))
 
 
@@ -19,3 +19,16 @@
 			return
 	else
 		return ..()
+
+/obj/structure/cable/handlecable(obj/item/W, mob/user, params)
+	..()
+	if(W.tool_behaviour == TOOL_TRAY)
+		if(powernet && powernet.cables)	// we need a powernet first
+			for(var/obj/structure/cable/C in powernet.cables)
+				var/turf/T = get_turf(C)
+				if((C.linked_dirs in GLOB.cardinals))
+					for(var/obj/machinery/power/P in T.contents)
+						if(istype(P))
+							return
+					if(get_dist(W,C))
+						W.say("Found a break at [C] [get_dist(W,C)] standard lengths away to the [dir2text(get_dir(W,C))]")


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
add: T-ray scanners can now scan wires and detect breaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Take a t-ray scanner, click a cable on the floor, it tells you if there's a break and how far away it is. 

![image](https://user-images.githubusercontent.com/32651551/71349766-c1a0e000-253d-11ea-90f2-7b686ea8a9e1.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Makes life slightly easier for engineers and gives t-ray scanners another use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
