### PR TITLE
Airlocks autoclose on power on

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -387,3 +387,8 @@
 
 /obj/machinery/door/GetExplosionBlock()
 	return density ? real_explosion_block : 0
+
+/obj/machinery/door/power_change()
+	. = ..()
+	if(. && !(machine_stat & NOPOWER))
+		autoclose_in(rand(0.5 SECONDS, 3 SECONDS))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -390,5 +390,5 @@
 
 /obj/machinery/door/power_change()
 	. = ..()
-	if(. && !(machine_stat & NOPOWER))
+	if(. && !(stat & NOPOWER))
 		autoclose_in(rand(0.5 SECONDS, 3 SECONDS))

--- a/html/changelogs/AutoChangeLog-pr-50115.yml
+++ b/html/changelogs/AutoChangeLog-pr-50115.yml
@@ -1,0 +1,4 @@
+author: "Dennok"
+delete-after: True
+changes: 
+  - tweak: "Airlocks now try close self on power up."


### PR DESCRIPTION
Ported w/ changelogs from tg: https://github.com/tgstation/tgstation/pull/50115

Title, when power gets restored to an area, any open airlocks will now close.