### PR TITLE
Makes cult actually have a pop requirement.

### DIFF
--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -143,6 +143,7 @@
 /datum/dynamic_ruleset/roundstart/bloodcult
 	restricted_roles = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Vice Officer")
 	weight = 30
+	high_population_requirement = 10
 
 /datum/dynamic_ruleset/roundstart/infiltrator
 	name = "Infiltration Unit"


### PR DESCRIPTION
As shown by this: http://forums.hippiestation.com/viewtopic.php?f=7&t=2131

Lowpop cult is not bearable and is very boring if some guy will just murderbone everyone. There is also the problem of having less than 9 players on the server at once, which means even though cult WILL be rolled, the cultists won't be able to summon Nar'Sie properly.