### PR TITLE
Funny suicide from /tg/

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -126,20 +126,12 @@
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
-		for(var/obj/item/W in H)
-			H.dropItemToGround(W)
-			if(prob(50))
-				step(W, pick(GLOB.alldirs))
 		ADD_TRAIT(H, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		H.bleed_rate = 5
-		H.gib_animation()
-		sleep(3)
-		H.adjustBruteLoss(1000) //to make the body super-bloody
-		H.spawn_gibs()
-		H.spill_organs()
-		H.spread_bodyparts()
-
-	return (BRUTELOSS)
+		H.inflate_gib()
+		return MANUAL_SUICIDE
+	else
+		to_chat(user, "<span class='warning'>There isn't enough pressure in [src] to commit suicide with...</span>")
+	return SHAME
 
 /obj/item/tank/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -33,7 +33,7 @@
 	for(var/mob/M in src)
 		M.forceMove(Tsec)
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
-	throw_hats(500, GLOB.alldirs) // hippie -- Throw our hats all over the place	
+	throw_hats(500, GLOB.alldirs) //hippie edit -- Throw our hats all over the place	
 	. = ..()
 
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -17,15 +17,24 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
-/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
+	addtimer(CALLBACK(src, .proc/gib, null, null, TRUE, TRUE), 25)
+	var/matrix/M = matrix()
+	M.Scale(1.8, 1.2)
+	animate(src, time = 40, transform = M, easing = SINE_EASING)
+
+/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
+	if(safe_gib) // If you want to keep all the mob's items and not have them deleted
+		for(var/obj/item/W in src)
+			dropItemToGround(W)
+			if(prob(50))
+				step(W, pick(GLOB.alldirs))
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)
 		M.forceMove(Tsec)
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
-	
-	throw_hats(500, GLOB.alldirs) // hippie -- Throw our hats all over the place
-		
-	..()
+	throw_hats(500, GLOB.alldirs) // hippie -- Throw our hats all over the place	
+	. = ..()
 
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -130,7 +130,7 @@
 
 /datum/reagent/toxin/minttoxin/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_FAT))
-		M.gib()
+		M.inflate_gib()
 	return ..()
 
 /datum/reagent/toxin/carpotoxin

--- a/html/changelogs/AutoChangeLog-pr-47714.yml
+++ b/html/changelogs/AutoChangeLog-pr-47714.yml
@@ -1,0 +1,5 @@
+author: "SteelSlayer"
+delete-after: True
+changes: 
+  - tweak: "When you suicide using an internals tank, you're character will now inflate, and grow in size before you gib."
+  - code_imp: "Adds a safe_gib argument to the carbon gib proc. Allows you to specifiy if you want to preserve the items on the mob you're gibbing."


### PR DESCRIPTION
Changelog included

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
When you suicide with an internals tank, normally you just fall over and gib immediately. Now you get to see people inflate from inhaling the gas in the tank before they explode. I can still tweak how it looks but this is what I have so far:
![image](https://user-images.githubusercontent.com/42044220/68607138-907cbc80-0475-11ea-9305-c66d6660bf4e.gif)
