### PR TITLE
syndicate firesuit description fix

### DIFF
--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -121,7 +121,7 @@
 	name = "Syndicate Firesuit"
 	desc = "A less heavy, armored version of the common firesuit developed by a now-defunct, \
 	Syndicate-affiliated collective with a penchant for arson. It offers complete fireproofing, \
-	spaceproofing, the added bonus of not slowing the wearer while equipped and it fits into any backpack. \
+	the added bonus of not slowing the wearer while equipped and it fits into any backpack. \
 	Comes in conspicuous red/orange colors. Helmet included."
 	cost = 4
 	item = /obj/item/storage/box/syndie_kit/firesuit/
@@ -395,7 +395,7 @@
 	item = /obj/item/storage/box/syndie_kit/nanosuit
 	cost = 20
 	surplus = 10
-	cant_discount = TRUE	
+	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration)
 
 /datum/uplink_item/dangerous/synth

--- a/hippiestation/code/modules/uplink/uplink_items.dm
+++ b/hippiestation/code/modules/uplink/uplink_items.dm
@@ -121,7 +121,7 @@
 	name = "Syndicate Firesuit"
 	desc = "A less heavy, armored version of the common firesuit developed by a now-defunct, \
 	Syndicate-affiliated collective with a penchant for arson. It offers complete fireproofing, \
-	the added bonus of not slowing the wearer while equipped and it fits into any backpack. \
+	the added bonus of not slowing the wearer while equipped, and it fits into any backpack. \
 	Comes in conspicuous red/orange colors. Helmet included."
 	cost = 4
 	item = /obj/item/storage/box/syndie_kit/firesuit/


### PR DESCRIPTION
:cl:
spellcheck: Previously syndicate firesuit description incorrectly stated it was spaceproof. The description has been corrected.
/:cl:

Fixes: #10683