### PR TITLE
removes stand arrow ruin but actually works

### DIFF
--- a/hippiestation/code/datums/ruins/lavaland.dm
+++ b/hippiestation/code/datums/ruins/lavaland.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/lavaland/stand_arrow
+/*/datum/map_template/ruin/lavaland/stand_arrow
 	name = "Mysterious Attic"
 	id = "guardian-arrow"
 	suffix = "lavaland_surface_stand.dmm"
@@ -9,7 +9,7 @@
 	..()
 	if(prob(1))
 		allow_duplicates = TRUE
-
+*/
 /area/ruin/powered/stand_ruin
 	name = "Mysterious Attic"
 	icon_state = "dk_yellow"


### PR DESCRIPTION
the same as #12532 but can actually place the end of comment in a place that wont break the game
🆑
del: removes stand arrow ruin
/🆑