### PR TITLE
Lavaland Freon

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -13,6 +13,7 @@
 	)
 	restricted_gases = list(
 		/datum/gas/bz=10,
+		/datum/gas/freon=5,
 		/datum/gas/miasma=10,
 		/datum/gas/plasma=0.1,
 		/datum/gas/water_vapor=0.1,


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: lavaland now has a 5% chance to have freon in its atmosphere
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Adds freon to the list of restricted_gases meaning that lavaland has 5% chance to have freon as apart of its atmosphere
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Adds a way to collect freon gass en-mass like miasma or plasma

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
