### PR TITLE
Animal Husbandry in Hydroponics Maint

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -8342,6 +8342,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awy" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window,
+/obj/item/stack/ducttape,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -10150,10 +10155,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aCy" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aCB" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
@@ -10527,19 +10528,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aDL" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "aDM" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "aDN" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -11251,25 +11249,6 @@
 /obj/machinery/atmospherics/components/binary/valve/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGc" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aGd" = (
-/obj/structure/cable,
-/obj/structure/grille/broken,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/fore)
 "aGf" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -11286,6 +11265,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aGl" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "aGp" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba,
@@ -12240,8 +12223,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "aIN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12799,21 +12782,18 @@
 /area/maintenance/starboard/fore)
 "aKk" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aKl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aKn" = (
 /obj/structure/disposalpipe/segment{
@@ -12831,28 +12811,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aKp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aKq" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -13464,7 +13438,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aLO" = (
 /obj/structure/cable,
@@ -13479,7 +13454,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aLP" = (
 /obj/structure/cable,
@@ -13492,7 +13467,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/sign/departments/botany{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aLQ" = (
 /obj/structure/cable,
@@ -13507,7 +13488,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/applejack{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/apple/gold{
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aLR" = (
 /turf/closed/wall,
@@ -14102,7 +14091,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aNz" = (
 /obj/structure/table,
@@ -49506,6 +49495,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"dNC" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "dNP" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -49597,6 +49589,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dXk" = (
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "dXt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -49953,6 +49949,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ezY" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "eAI" = (
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -50208,6 +50210,13 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/longface)
+"eYz" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "eYA" = (
 /obj/machinery/vending/cart/old,
 /turf/open/floor/plating,
@@ -50401,6 +50410,10 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
+"fiA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "fiF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -50961,7 +50974,7 @@
 	name = "Service Hall APC";
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ggz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -51236,8 +51249,9 @@
 "gBw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
-/obj/item/shovel/spade,
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/plantbgone,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "gCc" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -51320,6 +51334,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"gJx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "gKo" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51535,7 +51555,7 @@
 /area/construction/mining/aux_base)
 "hhz" = (
 /obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "hic" = (
 /obj/structure/cable,
@@ -51549,7 +51569,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "hii" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52321,6 +52341,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ixp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "iyD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -53022,7 +53046,7 @@
 "jxZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "jyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53713,6 +53737,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"kzh" = (
+/obj/machinery/biogenerator{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "kzB" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -53831,6 +53862,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"kLo" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "kMd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53902,6 +53937,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"kQm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "kRp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53915,6 +53954,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kTy" = (
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "kTC" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North-West";
@@ -54493,6 +54535,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"lNk" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "lNs" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -55647,6 +55695,11 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nAE" = (
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -56545,6 +56598,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
+"pdI" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "pdL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57007,6 +57067,13 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"pQq" = (
+/obj/machinery/door/airlock{
+	name = "Animal Husbandry";
+	req_one_access_txt = "25;26;35;28"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "pRd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/valve{
@@ -57222,6 +57289,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qkh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "qlb" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -57612,6 +57685,16 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"qNF" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = -6
+	},
+/obj/item/seeds/wheat,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "qOO" = (
 /obj/structure/easel,
 /turf/open/floor/carpet,
@@ -57649,6 +57732,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"qUI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "qUO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57805,6 +57892,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"rmA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "rnp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -57982,7 +58073,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "rDe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58079,6 +58170,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"rLe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "rLj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -59464,6 +59567,14 @@
 	},
 /turf/closed/wall,
 /area/chapel/main)
+"tYm" = (
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Animal Pen"
+	},
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "tZB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -59814,6 +59925,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"uDZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "uFF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -59956,6 +60075,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
+"uPr" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = -6
+	},
+/obj/item/seeds/wheat,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "uPM" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -59969,6 +60099,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
+"uQa" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = -6
+	},
+/obj/item/seeds/wheat,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "uQM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60879,9 +61019,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wvw" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "wxm" = (
 /obj/structure/window/reinforced{
@@ -61235,6 +61373,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"wVX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "wWs" = (
 /obj/machinery/the_singularitygen,
 /turf/open/floor/plating/airless,
@@ -61315,6 +61466,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"xbt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "xcx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -61848,7 +62005,8 @@
 	},
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel,
+/obj/item/hatchet/wooden,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "xVV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -61966,6 +62124,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ycO" = (
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/hallway/secondary/service)
 "ydj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -61987,6 +62149,13 @@
 /obj/item/reagent_containers/food/snacks/grown/banana/bluespace,
 /turf/open/floor/mineral/bananium,
 /area/maintenance/longface)
+"yfE" = (
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "25;26;35;28"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/hallway/secondary/service)
 "ygX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -102006,7 +102175,7 @@ alO
 alO
 mpy
 gfP
-lrb
+eYz
 rCG
 jxZ
 hic
@@ -102267,7 +102436,7 @@ wvw
 xUX
 gBw
 uvh
-alO
+kTy
 aLO
 aNy
 aOS
@@ -102520,7 +102689,7 @@ ajz
 alO
 mpy
 mpy
-mpy
+yfE
 mpy
 mpy
 mpy
@@ -102774,14 +102943,14 @@ awv
 axw
 asg
 azK
-alO
-ajz
-aso
-alO
-aGc
 aBf
-aBf
-aIN
+aow
+aGl
+aGl
+aGl
+kLo
+lrb
+wVX
 aLQ
 aLR
 aOU
@@ -103031,15 +103200,15 @@ atn
 alO
 asg
 arm
-aBf
-aBf
-aBf
-aBf
-aGd
-alO
-azI
-aKn
-alO
+nAE
+mpy
+mpy
+pQq
+mpy
+qUI
+qUI
+rLe
+pdI
 aLR
 aOU
 aQK
@@ -103289,13 +103458,13 @@ axx
 asg
 azL
 aBf
-ajz
-ajz
-ajz
-ajz
-ajz
-wkX
-aKo
+mpy
+kzh
+kQm
+xbt
+qNF
+qUI
+aKn
 aLR
 aLR
 aOV
@@ -103546,12 +103715,12 @@ kyJ
 asg
 azM
 aBf
-ajz
+mpy
 aDL
-alO
-ajz
-aaa
-aai
+dXk
+qkh
+uQa
+gJx
 aKp
 aLR
 aNz
@@ -103803,12 +103972,12 @@ kyJ
 asg
 avs
 aBf
-aCy
-alO
-aww
-ajz
-ajz
-wkX
+mpy
+ezY
+ixp
+rmA
+uPr
+fiA
 aKo
 aLR
 aNA
@@ -104060,11 +104229,11 @@ kyJ
 asg
 ajz
 aBf
-ajz
-ajz
-ajz
-ajz
-alO
+mpy
+lNk
+tYm
+lNk
+mpy
 aIM
 aKq
 aLR
@@ -104317,11 +104486,11 @@ axy
 asg
 axw
 aBf
-ajz
+mpy
 aDM
-alO
-ajz
-alO
+ycO
+aDM
+mpy
 aIN
 aKr
 aIG
@@ -104574,11 +104743,11 @@ axz
 asg
 avs
 aBf
-tVk
-alO
-alO
-ajz
-alO
+mpy
+dNC
+uDZ
+dNC
+mpy
 nhZ
 aIQ
 aIQ
@@ -104831,11 +105000,11 @@ axA
 ajz
 ajz
 aBf
-ajz
-ajz
-ajz
-ajz
-alO
+mpy
+mpy
+mpy
+mpy
+mpy
 nhZ
 aIQ
 aLU
@@ -106112,7 +106281,7 @@ ajz
 ajz
 ajz
 awy
-aBf
+nAE
 ajz
 alO
 awz

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -13473,8 +13473,8 @@
 	pixel_x = -7;
 	pixel_y = 7
 	},
-/obj/item/reagent_containers/food/snacks/grown/apple{
-	pixel_x = 6
+/obj/item/reagent_containers/food/snacks/grown/apple/gold{
+	pixel_x = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -104515,7 +104515,7 @@ awx
 axy
 asg
 aBf
-ajz
+aLR
 aLR
 aDM
 tlW

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -49593,13 +49593,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dXk" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "dXt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -50211,6 +50204,17 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/longface)
+"eYx" = (
+/obj/machinery/hydroponics,
+/obj/item/seeds/wheat,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "eYA" = (
 /obj/machinery/vending/cart/old,
 /turf/open/floor/plating,
@@ -50414,12 +50418,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 28;
 	pixel_y = 0
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -52380,6 +52384,9 @@
 /area/hallway/secondary/entry)
 "ixp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -54766,6 +54773,9 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "mbi" = (
 /obj/structure/cable,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -57711,6 +57721,9 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/shovel/spade,
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qOO" = (
@@ -58440,6 +58453,11 @@
 /area/security/checkpoint/auxiliary{
 	name = "Security Checkpoint - Arrivals"
 	})
+"sjY" = (
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "skg" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -58656,6 +58674,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "sGA" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -59575,6 +59596,9 @@
 /obj/item/plant_analyzer,
 /obj/item/cultivator,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tWk" = (
@@ -61502,6 +61526,9 @@
 /obj/machinery/biogenerator,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -103745,11 +103772,11 @@ kyJ
 asg
 mbi
 aLR
-hjy
-aUI
-dXk
-aUI
-aUI
+eYx
+aWv
+bbb
+aWv
+aWv
 gJx
 aKp
 aWv
@@ -104003,7 +104030,7 @@ asg
 fex
 aLR
 hjy
-aUI
+aWv
 ixp
 rmA
 rmA
@@ -104257,7 +104284,7 @@ alO
 aps
 kyJ
 asg
-aBf
+sjY
 aLR
 tWf
 sGA

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -8345,7 +8345,6 @@
 /obj/structure/window{
 	dir = 8
 	},
-/obj/structure/window,
 /obj/item/stack/ducttape,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -10528,16 +10527,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aDL" = (
-/obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/wheat,
+/turf/open/floor/grass,
+/area/hydroponics)
 "aDM" = (
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "aDN" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -11265,10 +11262,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGl" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
 "aGp" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba,
@@ -12224,7 +12217,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "aIN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12236,8 +12229,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/hydroponics)
 "aIP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12805,8 +12798,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/hydroponics)
 "aKo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12815,8 +12808,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/hydroponics)
 "aKp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12825,8 +12818,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "aKq" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -12838,8 +12835,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/hydroponics)
 "aKr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13494,7 +13491,7 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/food/snacks/grown/apple/gold{
-	pixel_x = 6
+	pixel_x = 10
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
@@ -13502,11 +13499,10 @@
 /turf/closed/wall,
 /area/hydroponics)
 "aLU" = (
-/obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/library)
 "aLV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14108,6 +14104,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
+/obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/library)
 "aNC" = (
@@ -48783,6 +48780,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cNg" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
+/area/hydroponics)
 "cNn" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/mousetrap,
@@ -49496,8 +49500,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dNC" = (
+/obj/structure/bed/dogbed{
+	name = "chicken bed"
+	},
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "dNP" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -49591,8 +49598,11 @@
 /area/maintenance/port/aft)
 "dXk" = (
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "dXt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -49953,8 +49963,11 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
 	},
+/obj/structure/window,
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/wheat,
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "eAI" = (
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -50412,8 +50425,14 @@
 /area/vacant_room)
 "fiA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "fiF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -51155,6 +51174,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"gtk" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "gtu" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -51336,10 +51362,17 @@
 /area/science/explab)
 "gJx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
+	dir = 6
 	},
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "gKo" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -52343,8 +52376,11 @@
 /area/hallway/secondary/entry)
 "ixp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "iyD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -53738,12 +53774,11 @@
 /turf/open/space/basic,
 /area/space)
 "kzh" = (
-/obj/machinery/biogenerator{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/structure/window,
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/wheat,
+/turf/open/floor/grass,
+/area/hydroponics)
 "kzB" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -53937,10 +53972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"kQm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
 "kRp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54540,7 +54571,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "lNs" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -54912,6 +54943,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mnT" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "moV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area,
@@ -55546,6 +55582,9 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/maintenance/strangeroom)
+"noW" = (
+/turf/open/floor/grass,
+/area/hydroponics)
 "npK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -57072,8 +57111,8 @@
 	name = "Animal Husbandry";
 	req_one_access_txt = "25;26;35;28"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/hallway/secondary/service)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "pRd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/valve{
@@ -57289,12 +57328,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"qkh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
 "qlb" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -57686,15 +57719,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "qNF" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = -6
-	},
-/obj/item/seeds/wheat,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "qOO" = (
 /obj/structure/easel,
 /turf/open/floor/carpet,
@@ -57732,10 +57764,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
-"qUI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/service)
 "qUO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57894,8 +57922,11 @@
 /area/science/mixing)
 "rmA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "rnp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -59063,6 +59094,12 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"tjP" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tkO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -59572,9 +59609,8 @@
 	dir = 8;
 	name = "Animal Pen"
 	},
-/mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "tZB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -59930,9 +59966,8 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
-/mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "uFF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -60075,17 +60110,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/port_engineering)
-"uPr" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = -6
-	},
-/obj/item/seeds/wheat,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
 "uPM" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -60099,16 +60123,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/port_engineering)
-"uQa" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = -6
-	},
-/obj/item/seeds/wheat,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
 "uQM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61467,11 +61481,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xbt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/service)
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "xcx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62127,7 +62140,7 @@
 "ycO" = (
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "ydj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -62154,7 +62167,7 @@
 	name = "Service Hall";
 	req_one_access_txt = "25;26;35;28"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "ygX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -101401,7 +101414,7 @@ aud
 aud
 aud
 aud
-aud
+tjP
 aud
 ajz
 ajz
@@ -102944,10 +102957,10 @@ axw
 asg
 azK
 aBf
-aow
-aGl
-aGl
-aGl
+mnT
+kLo
+kLo
+kLo
 kLo
 lrb
 wVX
@@ -103200,13 +103213,13 @@ atn
 alO
 asg
 arm
-nAE
-mpy
-mpy
+aBf
+aLR
+bfS
 pQq
-mpy
-qUI
-qUI
+bfS
+aLR
+aLR
 rLe
 pdI
 aLR
@@ -103458,14 +103471,14 @@ axx
 asg
 azL
 aBf
-mpy
+aLR
 kzh
-kQm
+aUI
 xbt
 qNF
-qUI
-aKn
 aLR
+aKn
+bfS
 aLR
 aOV
 aQI
@@ -103715,15 +103728,15 @@ kyJ
 asg
 azM
 aBf
-mpy
+aLR
 aDL
 dXk
-qkh
-uQa
+aUI
+aUI
 gJx
 aKp
-aLR
-aNz
+aWv
+aWv
 aOW
 aQM
 aSc
@@ -103972,14 +103985,14 @@ kyJ
 asg
 avs
 aBf
-mpy
+aLR
 ezY
 ixp
 rmA
-uPr
+rmA
 fiA
 aKo
-aLR
+aNz
 aNA
 aOX
 aQN
@@ -104229,11 +104242,11 @@ kyJ
 asg
 ajz
 aBf
-mpy
+aLR
 lNk
 tYm
-lNk
-mpy
+cNg
+gtk
 aIM
 aKq
 aLR
@@ -104486,11 +104499,11 @@ axy
 asg
 axw
 aBf
-mpy
+aLR
 aDM
 ycO
-aDM
-mpy
+noW
+aLR
 aIN
 aKr
 aIG
@@ -104743,13 +104756,13 @@ axz
 asg
 avs
 aBf
-mpy
+aLR
 dNC
 uDZ
-dNC
-mpy
+noW
+aLR
 nhZ
-aIQ
+alO
 aIQ
 aIQ
 aIQ
@@ -105000,11 +105013,11 @@ axA
 ajz
 ajz
 aBf
-mpy
-mpy
-mpy
-mpy
-mpy
+aLR
+aLR
+aLR
+aLR
+aLR
 nhZ
 aIQ
 aLU

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -8014,10 +8014,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"avv" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "avw" = (
 /turf/closed/wall,
 /area/maintenance/department/electrical)
@@ -9323,12 +9319,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"azJ" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "azK" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -10526,13 +10516,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aDL" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheat,
-/turf/open/floor/grass,
-/area/hydroponics)
 "aDM" = (
-/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Animal pen"
+	},
 /turf/open/floor/grass,
 /area/hydroponics)
 "aDN" = (
@@ -12219,15 +12207,8 @@
 /turf/closed/wall,
 /area/hydroponics)
 "aIN" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
 	},
 /turf/closed/wall,
 /area/hydroponics)
@@ -12779,14 +12760,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aKl" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light/small{
+	brightness = 5;
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aKn" = (
 /obj/structure/disposalpipe/segment{
@@ -12819,7 +12803,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics";
+	name = "Animal Husbandry";
 	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
@@ -12842,11 +12826,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13435,8 +13419,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aLO" = (
 /obj/structure/cable,
@@ -13451,7 +13434,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aLP" = (
 /obj/structure/cable,
@@ -13470,7 +13453,7 @@
 /obj/structure/sign/departments/botany{
 	pixel_y = -31
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aLQ" = (
 /obj/structure/cable,
@@ -13490,10 +13473,10 @@
 	pixel_x = -7;
 	pixel_y = 7
 	},
-/obj/item/reagent_containers/food/snacks/grown/apple/gold{
-	pixel_x = 10
+/obj/item/reagent_containers/food/snacks/grown/apple{
+	pixel_x = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aLR" = (
 /turf/closed/wall,
@@ -48785,7 +48768,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/grass,
+/mob/living/simple_animal/cow,
+/turf/open/floor/plasteel/sepia,
 /area/hydroponics)
 "cNn" = (
 /obj/structure/table/reinforced,
@@ -49375,6 +49359,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dCT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dCY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49959,15 +49956,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ezY" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
-	},
-/obj/structure/window,
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheat,
-/turf/open/floor/grass,
-/area/hydroponics)
 "eAI" = (
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -50223,13 +50211,6 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/longface)
-"eYz" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "eYA" = (
 /obj/machinery/vending/cart/old,
 /turf/open/floor/plating,
@@ -50350,6 +50331,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fex" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "feO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50430,6 +50416,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -50623,6 +50613,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fBp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fBV" = (
 /obj/machinery/light/small,
 /obj/machinery/airalarm{
@@ -50993,7 +50993,7 @@
 	name = "Service Hall APC";
 	pixel_y = 25
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "ggz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -51277,7 +51277,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/spray/plantbgone,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "gCc" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -51363,10 +51363,6 @@
 "gJx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -51588,7 +51584,7 @@
 /area/construction/mining/aux_base)
 "hhz" = (
 /obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "hic" = (
 /obj/structure/cable,
@@ -51602,7 +51598,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "hii" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -51610,6 +51606,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hjy" = (
+/obj/machinery/hydroponics,
+/obj/item/seeds/wheat,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "hka" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/effect/turf_decal/stripes/line{
@@ -52376,7 +52380,7 @@
 /area/hallway/secondary/entry)
 "ixp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53082,7 +53086,7 @@
 "jxZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "jyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53773,12 +53777,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"kzh" = (
-/obj/structure/window,
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheat,
-/turf/open/floor/grass,
-/area/hydroponics)
 "kzB" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -53897,10 +53895,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"kLo" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "kMd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53985,9 +53979,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kTy" = (
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/fore)
 "kTC" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North-West";
@@ -54773,6 +54764,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"mbi" = (
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/fore)
 "mck" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Vacant Office Maintenance";
@@ -54943,11 +54940,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mnT" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "moV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area,
@@ -55582,9 +55574,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/maintenance/strangeroom)
-"noW" = (
-/turf/open/floor/grass,
-/area/hydroponics)
 "npK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -56641,8 +56630,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pdL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -57109,7 +57097,7 @@
 "pQq" = (
 /obj/machinery/door/airlock{
 	name = "Animal Husbandry";
-	req_one_access_txt = "25;26;35;28"
+	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -57723,9 +57711,7 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/shovel/spade,
 /obj/item/reagent_containers/glass/bucket,
-/obj/item/plant_analyzer,
-/obj/item/cultivator,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "qOO" = (
 /obj/structure/easel,
@@ -58104,7 +58090,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "rDe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58211,7 +58197,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rLj" = (
 /obj/effect/turf_decal/stripes/line,
@@ -58555,6 +58541,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"stP" = (
+/obj/item/seeds/wheat,
+/obj/machinery/hydroponics,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "stU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -58661,6 +58655,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"sGA" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "sHn" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -59125,6 +59125,13 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/engine/port_engineering)
+"tlW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/hydroponics)
 "tlY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -59563,6 +59570,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tWf" = (
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "tWk" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -59607,9 +59621,13 @@
 "tYm" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	name = "Animal Pen"
+	name = "Animal pen"
 	},
-/turf/open/floor/grass,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/sepia,
 /area/hydroponics)
 "tZB" = (
 /obj/effect/turf_decal/bot,
@@ -61033,7 +61051,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wvw" = (
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "wxm" = (
 /obj/structure/window/reinforced{
@@ -61398,7 +61416,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wWs" = (
 /obj/machinery/the_singularitygen,
@@ -61482,8 +61500,10 @@
 /area/engine/engineering)
 "xbt" = (
 /obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "xcx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -61735,6 +61755,10 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1,
 /turf/open/floor/plating,
 /area/crew_quarters/bar/maint)
+"xwF" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xxi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -62019,7 +62043,7 @@
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
 /obj/item/hatchet/wooden,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "xVV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62162,13 +62186,6 @@
 /obj/item/reagent_containers/food/snacks/grown/banana/bluespace,
 /turf/open/floor/mineral/bananium,
 /area/maintenance/longface)
-"yfE" = (
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "25;26;35;28"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "ygX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -100904,7 +100921,7 @@ axr
 aud
 aDJ
 aFc
-alO
+xwF
 alO
 ajz
 gSs
@@ -101670,9 +101687,9 @@ wkX
 azI
 alO
 alO
-azI
 alO
-avs
+alO
+aww
 ajz
 aFe
 ajz
@@ -102184,11 +102201,11 @@ wkX
 alO
 apu
 ajz
-alO
+arm
 alO
 mpy
 gfP
-eYz
+lrb
 rCG
 jxZ
 hic
@@ -102439,9 +102456,9 @@ aaa
 aaa
 wkX
 ati
-alO
+azM
 ajz
-azJ
+aHC
 alO
 mpy
 hhz
@@ -102449,7 +102466,7 @@ wvw
 xUX
 gBw
 uvh
-kTy
+alO
 aLO
 aNy
 aOS
@@ -102702,7 +102719,7 @@ ajz
 alO
 mpy
 mpy
-yfE
+mpy
 mpy
 mpy
 mpy
@@ -102955,14 +102972,14 @@ avq
 awv
 axw
 asg
-azK
 aBf
-mnT
-kLo
-kLo
-kLo
-kLo
-lrb
+aBf
+aBf
+aBf
+aBf
+aBf
+aBf
+aBf
 wVX
 aLQ
 aLR
@@ -103212,12 +103229,12 @@ alO
 atn
 alO
 asg
-arm
 aBf
 aLR
-bfS
+aLR
+aLR
 pQq
-bfS
+aLR
 aLR
 aLR
 rLe
@@ -103469,16 +103486,16 @@ tDe
 tDe
 axx
 asg
-azL
 aBf
 aLR
-kzh
+stP
+aUI
 aUI
 xbt
 qNF
 aLR
 aKn
-bfS
+aLR
 aLR
 aOV
 aQI
@@ -103726,10 +103743,10 @@ alO
 alO
 kyJ
 asg
-azM
-aBf
+mbi
 aLR
-aDL
+hjy
+aUI
 dXk
 aUI
 aUI
@@ -103983,10 +104000,10 @@ avs
 aww
 kyJ
 asg
-avs
-aBf
+fex
 aLR
-ezY
+hjy
+aUI
 ixp
 rmA
 rmA
@@ -104240,10 +104257,10 @@ alO
 aps
 kyJ
 asg
-ajz
 aBf
 aLR
-lNk
+tWf
+sGA
 tYm
 cNg
 gtk
@@ -104497,12 +104514,12 @@ ajz
 awx
 axy
 asg
-axw
 aBf
+ajz
 aLR
 aDM
-ycO
-noW
+tlW
+lNk
 aLR
 aIN
 aKr
@@ -104754,15 +104771,15 @@ ajz
 tVk
 axz
 asg
-avs
+aBf
 aBf
 aLR
-dNC
+ycO
 uDZ
-noW
+dNC
 aLR
-nhZ
-alO
+dCT
+fBp
 aIQ
 aIQ
 aIQ
@@ -106296,7 +106313,7 @@ ajz
 awy
 nAE
 ajz
-alO
+axw
 awz
 tVk
 alO
@@ -107063,7 +107080,7 @@ aBf
 aBf
 atm
 aup
-avv
+auo
 alO
 alO
 ajz


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48893662/79080247-ad960f80-7ce1-11ea-8f48-7e9643d87cb6.png)

## Changelog
:cl: Carlospaul
add: Added Animal Husbandry room in Botany maint. 
/:cl:

## About The Pull Request
Protozoa is making cow cubes, rabbit cubes, and chicken cubes along with breeding for cows and rabbits so you can have a stable source of milk and rabbit meat (meat). 

**EDIT:** I forgot to mention that I also included an assistant spawn location at the fancy table and a botanist spawn location in the animal husbandry room

## Why It's Good For The Game
Because coom. For now it will just have chickens because you can feed them and they lay eggs, so egg supply. I hope all of service can access the room because I just copied the Service Hall door and renamed it. 
