### PR TITLE
Removed location condition on lockers escapes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -368,6 +368,7 @@
 		return 0
 	return 1
 
+/*Hippie start - breaking out isn't stopped by being moved
 /obj/structure/closet/container_resist(mob/living/user)
 	if(opened)
 		return
@@ -397,6 +398,7 @@
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, "<span class='warning'>You fail to break out of [src]!</span>")
+Hippie end */
 
 /obj/structure/closet/proc/bust_open()
 	welded = FALSE //applies to all lockers

--- a/hippiestation/code/game/objects/structures/crates_lockers/closets.dm
+++ b/hippiestation/code/game/objects/structures/crates_lockers/closets.dm
@@ -33,3 +33,33 @@ Sorry for doing this, but apparently the Hippie community hates art and new thin
 			add_overlay("[icon_door]_open")
 		else
 			add_overlay("[icon_state]_open")
+
+/obj/structure/closet/container_resist(mob/living/user)
+	if(opened)
+		return
+	if(ismovable(loc))
+		user.changeNext_move(CLICK_CD_BREAKOUT)
+		user.last_special = world.time + CLICK_CD_BREAKOUT
+		var/atom/movable/AM = loc
+		AM.relay_container_resist(user, src)
+		return
+	if(!welded && !locked)
+		open()
+		return
+
+	//okay, so the closet is either welded or locked... resist!!!
+	user.changeNext_move(CLICK_CD_BREAKOUT)
+	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.visible_message("<span class='warning'>[src] begins to shake violently!</span>", \
+		"<span class='notice'>You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)</span>", \
+		"<span class='italics'>You hear banging from [src].</span>")
+	if(do_after(user,(breakout_time)))
+		if(!user || user.stat != CONSCIOUS || user.loc != src || opened || (!locked && !welded) )
+			return
+		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
+		user.visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>",
+							"<span class='notice'>You successfully break out of [src]!</span>")
+		bust_open()
+	else
+		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
+			to_chat(user, "<span class='warning'>You fail to break out of [src]!</span>")


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
balance: moving a locker around will no longer prevents you from escaping it after the 2 minutes wait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
this is mainly because just taking a step while holding down a locker is too easy for crashing someone's fun for 2 more minutes, addresses issue #8702
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
you no longer will be trapped in infinite conveyor belts loop fucking your game up
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
