### PR TITLE
No more macrobombs for infiltrators

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -236,6 +236,7 @@
 	surplus = 60
 
 /datum/uplink_item/implants/macrobomb
+	exclude_modes = list(/datum/game_mode/infiltration)
 	restricted = FALSE
 
 /datum/uplink_item/dangerous/hockey


### PR DESCRIPTION
:cl:
tweak: No more macrobombs for infiltrators. They were never meant to have them in the first place!!
/:cl:
