### PR TITLE
Safety Doors port from TG(#46332)

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -55187,7 +55187,8 @@
 /area/maintenance/port/aft)
 "mOQ" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -55438,7 +55439,8 @@
 /area/engine/port_engineering)
 "nkD" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -57208,7 +57210,8 @@
 /area/medical/medbay/central)
 "qlb" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -58305,7 +58308,8 @@
 	})
 "skg" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -36,6 +36,7 @@
 	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
+	var/safety_mode = FALSE ///Whether or not the airlock can be opened with bare hands while unpowered
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -46,6 +47,8 @@
 			. += "<span class='notice'>In the event of a red alert, its access requirements will automatically lift.</span>"
 	if(!poddoor)
 		. += "<span class='notice'>Its maintenance panel is <b>screwed</b> in place.</span>"
+	if(safety_mode)
+		. += "<span class='notice'>It has labels indicating that it has an emergency mechanism to open it with <b>just your hands</b> if there's no power.</span>"
 
 /obj/machinery/door/check_access_list(list/access_list)
 	if(red_alert_access && GLOB.security_level >= SEC_LEVEL_RED)
@@ -79,6 +82,14 @@
 		spark_system = null
 	return ..()
 
+/obj/machinery/door/proc/try_safety_unlock(mob/user)
+	if(safety_mode && !hasPower() && density)
+		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
+		if(do_after(user, 15 SECONDS, target = src))
+			try_to_crowbar(null, user)
+			return TRUE
+	return FALSE
+
 /obj/machinery/door/Bumped(atom/movable/AM)
 	. = ..() // hippie -- port bumped comsig for better guardian booms
 	if(operating || (obj_flags & EMAGGED))
@@ -93,6 +104,8 @@
 				return	//Can bump-open one airlock per second. This is to prevent shock spam.
 			M.last_bumped = world.time
 			if(M.restrained() && !check_access(null))
+				return
+			if(try_safety_unlock(M))
 				return
 			bumpopen(M)
 			return
@@ -133,8 +146,8 @@
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)
 		return
-	src.add_fingerprint(user)
-	if(!src.requiresID())
+	add_fingerprint(user)
+	if(!requiresID())
 		user = null
 
 	if(density && !(obj_flags & EMAGGED))
@@ -147,6 +160,8 @@
 /obj/machinery/door/attack_hand(mob/user)
 	. = ..()
 	if(.)
+		return
+	if(try_safety_unlock(user))	
 		return
 	return try_to_activate_door(user)
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -26,6 +26,7 @@
 	var/nextstate = null
 	var/boltslocked = TRUE
 	var/list/affecting_areas
+	safety_mode = TRUE
 
 /obj/machinery/door/firedoor/Initialize()
 	. = ..()


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
add: Firelocks and arrivals shuttle airlocks now have a safety mechanism to open them in a power outage, simply use your hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Port of this https://github.com/tgstation/tgstation/pull/46332 but applies to firelocks and our main map.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
No stuck.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
