### PR TITLE
GREYTIDE WORLDWIDE TAKE 2

### DIFF
--- a/hippiestation/code/datums/components/crafting/recipes.dm
+++ b/hippiestation/code/datums/components/crafting/recipes.dm
@@ -1,5 +1,5 @@
 /datum/crafting_recipe/stunprod
-	result = /obj/item/melee/baton/cattleprod/hippie_cattleprod
+	result = /obj/item/melee/baton/cattleprod/cattleprod
 
 /datum/crafting_recipe/butterfly
 	name = "Butterfly Knife"

--- a/hippiestation/code/datums/components/crafting/recipes.dm
+++ b/hippiestation/code/datums/components/crafting/recipes.dm
@@ -1,5 +1,5 @@
 /datum/crafting_recipe/stunprod
-	result = /obj/item/melee/baton/cattleprod/cattleprod
+	result = /obj/item/melee/baton/cattleprod
 
 /datum/crafting_recipe/butterfly
 	name = "Butterfly Knife"


### PR DESCRIPTION
:cl:
balance: Stunprod is actually useful again.
/:cl:

Alright, so. Any antag with two spare brain cells can get their hands on a stun baton. Anyone who is actually permitted by the rules to kill can get their hands on a stun baton. Honestly, most jobs on the station can get their hands on a stun baton. The only thing that nerfing the stunprod did was completely remove the greytide's ability to defend themselves from shitsec, and it has resulted in a no fun allowed atmosphere whenever someone is playing sec with the intention of making people's lives miserable. As part of an ongoing effort to give the tide its teeth back, I think we should give them access to a non-lethal tool for dealing with the absolute worst of the power gaming, line toeing, on the spectrum so hard they're off the charts sec officers.

Also turns out the old prod is still in-game, so I just changed the crafting recipe to make the proper version again.