### PR TITLE
GREYTIDE WORLD WIDE

### DIFF
--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -105,7 +105,6 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.adjustStaminaLoss(stamforce)
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)

--- a/hippiestation/code/game/objects/items/stunbaton.dm
+++ b/hippiestation/code/game/objects/items/stunbaton.dm
@@ -84,8 +84,7 @@
 	stunforce = 100
 
 /obj/item/melee/baton/cattleprod/hippie_cattleprod
-	stunforce = 7
-	var/stamforce = 100
+	stunforce = 100
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/melee/baton/cattleprod/hippie_cattleprod/baton_stun(mob/living/L, mob/user)


### PR DESCRIPTION
## Changelog
:cl:
balance: Stunprod is actually useful again.
/:cl:

Alright, so. Any antag with two spare brain cells can get their hands on a stun baton. Anyone who is actually permitted by the rules to kill can get their hands on a stun baton. Honestly, most jobs on the station can get their hands on a stun baton. The only thing that nerfing the stunprod did was completely remove the greytide's ability to defend themselves from shitsec, and it has resulted in a no fun allowed atmosphere whenever someone is playing sec with the intention of making people's lives miserable. As part of an ongoing effort to give the tide its teeth back, I think we should give them access to a non-lethal tool for dealing with the absolute worst of the power gaming, line toeing, on the spectrum so hard they're off the charts sec officers.
