### PR TITLE
toxin_reagent.dm runtime fix

### DIFF
--- a/hippiestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -277,6 +277,8 @@
 	..()
 
 /datum/reagent/toxin/acid/hydrazine/process()
+	if(!data)
+		data = list("misc" = 1)
 	if(holder)
 		data["misc"]++
 		if(prob(2) && data > 40) //randomly creates small explosions or fireballs but has a delay so it doesn't just kill people while they're still mixing


### PR DESCRIPTION
Title. Runtime in toxin_reagents.dm, line 281: bad index