### PR TITLE
Removing Statechange Restrictions (Dont close it randomly)

### DIFF
--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT(statechange_reagent_blacklist, typecacheof(list(
 	/datum/reagent/oxygen,
 	/datum/reagent/nitrogen,
 	/datum/reagent/nitrous_oxide,
+	/datum/reagent/toxin/plasma,
 	/datum/reagent/carbondioxide)
 ))
 

--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -26,22 +26,10 @@ GLOBAL_LIST_INIT(no_reagent_statechange_typecache, typecacheof(list(
 ))
 
 GLOBAL_LIST_INIT(statechange_reagent_blacklist, typecacheof(list(
-	/datum/reagent/water,
-	/datum/reagent/toxin/bleach,
-	/datum/reagent/consumable/condensedcapsaicin,
-	/datum/reagent/space_cleaner,
-	/datum/reagent/smoke_powder,
-	/datum/reagent/consumable/sugar,
-	/datum/reagent/thermite,
-	/datum/reagent/toxin/plasma,
-	/datum/reagent/radium,
 	/datum/reagent/oxygen,
 	/datum/reagent/nitrogen,
 	/datum/reagent/nitrous_oxide,
-	/datum/reagent/carbondioxide,
-	/datum/reagent/cryostylane,
-	/datum/reagent/consumable/ethanol/neurotoxin,
-	/datum/reagent/mutationtoxin)
+	/datum/reagent/carbondioxide)
 ))
 
 GLOBAL_LIST_INIT(vaporchange_reagent_blacklist, typecacheof(list(

--- a/hippiestation/code/_globalvars/lists/typecache.dm
+++ b/hippiestation/code/_globalvars/lists/typecache.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_INIT(statechange_reagent_blacklist, typecacheof(list(
 	/datum/reagent/nitrogen,
 	/datum/reagent/nitrous_oxide,
 	/datum/reagent/toxin/plasma,
+	/datum/reagent/smoke_powder,
 	/datum/reagent/carbondioxide)
 ))
 


### PR DESCRIPTION
Changelog
🆑
del: removed most reagents (other than gases) from the statechange blacklist. However, mutation toxin and etc are still blacklisted from vapour form.
/🆑

About The Pull Request
Since the old PR was closed 4noraisin, here it is again. Re-enables a bunch of unreasonably restricted chemicals from both statechanging and forging.

Why It's Good For The Game
After a bit of testing, and proving my point, it was determined that with various forged weaponry changes, chemical changes etc and how reagents were proccessed had been changed that re-enabling some restricted chemicals would no longer do the nono.