### PR TITLE
Fixes bad reference to deepfry

### DIFF
--- a/hippiestation/code/modules/mob/living/simple_animal/gremlin/gremlin_act.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/gremlin/gremlin_act.dm
@@ -118,7 +118,7 @@
 	attack_hand(L)
 
 
-/obj/machinery/cooking/deepfryer/npc_tamper_act(mob/living/L)
+/obj/machinery/deepfryer/npc_tamper_act(mob/living/L)
 	//Deepfry a random nearby item
 	var/list/pickable_items = list()
 


### PR DESCRIPTION
Title, allows gremlins to tamper with them once more.