### PR TITLE
Adds gravity room to the power failure safe areas

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -3,7 +3,8 @@
 GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
 															    /area/engine/supermatter, \
 															    /area/engine/atmospherics_engine, \
-															    /area/ai_monitored/turret_protected/ai))
+															    /area/ai_monitored/turret_protected/ai, \
+																/area/engine/gravity_generator)) // hippie edit -- adds gravity room
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs


### PR DESCRIPTION
## Changelog
:cl: Neotw
tweak: Gravity will no longer be affected during the power failure event
/:cl:

## About The Pull Request
see changelog

## Why It's Good For The Game
yes
