### PR TITLE
Adds character limit to stripped inputs

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -419,7 +419,7 @@
 
 	if(D.symptoms.len > 0)
 
-		var/new_name = stripped_input(user, "Name your new disease.", "New Name", max_length = MAX_NAME_LEN)
+		var/new_name = stripped_input(user, "Name your new disease.", "New Name", max_length = MAX_CHARTER_LEN)
 		if(!new_name)
 			return
 		D.AssignName(new_name)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -419,7 +419,7 @@
 
 	if(D.symptoms.len > 0)
 
-		var/new_name = stripped_input(user, "Name your new disease.", "New Name")
+		var/new_name = stripped_input(user, "Name your new disease.", "New Name", max_length = MAX_NAME_LEN)
 		if(!new_name)
 			return
 		D.AssignName(new_name)

--- a/code/game/gamemodes/sandbox/airlock_maker.dm
+++ b/code/game/gamemodes/sandbox/airlock_maker.dm
@@ -78,7 +78,7 @@
 		return
 
 	if("rename" in href_list)
-		var/newname = stripped_input(usr,"New airlock name:","Name the airlock", doorname, max_length = MAX_NAME_LEN)
+		var/newname = stripped_input(usr,"New airlock name:","Name the airlock", doorname, max_length = MAX_CHARTER_LEN)
 		if(newname)
 			doorname = newname
 	if("access" in href_list)

--- a/code/game/gamemodes/sandbox/airlock_maker.dm
+++ b/code/game/gamemodes/sandbox/airlock_maker.dm
@@ -78,7 +78,7 @@
 		return
 
 	if("rename" in href_list)
-		var/newname = stripped_input(usr,"New airlock name:","Name the airlock",doorname)
+		var/newname = stripped_input(usr,"New airlock name:","Name the airlock", doorname, max_length = MAX_NAME_LEN)
 		if(newname)
 			doorname = newname
 	if("access" in href_list)

--- a/hippiestation/code/game/objects/items/execution_sword.dm
+++ b/hippiestation/code/game/objects/items/execution_sword.dm
@@ -31,7 +31,7 @@ obj/item/melee/execution_sword/attack_self(mob/living/user)
 			return
 
 		if(custom_faction == "Yes")
-			execution_faction = stripped_input(user, "Insert your new faction", "Faction", max_length = MAX_NAME_LEN)
+			execution_faction = stripped_input(user, "Insert your new faction", "Faction", max_length = MAX_BROADCAST_LEN)
 			faction_chosen = TRUE
 	..()
 

--- a/hippiestation/code/game/objects/items/execution_sword.dm
+++ b/hippiestation/code/game/objects/items/execution_sword.dm
@@ -1,5 +1,5 @@
 #define EXECUTE_INFIDEL 300
-#define EXECUTE_COOLDOWN 50
+#define EXECUTE_COOLDOWN 100
 
 /obj/item/melee/execution_sword
 	name = "Executioners sword"
@@ -31,7 +31,7 @@ obj/item/melee/execution_sword/attack_self(mob/living/user)
 			return
 
 		if(custom_faction == "Yes")
-			execution_faction = stripped_input(user, "Insert your new faction", "Faction")
+			execution_faction = stripped_input(user, "Insert your new faction", "Faction", max_length = MAX_NAME_LEN)
 			faction_chosen = TRUE
 	..()
 


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: Centcom now forbids extra long names of viruses and executioners swords 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Basically limits how long you can now diseases, airlocks and executioners swords because they were too easily spammed and overfilled the chat with extra long names that made no sense.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Less stress on chat and reduces unreadable garbage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
