### PR TITLE
Blackmarket multitool fix

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -204,33 +204,6 @@
 		visible_message("<span class='notice'>[src] fails to expand!</span>")
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/living/M)
-	M.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
-	var/eating_success = do_after(M, 10, TRUE, src, TRUE)
-	if(QDELETED(M)) //qdeletion: the nuclear option of self-harm
-		return SHAME
-	if(!eating_success || QDELETED(src)) //checks if src is gone or if they failed to wait for a second
-		M.visible_message("<span class='suicide'>[M] chickens out!</span>")
-		return SHAME
-	if(HAS_TRAIT(M, TRAIT_NOHUNGER)) //plasmamen don't have saliva/stomach acid
-		M.visible_message("<span class='suicide'>[M] realizes [M.p_their()] body won't activate [src]!</span>"
-		,"<span class='warning'>Your body won't activate [src]...</span>")
-		return SHAME
-	playsound(M, 'sound/items/eatfood.ogg', rand(10,50), TRUE)
-	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
-	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
-	return MANUAL_SUICIDE
-
-/obj/item/reagent_containers/food/snacks/monkeycube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
-	if(QDELETED(M) || QDELETED(src))
-		return
-	if((src.loc != M)) //how the hell did you manage this
-		to_chat(M, "<span class='warning'>Something happened to [src]...</span>")
-		return
-	Expand()
-	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
-	M.gib(null, TRUE, null, TRUE)
-
 /obj/item/reagent_containers/food/snacks/monkeycube/syndicate
 	faction = list("neutral", ROLE_SYNDICATE)
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -204,6 +204,33 @@
 		visible_message("<span class='notice'>[src] fails to expand!</span>")
 	qdel(src)
 
+/obj/item/reagent_containers/food/snacks/monkeycube/suicide_act(mob/living/M)
+	M.visible_message("<span class='suicide'>[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!</span>")
+	var/eating_success = do_after(M, 10, TRUE, src, TRUE)
+	if(QDELETED(M)) //qdeletion: the nuclear option of self-harm
+		return SHAME
+	if(!eating_success || QDELETED(src)) //checks if src is gone or if they failed to wait for a second
+		M.visible_message("<span class='suicide'>[M] chickens out!</span>")
+		return SHAME
+	if(HAS_TRAIT(M, TRAIT_NOHUNGER)) //plasmamen don't have saliva/stomach acid
+		M.visible_message("<span class='suicide'>[M] realizes [M.p_their()] body won't activate [src]!</span>"
+		,"<span class='warning'>Your body won't activate [src]...</span>")
+		return SHAME
+	playsound(M, 'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
+	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
+	return MANUAL_SUICIDE
+
+/obj/item/reagent_containers/food/snacks/monkeycube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
+	if(QDELETED(M) || QDELETED(src))
+		return
+	if((src.loc != M)) //how the hell did you manage this
+		to_chat(M, "<span class='warning'>Something happened to [src]...</span>")
+		return
+	Expand()
+	M.visible_message("<span class='danger'>[M]'s torso bursts open as a primate emerges!</span>")
+	M.gib(null, TRUE, null, TRUE)
+
 /obj/item/reagent_containers/food/snacks/monkeycube/syndicate
 	faction = list("neutral", ROLE_SYNDICATE)
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -320,5 +320,4 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/bbqsauce = 5)
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("meat" = 3, "smokey sauce" = 1)
-	
 	foodtype = MEAT

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -320,4 +320,5 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/bbqsauce = 5)
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("meat" = 3, "smokey sauce" = 1)
+	
 	foodtype = MEAT

--- a/hippiestation/code/game/objects/items/devices/multitool.dm
+++ b/hippiestation/code/game/objects/items/devices/multitool.dm
@@ -77,6 +77,4 @@
 
 /obj/item/multitool/syndicate/update_icon() //this seems redundant but pretty sure it will stop it from becoming invisible when clicked
 	if(selected_io)
-		icon_state = "multitool_nuke"
-	else
-		icon_state = "multitool_nuke"
+		return

--- a/hippiestation/code/game/objects/items/devices/multitool.dm
+++ b/hippiestation/code/game/objects/items/devices/multitool.dm
@@ -74,3 +74,9 @@
 	icon = 'hippiestation/icons/obj/tools.dmi'
 	icon_state = "multitool_nuke"
 	toolspeed = 0.5
+
+/obj/item/multitool/syndicate/update_icon() //this seems redundant but pretty sure it will stop it from becoming invisible when clicked
+	if(selected_io)
+		icon_state = "multitool_nuke"
+	else
+		icon_state = "multitool_nuke"

--- a/hippiestation/code/modules/clothing/outfits/ert.dm
+++ b/hippiestation/code/modules/clothing/outfits/ert.dm
@@ -3,7 +3,7 @@
 	uniform = /obj/item/clothing/under/syndicate/tacticool
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/headset_cent/commander
+	ears = /obj/item/radio/headset/headset_cent/alt
 	back = /obj/item/storage/backpack/ert
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/card/id/ert

--- a/hippiestation/code/modules/clothing/outfits/ert.dm
+++ b/hippiestation/code/modules/clothing/outfits/ert.dm
@@ -3,7 +3,7 @@
 	uniform = /obj/item/clothing/under/syndicate/tacticool
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/headset_cent/alt
+	ears = /obj/item/radio/headset/headset_cent/commander
 	back = /obj/item/storage/backpack/ert
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/card/id/ert


### PR DESCRIPTION
:cl:
fix: Black market multitool will no longer become invisible when clicked.
/:cl:

pretty sure the BM multitool was inheriting properties from the other multitool. All I did was copy the proc for selection and specify a black market variation and have it keep the icon the same when selected/clicked. This **_should_** fix the issue.
