### PR TITLE
silicon console

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,7 @@
 		"./tgui-next"
 	],
 
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewType": "imagePreview.previewEditor"
-		}
-	]
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	}
 }

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -142,6 +142,8 @@
 	sleep(5)
 	to_chat(src, "<span class='danger'>LAW SYNCHRONISATION ERROR</span>")
 	sleep(5)
+	if(user)
+		logevent("LOG: New user \[[replacetext(user.real_name," ","")]\], groups \[root\]")
 	to_chat(src, "<span class='danger'>Would you like to send a report to NanoTraSoft? Y/N</span>")
 	sleep(10)
 	to_chat(src, "<span class='danger'>> N</span>")

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -69,61 +69,22 @@
 	physical = null
 	return ..()
 
-
-/obj/item/modular_computer/proc/add_verb(var/path)
-	switch(path)
-		if(MC_CARD)
-			verbs += /obj/item/modular_computer/proc/eject_id
-		if(MC_SDD)
-			verbs += /obj/item/modular_computer/proc/eject_disk
-		if(MC_AI)
-			verbs += /obj/item/modular_computer/proc/eject_card
-
-/obj/item/modular_computer/proc/remove_verb(path)
-	switch(path)
-		if(MC_CARD)
-			verbs -= /obj/item/modular_computer/proc/eject_id
-		if(MC_SDD)
-			verbs -= /obj/item/modular_computer/proc/eject_disk
-		if(MC_AI)
-			verbs -= /obj/item/modular_computer/proc/eject_card
-
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/item/modular_computer/proc/eject_id()
-	set name = "Eject ID"
-	set category = "Object"
-	set src in view(1)
-
-	if(issilicon(usr))
-		return
-	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-	if(usr.canUseTopic(src, BE_CLOSE))
-		card_slot.try_eject(null, usr)
-
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/item/modular_computer/proc/eject_card()
-	set name = "Eject Intellicard"
-	set category = "Object"
-
-	if(issilicon(usr))
-		return
-	var/obj/item/computer_hardware/ai_slot/ai_slot = all_components[MC_AI]
-	if(usr.canUseTopic(src, BE_CLOSE))
-		ai_slot.try_eject(null, usr,1)
+/obj/item/modular_computer/pre_attack_secondary(atom/A, mob/living/user, params)
+	if(active_program?.tap(A, user, params))
+		user.do_attack_animation(A) //Emulate this animation since we kill the attack in three lines
+		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1) //Likewise for the tap sound
+		addtimer(CALLBACK(src, .proc/play_ping), 0.5 SECONDS, TIMER_UNIQUE) //Slightly delayed ping to indicate success
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/item/modular_computer/proc/eject_disk()
-	set name = "Eject Data Disk"
-	set category = "Object"
-
-	if(issilicon(usr))
-		return
-
-	if(usr.canUseTopic(src, BE_CLOSE))
-		var/obj/item/computer_hardware/hard_drive/portable/portable_drive = all_components[MC_SDD]
-		if(uninstall_component(portable_drive, usr))
-			portable_drive.verb_pickup()
+/**
+ * Plays a ping sound.
+ *
+ * Timers runtime if you try to make them call playsound. Yep.
+ */
+/obj/item/modular_computer/proc/play_ping()
+	playsound(loc, 'sound/machines/ping.ogg', get_clamped_volume(), FALSE, -1)
 
 /obj/item/modular_computer/AltClick(mob/user)
 	..()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -52,6 +52,21 @@
 		return computer.add_log(text)
 	return 0
 
+/**
+ *Runs when the device is used to attack an atom in non-combat mode.
+ *
+ *Simulates using the device to read or scan something. Tap is called by the computer during pre_attack
+ *and sends us all of the related info. If we return TRUE, the computer will stop the attack process
+ *there. What we do with the info is up to us, but we should only return TRUE if we actually perform
+ *an action of some sort.
+ *Arguments:
+ *A is the atom being tapped
+ *user is the person making the attack action
+ *params is anything the pre_attack() proc had in the same-named variable.
+*/
+/datum/computer_file/program/proc/tap(atom/A, mob/living/user, params)
+	return FALSE
+
 /datum/computer_file/program/proc/is_supported_by_hardware(hardware_flag = 0, loud = 0, mob/user = null)
 	if(!(hardware_flag & usage_flags))
 		if(loud && computer && user)

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -1,0 +1,186 @@
+/datum/computer_file/program/borg_monitor
+	filename = "siliconnect"
+	filedesc = "SiliConnect"
+	category = PROGRAM_CATEGORY_ROBO
+	ui_header = "borg_mon.gif"
+	program_icon_state = "generic"
+	extended_desc = "This program allows for remote monitoring of station cyborgs."
+	requires_ntnet = TRUE
+	transfer_access = ACCESS_ROBOTICS
+	size = 5
+	tgui_id = "NtosCyborgRemoteMonitor"
+	program_icon = "project-diagram"
+	var/emagged = FALSE ///Bool of if this app has already been emagged
+	var/list/loglist = list() ///A list to copy a borg's IC log list into
+	var/mob/living/silicon/robot/DL_source ///reference of a borg if we're downloading a log, or null if not.
+	var/DL_progress = -1 ///Progress of current download, 0 to 100, -1 for no current download
+
+/datum/computer_file/program/borg_monitor/Destroy()
+	loglist = null
+	DL_source = null
+	return ..()
+
+/datum/computer_file/program/borg_monitor/kill_program(forced = FALSE)
+	loglist = null //Not everything is saved if you close an app
+	DL_source = null
+	DL_progress = 0
+	return ..()
+
+/datum/computer_file/program/borg_monitor/run_emag()
+	if(emagged)
+		return FALSE
+	emagged = TRUE
+	return TRUE
+
+/datum/computer_file/program/borg_monitor/tap(atom/A, mob/living/user, params)
+	var/mob/living/silicon/robot/borgo = A
+	if(!istype(borgo) || !borgo.modularInterface)
+		return FALSE
+	DL_source = borgo
+	DL_progress = 0
+
+	var/username = "unknown user"
+	var/obj/item/card/id/stored_card = computer.GetID()
+	if(istype(stored_card) && stored_card.registered_name)
+		username = "user [stored_card.registered_name]"
+	to_chat(borgo, "<span class='userdanger'>Request received from [username] for the system log file. Upload in progress.</span>")//Damning evidence may be contained, so warn the borg
+	borgo.logevent("File request by [username]: /var/logs/syslog")
+	return TRUE
+
+/datum/computer_file/program/borg_monitor/process_tick()
+	if(!DL_source)
+		DL_progress = -1
+		return
+
+	var/turf/here = get_turf(computer)
+	var/turf/there = get_turf(DL_source)
+	if(!here.Adjacent(there))//If someone walked away, cancel the download
+		to_chat(DL_source, "<span class='danger'>Log upload failed: general connection error.</span>")//Let the borg know the upload stopped
+		DL_source = null
+		DL_progress = -1
+		return
+
+	if(DL_progress == 100)
+		if(!DL_source || !DL_source.modularInterface) //sanity check, in case the borg or their modular tablet poofs somehow
+			loglist = list("System log of unit [DL_source.name]")
+			loglist += "Error -- Download corrupted."
+		else
+			loglist = DL_source.modularInterface.borglog.Copy()
+			loglist.Insert(1,"System log of unit [DL_source.name]")
+		DL_progress = -1
+		DL_source = null
+		for(var/datum/tgui/window in SStgui.open_uis_by_src[REF(src)])
+			window.send_full_update()
+		return
+
+	DL_progress += 25
+
+/datum/computer_file/program/borg_monitor/ui_data(mob/user)
+	var/list/data = get_header_data()
+
+	data["card"] = FALSE
+	if(checkID())
+		data["card"] = TRUE
+
+	data["cyborgs"] = list()
+	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
+		if(!evaluate_borg(R))
+			continue
+
+		var/list/upgrade
+		for(var/obj/item/borg/upgrade/I in R.upgrades)
+			upgrade += "\[[I.name]\] "
+
+		var/shell = FALSE
+		if(R.shell && !R.ckey)
+			shell = TRUE
+
+		var/list/cyborg_data = list(
+			name = R.name,
+			integ = round((R.health + 100) / 2), //mob heath is -100 to 100, we want to scale that to 0 - 100
+			locked_down = R.lockcharge,
+			status = R.stat,
+			shell_discon = shell,
+			charge = R.cell ? round(R.cell.percent()) : null,
+			module = R.model ? "[R.model.name] Model" : "No Model Detected",
+			upgrades = upgrade,
+			ref = REF(R)
+		)
+		data["cyborgs"] += list(cyborg_data)
+		data["DL_progress"] = DL_progress
+	return data
+
+/datum/computer_file/program/borg_monitor/ui_static_data(mob/user)
+	var/list/data = list()
+	data["borglog"] = loglist
+	return data
+
+/datum/computer_file/program/borg_monitor/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("messagebot")
+			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
+			if(!istype(R))
+				return
+			var/ID = checkID()
+			if(!ID)
+				return
+			if(R.stat == DEAD) //Dead borgs will listen to you no longer
+				to_chat(usr, "<span class='warn'>Error -- Could not open a connection to unit:[R]</span>")
+			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
+			if(!message)
+				return
+			to_chat(R, "<br><br><span class='notice'>Message from [ID] -- \"[message]\"</span><br>")
+			to_chat(usr, "Message sent to [R]: [message]")
+			R.logevent("Message from [ID] -- \"[message]\"")
+			SEND_SOUND(R, 'sound/machines/twobeep_high.ogg')
+			if(R.connected_ai)
+				to_chat(R.connected_ai, "<br><br><span class='notice'>Message from [ID] to [R] -- \"[message]\"</span><br>")
+				SEND_SOUND(R.connected_ai, 'sound/machines/twobeep_high.ogg')
+			usr.log_talk(message, LOG_PDA, tag="Cyborg Monitor Program: ID name \"[ID]\" to [R]")
+
+///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
+/datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)
+	if((get_turf(computer)).z != (get_turf(R)).z)
+		return FALSE
+	if(R.scrambledcodes)
+		return FALSE
+	return TRUE
+
+///Gets the ID's name, if one is inserted into the device. This is a seperate proc solely to be overridden by the syndicate version of the app.
+/datum/computer_file/program/borg_monitor/proc/checkID()
+	var/obj/item/card/id/ID = computer.GetID()
+	if(!ID)
+		if(emagged)
+			return "STDERR:UNDF"
+		return FALSE
+	return ID.registered_name
+
+/datum/computer_file/program/borg_monitor/syndicate
+	filename = "roboverlord"
+	filedesc = "Roboverlord"
+	category = PROGRAM_CATEGORY_ROBO
+	ui_header = "borg_mon.gif"
+	program_icon_state = "generic"
+	extended_desc = "This program allows for remote monitoring of mission-assigned cyborgs."
+	requires_ntnet = FALSE
+	available_on_ntnet = FALSE
+	available_on_syndinet = TRUE
+	transfer_access = null
+	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
+
+/datum/computer_file/program/borg_monitor/syndicate/run_emag()
+	return FALSE
+
+/datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
+	if((get_turf(computer)).z != (get_turf(R)).z)
+		return FALSE
+	if(!R.scrambledcodes)
+		return FALSE
+	return TRUE
+
+/datum/computer_file/program/borg_monitor/syndicate/checkID()
+	return "\[CLASSIFIED\]" //no ID is needed for the syndicate version's message function, and the borg will see "[CLASSIFIED]" as the message sender.

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -1,0 +1,183 @@
+import { useBackend, useSharedState } from '../backend';
+import { Box, Button, LabeledList, NoticeBox, ProgressBar, Section, Stack, Tabs } from '../components';
+import { NtosWindow } from '../layouts';
+
+export const NtosCyborgRemoteMonitor = (props, context) => {
+  return (
+    <NtosWindow
+      width={600}
+      height={800}>
+      <NtosWindow.Content>
+        <NtosCyborgRemoteMonitorContent />
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};
+
+export const ProgressSwitch = param => {
+  switch (param) {
+    case -1:
+      return '_';
+    case 0:
+      return 'Connecting';
+    case 25:
+      return 'Starting Transfer';
+    case 50:
+      return 'Downloading';
+    case 75:
+      return 'Downloading';
+    case 100:
+      return 'Formatting';
+  }
+};
+
+export const NtosCyborgRemoteMonitorContent = (props, context) => {
+  const { act, data } = useBackend(context);
+  const [tab_main, setTab_main] = useSharedState(context, 'tab_main', 1);
+  const {
+    card,
+    cyborgs = [],
+    DL_progress,
+  } = data;
+  const storedlog = data.borglog || [];
+
+  if (!cyborgs.length) {
+    return (
+      <NoticeBox>
+        No cyborg units detected.
+      </NoticeBox>
+    );
+  }
+
+  return (
+    <Stack fill vertical>
+      <Stack.Item>
+        <Tabs>
+          <Tabs.Tab
+            icon="robot"
+            lineHeight="23px"
+            selected={tab_main === 1}
+            onClick={() => setTab_main(1)}>
+            Cyborgs
+          </Tabs.Tab>
+          <Tabs.Tab
+            icon="clipboard"
+            lineHeight="23px"
+            selected={tab_main === 2}
+            onClick={() => setTab_main(2)}>
+            Stored Log File
+          </Tabs.Tab>
+        </Tabs>
+      </Stack.Item>
+      {tab_main === 1 && (
+        <>
+          {!card && (
+            <Stack.Item>
+              <NoticeBox>
+                Certain features require an ID card login.
+              </NoticeBox>
+            </Stack.Item>
+          )}
+          <Stack.Item grow={1}>
+            <Section fill scrollable>
+              {cyborgs.map(cyborg => (
+                <Section
+                  key={cyborg.ref}
+                  title={cyborg.name}
+                  buttons={(
+                    <Button
+                      icon="terminal"
+                      content="Send Message"
+                      color="blue"
+                      disabled={!card}
+                      onClick={() => act('messagebot', {
+                        ref: cyborg.ref,
+                      })} />
+                  )}>
+                  <LabeledList>
+                    <LabeledList.Item label="Status">
+                      <Box color={cyborg.status
+                        ? 'bad'
+                        : cyborg.locked_down
+                          ? 'average'
+                          : 'good'}>
+                        {cyborg.status
+                          ? "Not Responding"
+                          : cyborg.locked_down
+                            ? "Locked Down"
+                            : cyborg.shell_discon
+                              ? "Nominal/Disconnected"
+                              : "Nominal"}
+                      </Box>
+                    </LabeledList.Item>
+                    <LabeledList.Item label="Condition">
+                      <Box color={cyborg.integ <= 25
+                        ? 'bad'
+                        : cyborg.integ <= 75
+                          ? 'average'
+                          : 'good'}>
+                        {cyborg.integ === 0
+                          ? "Hard Fault"
+                          : cyborg.integ <= 25
+                            ? "Functionality Disrupted"
+                            : cyborg.integ <= 75
+                              ? "Functionality Impaired"
+                              : "Operational"}
+                      </Box>
+                    </LabeledList.Item>
+                    <LabeledList.Item label="Charge">
+                      <Box color={cyborg.charge <= 30
+                        ? 'bad'
+                        : cyborg.charge <= 70
+                          ? 'average'
+                          : 'good'}>
+                        {typeof cyborg.charge === 'number'
+                          ? cyborg.charge + "%"
+                          : "Not Found"}
+                      </Box>
+                    </LabeledList.Item>
+                    <LabeledList.Item label="Model">
+                      {cyborg.module}
+                    </LabeledList.Item>
+                    <LabeledList.Item label="Upgrades">
+                      {cyborg.upgrades}
+                    </LabeledList.Item>
+                  </LabeledList>
+                </Section>
+              ))}
+            </Section>
+          </Stack.Item>
+        </>
+      )}
+      {tab_main === 2 && (
+        <>
+          <Stack.Item>
+            <Section>
+              Scan a cyborg to download stored logs.
+              <ProgressBar
+                value={DL_progress/100}>
+                {ProgressSwitch(DL_progress)}
+              </ProgressBar>
+            </Section>
+          </Stack.Item>
+          <Stack.Item
+            grow={1}>
+            <Section
+              fill
+              scrollable
+              backgroundColor="black">
+              {storedlog.map(log => (
+                <Box
+                  mb={1}
+                  key={log}
+                  color="green">
+                  {log}
+                </Box>
+              ))}
+            </Section>
+          </Stack.Item>
+        </>
+      )}
+    </Stack>
+  );
+};


### PR DESCRIPTION
Adds a function to Siliconnect in which you can tap a borg using a mobile device that is currently running the software, and it will download the borg's logs. These logs list events such as being locked or unlocked, taken offline and being restored, and the process of being emagged. Borg logs will now list the emag user's name as a new user.

Downloading the logs is done by right-clicking the borg while the software is open and active. This will "tap" the borg with the device, initiating the log transfer automatically. The transfer will take eight seconds to complete, requiring you and the borg to stay adjacent the entire time, and the borg will get a large red text alert about the upload when it starts. The logs are also not stored permanently on the device, and will be lost if the app is closed.

This PR also introduces the tap() proc for modular computer programs, and adds functionality the the computers to call it when right-clicking with the tablet as a tool. Should the app use the tap in a meaningful way (such as starting a borg log download), it will return TRUE, and the computer will end the secondary attack chain.

Currently, this requires using a tablet or laptop with Siliconnect, as you cannot tap with a console. Someday I hope to add an additional hardware option for consoles in the form of a wireless hand scanner to replicate tapping.

[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
silicon logs 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
