### PR TITLE
Fixes map rotation chance delta config

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -383,7 +383,7 @@ PREFERENCE_MAP_VOTING 1
 ## This is the chance of map rotation factored to the round length.
 ## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
-#MAPROTATIONCHANCEDELTA 0.75
+#MAPROTATECHANCEDELTA 0.75
 
 ## AUTOADMIN
 ## The default admin rank


### PR DESCRIPTION

## About The Pull Request
`/datum/config_entry/number/maprotatechancedelta` and the config was `MAPROTATIONCHANCEDELTA`
`Unknown setting in configuration: 'maprotationchancedelta'`
lul