### PR TITLE
Clown Office Cap Gun

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -12486,6 +12486,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/toy/gun{
+	name = "35.7 Rovolber !TM!"
+	},
 /turf/open/floor/plasteel,
 /area/hippie/clown)
 "aJw" = (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48893662/77219161-62854400-6b09-11ea-9a33-5a16655c2d88.png)

## Changelog
:cl: Carlospaul
add: the Clown Office now has a cap gun for ePiC pRaNkS
/:cl:

## Why It's Good For The Game
pranking
