### PR TITLE
Fixes garrote recipe

### DIFF
--- a/hippiestation/code/game/objects/items/garrote.dm
+++ b/hippiestation/code/game/objects/items/garrote.dm
@@ -10,8 +10,8 @@
 
 /obj/item/garrotehandles/attackby(obj/item/I, mob/user, params)
 	..()
-	if(istype(I, /obj/item/stack/pipe_cleaner_coil))
-		var/obj/item/stack/pipe_cleaner_coil/R = I
+	if(istype(I, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/R = I
 		if (R.use(20))
 			var/obj/item/garrote/W = new /obj/item/garrote
 			if(!remove_item_from_storage(user))


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
fix: Garrotes are now properly able to be crafted using cable coils
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Title. So when pipe cleaners got introduced, they somehow modified this recipe to use them and require a stack of 20, which apparently is impossible to obtain, this PR fixes it by changing the recipe back to the original.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Garrotes work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
