### PR TITLE
You can now quick swap worn equipment

### DIFF
--- a/hippiestation/code/modules/mob/inventory.dm
+++ b/hippiestation/code/modules/mob/inventory.dm
@@ -3,3 +3,15 @@
 	items |= get_equipped_items(TRUE)
 	for(var/I in items)
 		dropItemToGround(I, force)
+
+/mob/living/quick_equip()
+	var/obj/item/I = get_active_held_item()
+	if (I)
+		if(!equip_to_appropriate_slot(I))
+			for(var/obj/item/inv in get_equipped_items())
+				if(I.slot_flags & inv.slot_flags)
+					if(putItemFromInventoryInHandIfPossible(inv, get_inactive_hand_index()))
+						I.equip_to_best_slot(src)
+						return
+		else
+			update_inv_hands()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
add: You can quick equip to swap worn items if you have at least 1 empty hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
What it says on the tin. Wear a bag, hold one in your can and quick equip, bags will be swapped but the one worn one gets placed in your inactive hand, you need 2 hands to do this operation after all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Makes it a little more friendly to newer players and doesn't mess with the original quick equip.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
