### PR TITLE
Comments out some ruins

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -1,5 +1,5 @@
 // Hey! Listen! Update \config\lavaruinblacklist.txt with your new ruins!
-
+// Some ruins will be commented out, simply uncomment them to have them reimplemented.
 /datum/map_template/ruin/lavaland
 	prefix = "_maps/RandomRuins/LavaRuins/"
 
@@ -7,12 +7,14 @@
 	cost = 5
 	allow_duplicates = FALSE
 
+/*
 /datum/map_template/ruin/lavaland/biodome/beach
 	name = "Biodome Beach"
 	id = "biodome-beach"
 	description = "Seemingly plucked from a tropical destination, this beach is calm and cool, with the salty waves roaring softly in the background. \
 	Comes with a rustic wooden bar and suicidal bartender."
 	suffix = "lavaland_biodome_beach.dmm"
+*/
 
 /datum/map_template/ruin/lavaland/biodome/winter
 	name = "Biodome Winter"
@@ -70,6 +72,7 @@
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
 
+/*
 /datum/map_template/ruin/lavaland/animal_hospital
 	name = "Animal Hospital"
 	id = "animal-hospital"
@@ -77,6 +80,7 @@
 	cost = 5
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
+*/
 
 /datum/map_template/ruin/lavaland/sin
 	cost = 10

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -16,6 +16,14 @@
 	suffix = "lavaland_biodome_beach.dmm"
 */
 
+/datum/map_template/ruin/lavaland/dwarves
+	name = "Dwarven Settlement"
+	id = "dwarves"
+	description = "A settlement of dwarves from a strange faraway land."
+	suffix = "lavaland_surface_dwarves.dmm"
+	always_place = FALSE
+	allow_duplicates = FALSE
+
 /datum/map_template/ruin/lavaland/biodome/winter
 	name = "Biodome Winter"
 	id = "biodome-winter"


### PR DESCRIPTION
:cl:
del: Beach ruins and animal hospital ruins have been commented out of code. They will no longer spawn.
code: Dwarf ruins have been added to the lavaland ruins spawner file, however it will not spawn as of yet.
/:cl:

This PR comments out the beach bum ruins and the animal hospital ruins so that they will not spawn during normal rounds. They are **not** removed from code since that was extremely unpopular, just commented out. For transparency I will point out that the template code for Dwarves is also being added in this same PR. This will not change or affect anything in round, as it is just giving me the framework to implement it more easily later. It is currently set to false so it will spawn nothing (also the map file for the dwarves ruin does not exist in this PR so even if it was true it would spawn nothing.)