### PR TITLE
Mime Buff

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -428,6 +428,15 @@
 	item_chair = null
 	flags_1 = NODECONSTRUCT_1
 
+/obj/structure/chair/mime/Crossed(AM as mob)
+	if(isturf(loc))
+		if(ismob(AM))
+			var/mob/living/MM = AM
+			if(!(MM.movement_type & FLYING))
+				if(!MM.mind.miming)
+					MM.AdjustKnockdown(10)
+					visible_message("<span class='warning'>[MM] trips and falls over an invisible chair!")
+
 /obj/structure/chair/mime/post_buckle_mob(mob/living/M)
 	M.pixel_y += 5
 

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -72,8 +72,8 @@
 	summon_type = list(/obj/item/storage/box/mime)
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='notice'>You conjure up an invisible box, large enough to store a few things.</span>"
-	summon_lifespan = 250
-	charge_max = 300
+	summon_lifespan = 3000
+	charge_max = 600
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
 	range = 0


### PR DESCRIPTION
## Changelog
:cl:
balance: People can now trip over the mime's invisible chair
balance: The mime's invisible box now lasts for 5 minutes instead of 25 seconds.
balance: The cooldown for the invisible box spell is now 1 minute (+30 seconds)
/:cl:

## About The Pull Request
No help from Neo. Mr. Epic Sax gave me the idea to make the chair trip people. 

## Why It's Good For The Game
The invisible wall is the only good mime spell. The chair doesn't do anything that is useful and the box doesn't last long enough to be useful; this PR fixes that.
