### PR TITLE
Fixed forged weapon equipping being broken

### DIFF
--- a/hippiestation/code/game/objects/items/forged_weapons.dm
+++ b/hippiestation/code/game/objects/items/forged_weapons.dm
@@ -75,7 +75,7 @@
 	icon_state = "forged_sword"
 	item_state = "forged_sword"
 	alternate_worn_icon = 'hippiestation/icons/mob/belt.dmi'
-	slot_flags = SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	weapon_type = MELEE_TYPE_SWORD
 	stabby = TRANSFER_SHARPER
@@ -90,7 +90,7 @@
 	icon_state = "forged_mace"
 	item_state = "forged_mace"
 	alternate_worn_icon = 'hippiestation/icons/mob/belt.dmi'
-	slot_flags = SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'hippiestation/sound/misc/crunch.ogg'
 	weapon_type = MELEE_TYPE_MACE
 	stabby = TRANSFER_PARTIALLY_BLUNT


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
fix: Fixed forged weapon equipping being broken
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
This PR fixes the bug that caused forged weapons to be equippable on every slot, breaking not just them, but also any attempt at sprotes. Someone literally only missed "ITEM_" causing this whole behavior. 2 year old open bug fixed.

Closes #8957 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Bug fixes fix bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
