### PR TITLE
Farts Now Spawn Miasma

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -445,6 +445,7 @@
 					usr.mind.teach_crafting_recipe(/datum/crafting_recipe/tier2/shittysafetywand)
 					usr.mind.teach_crafting_recipe(/datum/crafting_recipe/tier2/monstercube)
 					usr.mind.teach_crafting_recipe(/datum/crafting_recipe/tier2/soulshard)
+					usr.mind.teach_crafting_recipe(/datum/crafting_recipe/tier3/obelisk)
 					if(specialmessage2 == 1)
 						to_chat(usr, "<span class='warning'>The accursed knowledge of the greater obelisk has given you new magic crafting recipes!")
 						to_chat(usr, "<spance class ='notice'>This Obelisk is far more adept at conducting free flowing universal magical radicals. There appear to be odd magical frequencies at play here which manipulate our plain of existence. With more advanced parts you could probably tap directly into the source.")

--- a/hippiestation/code/modules/library/lib_machines.dm
+++ b/hippiestation/code/modules/library/lib_machines.dm
@@ -197,10 +197,6 @@
 
 /obj/machinery/computer/craftingbookcatalog/examine(mob/user)
 	. = ..()
-	if(!anchored)
-		. += "<span class='notice'>The <i>bolts</i> on the bottom are unsecured.</span>"
-	else
-		. += "<span class='notice'>It's secured in place with <b>bolts</b>.</span>"
 	if(ink > 0 && ink < 2)
 		. += "<span class ='notice'>The [src] has <b>1</b> Spacestar-brand ink cartridge loaded."
 	else

--- a/hippiestation/code/modules/mob/living/carbon/human/emote.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/emote.dm
@@ -6,6 +6,20 @@
 	var/fart_fly = 12
 	var/smug_cd = 0
 
+/proc/spawnfartgas(mob/living/carbon/user, is_super_fart)
+	var/turf/fartturf = get_turf(user)
+	var/datum/gas_mixture/stank = new
+	var/amount
+	if(is_super_fart)
+		amount = pick(20, 21, 22, 23, 24, 25)
+	else
+		amount = pick(1, 2, 3, 4, 5)
+	ADD_GAS(/datum/gas/miasma, stank.gases)
+	stank.gases[/datum/gas/miasma][MOLES] = amount //amount of gas spawned
+	stank.temperature = BODYTEMP_NORMAL  //otherwise we have gas below 2.7K which will break our lag generator
+	fartturf.assume_air(stank)
+	fartturf.air_update_turf()
+
 /datum/emote/living/carbon/fart
 	key = "fart"
 	key_third_person = "farts"
@@ -21,6 +35,9 @@
 	if(!B)
 		to_chat(user, "<span class='warning'>You don't have a butt!</span>")
 		return
+
+	spawnfartgas(user, 0)
+
 	for(var/mob/living/M in get_turf(user))
 		if(M == user)
 			continue
@@ -165,8 +182,10 @@
 	else
 		for(var/i in 1 to 10)
 			playsound(user, 'hippiestation/sound/effects/fart.ogg', 100, 1, 5)
+			spawnfartgas(user, 0)
 			sleep(1)
 		playsound(user, 'hippiestation/sound/effects/fartmassive.ogg', 75, 1, 5)
+		spawnfartgas(user, 1)
 		var/datum/component/storage/STR = B.GetComponent(/datum/component/storage)
 
 		if(STR)


### PR DESCRIPTION
## Changelog
:cl:
add: Farts now spawn miasma. Superfarts spawn ~4 times the miasma than normal farts. (Mostly coded by Yoyobatty)
tweak: The Spacestar Ordering Book Catalog no longer tells you it is anchored with bolts when you examine it, as that is pointless.
tweak: I fixed a bug where you were not given the crafting recipe to make a tier 3 obelisk when constructing the tier 2 obelisk. 
/:cl:
## About The Pull Request
Yoyobatty coded 70% of it. I don't know jack about atmospherics.

## Why It's Good For The Game
Fart is now stinky.