### PR TITLE
Magical Item Room (2nd PR)

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -10563,14 +10563,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aDQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aDR" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -10992,14 +10984,11 @@
 /area/maintenance/starboard/fore)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/chapel/office)
 "aFh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
@@ -11865,30 +11854,37 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/chapel/office)
 "aHK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/power/apc{
-	areastring = "/area/chapel/main";
-	name = "Chapel APC";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood/fancy,
+/obj/item/nullrod{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/soulstone/anybody/chaplain{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/chapel/office)
 "aHM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12487,7 +12483,7 @@
 	dir = 8
 	},
 /obj/item/toy/gun{
-	name = "35.7 Rovolber !TM!"
+	name = "3.57 Rovolber !TM!"
 	},
 /turf/open/floor/plasteel,
 /area/hippie/clown)
@@ -12930,15 +12926,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aKA" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
 	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aKB" = (
 /obj/machinery/light_switch{
@@ -12953,6 +12943,9 @@
 "aKC" = (
 /obj/machinery/airalarm{
 	pixel_y = 25
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -14196,7 +14189,6 @@
 "aNK" = (
 /obj/structure/table/wood,
 /obj/item/pen,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14207,7 +14199,6 @@
 /area/chapel/office)
 "aNL" = (
 /obj/structure/table/wood,
-/obj/item/nullrod,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -49050,6 +49041,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dgM" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp{
+	pixel_y = 10
+	},
+/obj/item/clothing/shoes/bronze/slow,
+/obj/item/clothing/head/helmet/redtaghelm/afromaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "diE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -49835,6 +49838,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"etJ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/chapel/main";
+	name = "Chapel APC";
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "euG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -50243,6 +50264,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"fcR" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/chapel/office)
 "fdf" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -53281,6 +53306,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"jSu" = (
+/obj/machinery/door/morgue{
+	name = "Magical Item Storage";
+	req_access_txt = "22"
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/chapel/office)
 "jTb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55380,6 +55414,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nlE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -56529,6 +56570,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"pgZ" = (
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/office)
 "phb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -59375,6 +59424,16 @@
 /obj/item/seeds/cannabis,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ubw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ubL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59812,6 +59871,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uME" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "uOy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -106247,7 +106311,7 @@ ajz
 ajz
 ajz
 azL
-nhZ
+etJ
 ajz
 aIR
 aIR
@@ -106499,8 +106563,8 @@ alO
 alO
 ajz
 azP
-awA
-alO
+nlE
+axw
 tVk
 aFf
 aFf
@@ -106757,7 +106821,7 @@ alO
 ajz
 azQ
 alO
-azI
+arm
 tVk
 alO
 alO
@@ -107017,7 +107081,7 @@ aBf
 aBf
 aBf
 aBf
-aBf
+fcR
 aHJ
 aIR
 aIR
@@ -107271,10 +107335,10 @@ ajz
 ajz
 szb
 aBh
+ubw
 aBh
-aDQ
 aFg
-aBh
+aFg
 aHK
 aIR
 aKz
@@ -107529,16 +107593,16 @@ alO
 oFf
 alO
 auo
-tVk
-avs
-atn
-aHL
+uME
 aIR
+dgM
+aHL
+jSu
 aKA
 aMd
 aNK
 aPh
-aKD
+pgZ
 aIR
 aGu
 aGu

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -12486,6 +12486,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/toy/gun{
+	name = "35.7 Rovolber !TM!"
+	},
 /turf/open/floor/plasteel,
 /area/hippie/clown)
 "aJw" = (

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -12482,9 +12482,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/toy/gun{
-	name = "3.57 Rovolber !TM!"
-	},
 /turf/open/floor/plasteel,
 /area/hippie/clown)
 "aJw" = (

--- a/hippiestation/code/modules/clothing/head/helmet.dm
+++ b/hippiestation/code/modules/clothing/head/helmet.dm
@@ -12,3 +12,14 @@
 	icon = 'hippiestation/icons/obj/clothing/hats.dmi'
 	alternate_worn_icon = 'hippiestation/icons/mob/head.dmi'
 	alternate_screams = list('hippiestation/sound/voice/stop_right_there.ogg', 'hippiestation/sound/voice/stop_right_there2.ogg')
+
+/obj/item/clothing/head/helmet/redtaghelm/afromaker
+	name = "Afro Maker"
+	desc = "To wear this helmet is to accept its creator."
+	color = "#FF0000"
+	resistance_flags = INDESTRUCTIBLE
+/obj/item/clothing/head/helmet/redtaghelm/afromaker/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if(slot == SLOT_HEAD)
+		user.hair_style = "Afro (Large)"
+		user.update_hair()

--- a/hippiestation/code/modules/clothing/shoes/shoes.dm
+++ b/hippiestation/code/modules/clothing/shoes/shoes.dm
@@ -19,3 +19,9 @@
 	icon = 'hippiestation/icons/mob/feet.dmi'
 	icon_state = "dress-white"
 	item_color = "dress-white"
+
+/obj/item/clothing/shoes/bronze/slow
+    name = "Ratvar's Boots of Deceleration"
+    desc = "A cruel joke forged by the machine god himself. Just looking at them makes you feel lethargic."
+    slowdown = SHOES_SLOWDOWN+4
+    resistance_flags = INDESTRUCTIBLE


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48893662/77720474-69ef9600-6fbe-11ea-9a5e-124e028afc87.png)

## Changelog
:cl: Carlospaul
added: Chapel now has a Magical Item Storage. 
added: New helmet: The Afro Maker (Assisted by Yoyobatty)
added: New shoes: Ratvar's Boots of Deceleration (Assisted by Protozoa)
/:cl:

### Why It's Good For the Game
Chaplain should have more magic items available to him besides a null rod, flask of holy ass, and holy book. 

### Items in the room
- Chaplain's null rod
- Flask of holy water
- mysterious old shard (1 use soul shard) 
- Afro Maker
- Ratvar's Boots of Deceleration