### PR TITLE
Upgrade pygit2 dependency to v1.0.1

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==0.28.2
+pygit2==1.0.1
 bidict==0.18.3
 Pillow==6.2.1


### PR DESCRIPTION
B-because /tg/ did it: https://github.com/tgstation/tgstation/pull/48693

Will allow Python 3.8 to work