### PR TITLE
Makes hippiestation logo burn away properly

### DIFF
--- a/hippiestation/code/game/turfs/simulated/floor.dm
+++ b/hippiestation/code/game/turfs/simulated/floor.dm
@@ -21,6 +21,14 @@
 /turf/open/floor/plasteel/logo
 	icon = 'hippiestation/icons/turf/floors.dmi'
 
+/turf/open/floor/plasteel/logo/break_tile()
+	icon = 'icons/turf/floors.dmi'
+	..()
+
+/turf/open/floor/plasteel/logo/burn_tile()
+	icon = 'icons/turf/floors.dmi'
+	..()
+
 /turf/open/floor/plasteel/logo/l1
 	icon_state = "L1"
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
fix: Hippiestation floor tiles are now flammable!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Makes the hippiestation logo outside of bridge not turn black or default texture when burned
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because muh immersion and bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
