### PR TITLE
Firefix

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -227,6 +227,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(resistance_flags & ON_FIRE)
 		resistance_flags &= ~ON_FIRE
 		cut_overlay(GLOB.fire_overlay, TRUE)
+		update_icon()
 		SSfire_burning.processing -= src
 
 /obj/proc/tesla_act(power, tesla_flags, shocked_targets)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -859,6 +859,7 @@
 		var/obj/item/I = X
 		I.acid_level = 0 //washes off the acid on our clothes
 		I.extinguish() //extinguishes our clothes
+		I.cut_overlay(GLOB.fire_overlay, TRUE)
 	..()
 
 /mob/living/carbon/fakefire(var/fire_icon = "Generic_mob_burning")


### PR DESCRIPTION
Fixes #42800 as far as I'm aware.
So from what I understand, clothes sprites were working when they extinguished immediately after catching fire. But, when your clothes catch fire and get the damage overlay as well, they weren't losing the burning overlay, ever. Solution may be a bit hacky, but it seems to work in all cases, including throwing burning clothes onto showers, and individually extinguishing burning clothes.
Port from: https://github.com/tgstation/tgstation/pull/50062

Why It's Good For The Game
Bugs bad.

Changelog
🆑ArcaneMusic
fix: Burning clothes no longer burn forever if you're set on fire for too long.
/🆑