### PR TITLE
ChapDrobe now shows when emagged in examine menu when you shift+click the chapdrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -339,6 +339,11 @@
 	to_chat(user, "<span class='notice'>You short out the product lock on [src].</span>")
 	visible_message("<span class='warning'>The [src] spits out a samurai armaments beacon from a secret compartment!")
 
+/obj/machinery/vending/wardrobe/chap_wardrobe/examine()
+	. = ..()
+	if(obj_flags & EMAGGED)
+		. += "<span class='warning'>A secret compartment is exposed."
+
 /obj/item/vending_refill/wardrobe/chap_wardrobe
 	machine_name = "ChapDrobe"
 

--- a/hippiestation/code/game/objects/items/samurai_gear.dm
+++ b/hippiestation/code/game/objects/items/samurai_gear.dm
@@ -18,6 +18,7 @@
 	icon_state = "yakama"
 	item_state = "yakama"
 	alternate_worn_icon = 'hippiestation/icons/mob/uniform.dmi'
+	alternate_screams = list('hippiestation/sound/voice/yo.ogg')
 
 /obj/item/clothing/mask/samurai
 	name = "menpo mask"
@@ -41,7 +42,6 @@
 	force = 3
 	body_parts_covered = CHEST|GROIN|ARMS
 	var/equipped = FALSE
-	alternate_screams = list('hippiestation/sound/voice/yo.ogg')
 
 /obj/item/clothing/suit/armor/samurai/equipped(mob/living/carbon/human/user, slot)
 	..()


### PR DESCRIPTION
… yoyobatty aint got no mans arms on this slimy. I fucken did it. I have figured out how large Thano’s flaccid penis is. I know what you’re thinking: How could I have done this? Well, allow me to explain. I started out with an image. The picture was of Thanos and Iron Man standing next to each other. This image was exactly what I needed. It came directly from Marvel, so we know for certain that the proportions are correct. Now that we have the two characters, how does one go about actually determining Thano’s length? That’s easy. We only need the length of Robert Downey Jr.’s penis. Luckily, we have a vague idea of just how large that is. Back in 2014, Robert Downey Jr. was quoted saying something along the lines of: “I have a massive dick, and feminism is a joke”. From this statement, we can determine one major thing: Robert Downey Jr. slays women with his massive peen.


## Changelog
:cl:
add: chapdrobe displays an emag message if you examine it after it is emagged.
tweak: yakama now gives you the special scream instead of the haramaki armor
/:cl:

## About The Pull Request
shazbot is a liar and a thief

## Why It's Good For The Game
sloppy jaloppy
